### PR TITLE
extend processor capabilities - documented in README and Wiki

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,11 +32,9 @@ builds:
       - darwin
       - windows
     goarch:
-      - "386"
       - amd64
       - arm
       - arm64
-      - ppc64
     goarm:
       - "7"
     ignore:

--- a/README.adoc
+++ b/README.adoc
@@ -17,8 +17,8 @@ Rinse, Wash, Repeat (RWR) is a powerful and flexible configuration management to
 
 * *Blueprint-based Configuration*: RWR uses configuration files called blueprints (similar to Chef cookbooks or Ansible playbooks) to define and manage your system's configuration.
 * *Multi-format Support*: Blueprints can be written in YAML, JSON, or TOML format, providing flexibility and compatibility with your preferred configuration format.
-* *Package Management*: RWR integrates with various package managers, allowing you to easily install, remove, and manage packages across different Linux distributions, macOS, and Windows.
-* *File and Directory Management*: RWR provides functionality to manage files and directories, including copying, moving, deleting, creating, and modifying permissions and ownership.
+* *Package Management*: RWR integrates with various package managers, allowing you to easily install, remove, and manage packages across different Linux distributions, macOS, and Windows. Now supports specifying additional arguments for package installation.
+* *File and Directory Management*: RWR provides functionality to manage files and directories, including copying, moving, deleting, creating, and modifying permissions and ownership. Supports URL sources for files and intelligent renaming.
 * *Service Management*: RWR allows you to manage system services, including starting, stopping, enabling, and disabling services across different operating systems.
 * *Repository Management*: RWR supports managing repositories for different package managers, such as apt, brew, dnf, zypper, and more.
 * *User and Group Management*: RWR allows you to create and manage user accounts and groups on your system.
@@ -28,8 +28,7 @@ Rinse, Wash, Repeat (RWR) is a powerful and flexible configuration management to
 * *Bootstrap Process*: RWR includes a bootstrap process that can be used to set up the initial system configuration, including installing essential packages, creating directories, and setting permissions.
 * *Variable Substitution*: Use variables in your blueprints to make your configurations more dynamic and reusable.
 * *Extensible Architecture*: RWR is built with extensibility in mind, allowing you to easily add support for new package managers, file synchronization backends, and more.
-* *SSH Key Management*: RWR can generate and manage SSH keys, including copying public keys to GitHub.
-
+* *SSH Key Management*: RWR can generate and manage SSH keys, including copying public keys to GitHub and setting a key as the default RWR SSH key for operations.
 
 == Quick Install
 
@@ -163,10 +162,10 @@ NOTE: All configuration files (`.yaml`, `.json`, or `.toml`) can be in YAML, JSO
 
 RWR supports the following blueprint types:
 
-* `packages`: Defines packages to be installed or removed using various package managers.
+* `packages`: Defines packages to be installed or removed using various package managers. Supports additional arguments for installation.
 * `repositories`: Defines repositories to be managed for different package managers.
 * Files Blueprints (All fall under files processor)
-** `files`: Defines files to be copied, moved, deleted, created, or modified.
+** `files`: Defines files to be copied, moved, deleted, created, or modified. Supports URL sources and intelligent renaming.
 ** `directories`: Defines directories to be managed, including creation, deletion, and modification of permissions and ownership.
 ** `templates`: Defines template files to be processed and rendered during the execution of the blueprints.
 * `services`: Defines services to be managed, including starting, stopping, enabling, and disabling services.
@@ -175,7 +174,7 @@ RWR supports the following blueprint types:
 * `scripts`: Defines scripts to be executed as part of the configuration process.
 * `users`: Defines user accounts and groups to be created or managed.
 * `bootstrap`: Defines the initial setup tasks for the system.
-* `ssh_keys`: Defines SSH keys to be generated and managed.
+* `ssh_keys`: Defines SSH keys to be generated and managed, with the ability to set a key as the default RWR SSH key.
 
 == Documentation Wiki
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -143,6 +143,18 @@ var runSSHKeysCmd = &cobra.Command{
 	},
 }
 
+var runFontsCmd = &cobra.Command{
+	Use:   "fonts",
+	Short: "Run fonts processor",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := processors.All(initConfig, osInfo, []string{"fonts"})
+		if err != nil {
+			log.With("err", err).Errorf("Error running fonts processor")
+			os.Exit(1)
+		}
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(runCmd)
 	runCmd.AddCommand(runPackageCmd)
@@ -155,4 +167,5 @@ func init() {
 	runCmd.AddCommand(runGitCmd)
 	runCmd.AddCommand(runScriptsCmd)
 	runCmd.AddCommand(runSSHKeysCmd)
+	runCmd.AddCommand(runFontsCmd)
 }

--- a/examples/linux/Arch/json/packages/packages.json
+++ b/examples/linux/Arch/json/packages/packages.json
@@ -2,7 +2,7 @@
   "packages": [
     {
       "names": [
-        "docker.io",
+        "docker",
         "code",
         "vim",
         "tree"

--- a/examples/linux/Arch/toml/packages/packages.toml
+++ b/examples/linux/Arch/toml/packages/packages.toml
@@ -1,4 +1,4 @@
 [[packages]]
-names = ["docker.io", "code", "vim", "tree"]
+names = ["docker", "code", "vim", "tree"]
 action = "install"
 package_manager = "pacman"

--- a/internal/helpers/files.go
+++ b/internal/helpers/files.go
@@ -252,7 +252,7 @@ func CopyFile(source, target string, elevated bool) error {
 
 	_, err = io.Copy(targetFile, sourceFile)
 	if err != nil {
-		return fmt.Errorf("error copying file content: %v", err)
+		return fmt.Errorf("error copying file: %v", err)
 	}
 
 	// If elevated privileges are required, adjust permissions
@@ -279,6 +279,7 @@ func ExpandPath(path string) string {
 }
 
 func copyFileContent(source, target string) error {
+	log.Debugf("Copying file content from %s to %s", source, target)
 	sourceFile, err := os.Open(source)
 	if err != nil {
 		return fmt.Errorf("error opening source file: %v", err)

--- a/internal/processors/all.go
+++ b/internal/processors/all.go
@@ -95,6 +95,13 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 				case "ssh_keys":
 					log.Infof("Processing ssh keys")
 					err = ProcessSSHKeys(resolvedBlueprint, format, osInfo, initConfig)
+					// Add this to your All function, where you process other blueprints
+				case "fonts":
+					log.Info("Processing fonts")
+					err = ProcessFonts(blueprintData, blueprintDir, format, initConfig)
+					if err != nil {
+						return fmt.Errorf("error processing fonts: %w", err)
+					}
 				default:
 					log.Warnf("Unknown processor: %s", processor)
 					continue

--- a/internal/processors/blueprints.go
+++ b/internal/processors/blueprints.go
@@ -18,7 +18,7 @@ func GetBlueprints(initConfig *types.InitConfig) (string, error) {
 		if _, err := os.Stat(gitOpts.Target); os.IsNotExist(err) {
 			// If the target directory doesn't exist, clone the Git repository
 			log.Debugf("Directory %s does not exist. Cloning Git repository", gitOpts.Target)
-			err := helpers.HandleGitClone(*gitOpts)
+			err := helpers.HandleGitClone(*gitOpts, initConfig)
 			if err != nil {
 				return "", fmt.Errorf("error cloning Git repository: %v", err)
 			}

--- a/internal/processors/bootstrap.go
+++ b/internal/processors/bootstrap.go
@@ -87,7 +87,7 @@ func ProcessBootstrap(blueprintFile string, initConfig *types.InitConfig, osInfo
 
 	// Process Git repositories
 	log.Debugf("Processing Git repositories from %s", blueprintFile)
-	err = processGitRepositories(bootstrapData.Git)
+	err = processGitRepositories(bootstrapData.Git, initConfig)
 	if err != nil {
 		log.Errorf("Error processing Git repositories: %v", err)
 		return err

--- a/internal/processors/bootstrap.go
+++ b/internal/processors/bootstrap.go
@@ -71,7 +71,7 @@ func ProcessBootstrap(blueprintFile string, initConfig *types.InitConfig, osInfo
 
 	// Process Files
 	log.Debugf("Processing files from %s", blueprintFile)
-	err = processFiles(bootstrapData.Files, blueprintDir, initConfig)
+	err = processFiles(bootstrapData.Files, blueprintDir)
 	if err != nil {
 		log.Errorf("Error processing directories: %v", err)
 		return err

--- a/internal/processors/files.go
+++ b/internal/processors/files.go
@@ -26,7 +26,7 @@ func ProcessFiles(blueprintData []byte, blueprintDir string, format string, init
 	}
 
 	// Process regular files
-	err = processFiles(fileData.Files, blueprintDir, initConfig)
+	err = processFiles(fileData.Files, blueprintDir)
 	if err != nil {
 		return fmt.Errorf("error processing files: %w", err)
 	}
@@ -46,18 +46,18 @@ func ProcessFiles(blueprintData []byte, blueprintDir string, format string, init
 	return nil
 }
 
-func processFiles(files []types.File, blueprintDir string, initConfig *types.InitConfig) error {
+func processFiles(files []types.File, blueprintDir string) error {
 	for _, file := range files {
 		if len(file.Names) > 0 {
 			for _, name := range file.Names {
 				fileWithName := file
 				fileWithName.Name = name
-				if err := processFile(fileWithName, blueprintDir, initConfig); err != nil {
+				if err := processFile(fileWithName, blueprintDir); err != nil {
 					return fmt.Errorf("error processing file %s: %w", name, err)
 				}
 			}
 		} else {
-			if err := processFile(file, blueprintDir, initConfig); err != nil {
+			if err := processFile(file, blueprintDir); err != nil {
 				return fmt.Errorf("error processing file %s: %w", file.Name, err)
 			}
 		}
@@ -65,7 +65,7 @@ func processFiles(files []types.File, blueprintDir string, initConfig *types.Ini
 	return nil
 }
 
-func processFile(file types.File, blueprintDir string, initConfig *types.InitConfig) error {
+func processFile(file types.File, blueprintDir string) error {
 
 	log.Debugf("Processing file: %s", file.Name)
 
@@ -219,7 +219,7 @@ func processTemplate(template types.File, blueprintDir string, initConfig *types
 	}
 
 	// Process the template as a file
-	err = processFile(file, blueprintDir, initConfig)
+	err = processFile(file, blueprintDir)
 	if err != nil {
 		log.Errorf("Error processing template as file %s: %v", template.Name, err)
 		return fmt.Errorf("error processing template as file %s: %w", template.Name, err)
@@ -302,7 +302,7 @@ func deleteFile(file types.File) error {
 
 func createFile(file types.File) error {
 
-	log.Debugf("Creating file type: %s", file)
+	log.Debugf("Creating file type: %v", file)
 
 	targetPath := filepath.Join(helpers.ExpandPath(file.Target), file.Name)
 

--- a/internal/processors/files.go
+++ b/internal/processors/files.go
@@ -303,15 +303,30 @@ func createFile(file types.File) error {
 		log.Fatalf("error creating target directory: %v", err)
 	}
 
-	if _, err := os.Create(target); err != nil {
+	// Create the file
+	f, err := os.Create(target)
+	if err != nil {
 		log.Fatalf("error creating file: %v", err)
 	}
+	defer func(f *os.File) {
+		err := f.Close()
+		if err != nil {
+			log.Errorf("error closing file: %v", err)
+		}
+	}(f)
+
+	// Write the content to the file
+	_, err = f.WriteString(file.Content)
+	if err != nil {
+		log.Fatalf("error writing content to file: %v", err)
+	}
+
+	log.Infof("File created and content written: %s", target)
 
 	if err := applyFileAttributes(file); err != nil {
 		log.Fatalf("error applying file attributes: %v", err)
 	}
 
-	log.Infof("File created: %s", target)
 	return nil
 }
 

--- a/internal/processors/fonts.go
+++ b/internal/processors/fonts.go
@@ -1,0 +1,122 @@
+package processors
+
+import (
+	"fmt"
+	"github.com/charmbracelet/log"
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/types"
+	"path/filepath"
+)
+
+func ProcessFonts(blueprintData []byte, blueprintDir string, format string, initConfig *types.InitConfig) error {
+	var fontsData types.FontsData
+	var err error
+
+	log.Debug("Processing fonts from blueprint")
+
+	// Unmarshal the blueprint data
+	err = helpers.UnmarshalBlueprint(blueprintData, format, &fontsData)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling fonts blueprint data: %w", err)
+	}
+
+	// Process the fonts
+	for _, font := range fontsData.Fonts {
+		if len(font.Names) > 0 {
+			for _, name := range font.Names {
+				fontWithName := font
+				fontWithName.Name = name
+				if err := processFont(fontWithName, blueprintDir, initConfig); err != nil {
+					return fmt.Errorf("error processing font %s: %w", name, err)
+				}
+			}
+		} else {
+			if err := processFont(font, blueprintDir, initConfig); err != nil {
+				return fmt.Errorf("error processing font %s: %w", font.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func processFont(font types.Font, blueprintDir string, initConfig *types.InitConfig) error {
+	log.Infof("Processing font: %s", font.Name)
+
+	if font.Provider == "" {
+		font.Provider = "nerd"
+	}
+
+	elevated := font.Location == "system"
+
+	switch font.Action {
+	case "install":
+		return installFont(font, elevated, blueprintDir, initConfig)
+	case "remove":
+		return removeFont(font, elevated, blueprintDir, initConfig)
+	default:
+		return fmt.Errorf("unsupported action for font: %s", font.Action)
+	}
+}
+
+func installFont(font types.Font, elevated bool, blueprintDir string, initConfig *types.InitConfig) error {
+	log.Infof("Installing font: %s", font.Name)
+
+	installScript := filepath.Join(blueprintDir, "install.sh")
+
+	var args []string
+	if font.Name == "AllFonts" {
+		args = append(args, "-q") // quiet mode for all fonts
+	} else {
+		args = append(args, font.Name)
+	}
+
+	if elevated {
+		args = append([]string{"sudo"}, args...)
+	}
+
+	cmd := types.Command{
+		Exec:     installScript,
+		Args:     args,
+		Elevated: elevated,
+	}
+
+	err := helpers.RunCommand(cmd, initConfig.Variables.Flags.Debug)
+	if err != nil {
+		return fmt.Errorf("error installing font %s: %v", font.Name, err)
+	}
+
+	log.Infof("Font %s installed successfully", font.Name)
+	return nil
+}
+
+func removeFont(font types.Font, elevated bool, blueprintDir string, initConfig *types.InitConfig) error {
+	log.Infof("Removing font: %s", font.Name)
+
+	// For now, we'll just use the install script with the --remove flag
+	// In the future, you might want to implement a separate uninstall script or method
+	installScript := filepath.Join(blueprintDir, "install.sh")
+
+	args := []string{"--remove"}
+	if font.Name != "AllFonts" {
+		args = append(args, font.Name)
+	}
+
+	if elevated {
+		args = append([]string{"sudo"}, args...)
+	}
+
+	cmd := types.Command{
+		Exec:     installScript,
+		Args:     args,
+		Elevated: elevated,
+	}
+
+	err := helpers.RunCommand(cmd, initConfig.Variables.Flags.Debug)
+	if err != nil {
+		return fmt.Errorf("error removing font %s: %v", font.Name, err)
+	}
+
+	log.Infof("Font %s removed successfully", font.Name)
+	return nil
+}

--- a/internal/processors/git.go
+++ b/internal/processors/git.go
@@ -2,8 +2,9 @@ package processors
 
 import (
 	"fmt"
-	"github.com/fynxlabs/rwr/internal/types"
 	"os"
+
+	"github.com/fynxlabs/rwr/internal/types"
 
 	"github.com/charmbracelet/log"
 	"github.com/fynxlabs/rwr/internal/helpers"
@@ -65,28 +66,28 @@ func processGitRepositories(gitRepos []types.Git, initConfig *types.InitConfig) 
 	return nil
 }
 
-func cloneGitRepository(repo types.Git, initConfig *types.InitConfig) error {
-	gitOpts := types.GitOptions{
-		URL:     repo.URL,
-		Private: repo.Private,
-		Target:  repo.Path,
-		Branch:  repo.Branch,
-	}
+// func cloneGitRepository(repo types.Git, initConfig *types.InitConfig) error {
+// 	gitOpts := types.GitOptions{
+// 		URL:     repo.URL,
+// 		Private: repo.Private,
+// 		Target:  repo.Path,
+// 		Branch:  repo.Branch,
+// 	}
 
-	_, err := os.Stat(gitOpts.Target)
-	if err == nil {
-		// Repository already exists
-		log.Infof("Git repository %s already exists at %s", repo.Name, gitOpts.Target)
-		return nil
-	} else if !os.IsNotExist(err) {
-		// Some other error occurred
-		return fmt.Errorf("error checking Git repository %s: %w", repo.Name, err)
-	}
+// 	_, err := os.Stat(gitOpts.Target)
+// 	if err == nil {
+// 		// Repository already exists
+// 		log.Infof("Git repository %s already exists at %s", repo.Name, gitOpts.Target)
+// 		return nil
+// 	} else if !os.IsNotExist(err) {
+// 		// Some other error occurred
+// 		return fmt.Errorf("error checking Git repository %s: %w", repo.Name, err)
+// 	}
 
-	err = helpers.HandleGitClone(gitOpts, initConfig)
-	if err != nil {
-		return fmt.Errorf("error cloning Git repository %s: %w", repo.Name, err)
-	}
+// 	err = helpers.HandleGitClone(gitOpts, initConfig)
+// 	if err != nil {
+// 		return fmt.Errorf("error cloning Git repository %s: %w", repo.Name, err)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }

--- a/internal/processors/initialize.go
+++ b/internal/processors/initialize.go
@@ -82,7 +82,7 @@ func Initialize(initFilePath string, flags types.Flags) (*types.InitConfig, erro
 			err = helpers.HandleGitFileDownload(types.GitOptions{
 				URL:    repoURL + "/blob/" + filePath,
 				Target: "init" + fileExt, // Save the file with the original extension
-			})
+			}, &initConfig)
 			if err != nil {
 				return nil, fmt.Errorf("error downloading init file from GitHub: %w", err)
 			}

--- a/internal/processors/respository.go
+++ b/internal/processors/respository.go
@@ -2,13 +2,14 @@ package processors
 
 import (
 	"fmt"
-	"github.com/charmbracelet/log"
-	"github.com/fynxlabs/rwr/internal/helpers"
-	"github.com/fynxlabs/rwr/internal/types"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/charmbracelet/log"
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/types"
 )
 
 func ProcessRepositories(blueprintData []byte, format string, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
@@ -49,7 +50,7 @@ func processRepositories(repositories []types.Repository, osInfo *types.OSInfo, 
 			}
 		case "dnf", "yum":
 			log.Debugf("Processing DNF/Yum repository")
-			if err := processDnfYumRepository(repo, osInfo, initConfig); err != nil {
+			if err := processDnfYumRepository(repo, initConfig); err != nil {
 				return err
 			}
 		case "zypper":
@@ -230,7 +231,7 @@ func processBrewRepository(repo types.Repository, osInfo *types.OSInfo, initConf
 	return nil
 }
 
-func processDnfYumRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
+func processDnfYumRepository(repo types.Repository, initConfig *types.InitConfig) error {
 	if repo.Action == "add" {
 		// Use dnf config-manager to add the repository
 		addCmd := types.Command{

--- a/internal/types/fonts.go
+++ b/internal/types/fonts.go
@@ -1,0 +1,13 @@
+package types
+
+type Font struct {
+	Name     string   `mapstructure:"name" yaml:"name" json:"name" toml:"name"`
+	Names    []string `mapstructure:"names,omitempty" yaml:"names,omitempty" json:"names,omitempty" toml:"names,omitempty"`
+	Action   string   `mapstructure:"action" yaml:"action" json:"action" toml:"action"`
+	Provider string   `mapstructure:"provider,omitempty" yaml:"provider,omitempty" json:"provider,omitempty" toml:"provider,omitempty"`
+	Location string   `mapstructure:"location,omitempty" yaml:"location,omitempty" json:"location,omitempty" toml:"location,omitempty"`
+}
+
+type FontsData struct {
+	Fonts []Font `yaml:"fonts" json:"fonts" toml:"fonts"`
+}

--- a/internal/types/package.go
+++ b/internal/types/package.go
@@ -1,13 +1,14 @@
 package types
 
 type Package struct {
-	Name           string   `mapstructure:"name" yaml:"name" json:"name" toml:"name"`                                                                                     // Name of the package
-	Elevated       bool     `mapstructure:"elevated,omitempty" yaml:"elevated,omitempty" json:"elevated,omitempty" toml:"elevated,omitempty"`                             // Whether the package requires elevated privileges
-	Action         string   `mapstructure:"action" yaml:"action" json:"action" toml:"action"`                                                                             // Action to perform with the package
-	PackageManager string   `mapstructure:"package_manager,omitempty" yaml:"package_manager,omitempty" json:"package_manager,omitempty" toml:"package_manager,omitempty"` // Package manager to use
-	Names          []string `mapstructure:"names,omitempty" yaml:"names,omitempty" json:"names,omitempty" toml:"names,omitempty"`                                         // Names of the packages
+	Name           string   `mapstructure:"name" yaml:"name" json:"name" toml:"name"`
+	Elevated       bool     `mapstructure:"elevated,omitempty" yaml:"elevated,omitempty" json:"elevated,omitempty" toml:"elevated,omitempty"`
+	Action         string   `mapstructure:"action" yaml:"action" json:"action" toml:"action"`
+	PackageManager string   `mapstructure:"package_manager,omitempty" yaml:"package_manager,omitempty" json:"package_manager,omitempty" toml:"package_manager,omitempty"`
+	Names          []string `mapstructure:"names,omitempty" yaml:"names,omitempty" json:"names,omitempty" toml:"names,omitempty"`
+	Args           []string `mapstructure:"args,omitempty" yaml:"args,omitempty" json:"args,omitempty" toml:"args,omitempty"` // New field for additional arguments
 }
 
 type PackagesData struct {
-	Packages []Package `mapstructure:"packages,omitempty" yaml:"packages,omitempty" json:"packages,omitempty" toml:"packages,omitempty"` // Packages data
+	Packages []Package `mapstructure:"packages,omitempty" yaml:"packages,omitempty" json:"packages,omitempty" toml:"packages,omitempty"`
 }

--- a/internal/types/ssh_key.go
+++ b/internal/types/ssh_key.go
@@ -1,13 +1,14 @@
 package types
 
 type SSHKey struct {
-	Name         string `mapstructure:"name" yaml:"name" json:"name" toml:"name"`
-	Type         string `mapstructure:"type" yaml:"type" json:"type" toml:"type"`
-	Path         string `mapstructure:"path" yaml:"path" json:"path" toml:"path"`
-	Comment      string `mapstructure:"comment" yaml:"comment" json:"comment" toml:"comment"`
-	NoPassphrase bool   `mapstructure:"no_passphrase" yaml:"no_passphrase" json:"no_passphrase" toml:"no_passphrase"`
-	CopyToGitHub bool   `mapstructure:"copy_to_github" yaml:"copy_to_github" json:"copy_to_github" toml:"copy_to_github"`
-	GithubTitle  string `mapstructure:"github_title" yaml:"github_title" json:"github_title" toml:"github_title"`
+	Name           string `mapstructure:"name" yaml:"name" json:"name" toml:"name"`
+	Type           string `mapstructure:"type" yaml:"type" json:"type" toml:"type"`
+	Path           string `mapstructure:"path" yaml:"path" json:"path" toml:"path"`
+	Comment        string `mapstructure:"comment" yaml:"comment" json:"comment" toml:"comment"`
+	NoPassphrase   bool   `mapstructure:"no_passphrase" yaml:"no_passphrase" json:"no_passphrase" toml:"no_passphrase"`
+	CopyToGitHub   bool   `mapstructure:"copy_to_github" yaml:"copy_to_github" json:"copy_to_github" toml:"copy_to_github"`
+	GithubTitle    string `mapstructure:"github_title" yaml:"github_title" json:"github_title" toml:"github_title"`
+	SetAsRWRSSHKey bool   `mapstructure:"set_as_rwr_ssh_key" yaml:"set_as_rwr_ssh_key" json:"set_as_rwr_ssh_key" toml:"set_as_rwr_ssh_key"`
 }
 
 type SSHKeyData struct {


### PR DESCRIPTION
- Adds the following
	- Can use URL as File Source and will download file and move it to the target location
	- Added intelligent file renames (target: /i'm/a/path/ vs /i'm/a/rename.txt)
	- Git processor will update .git/config of a repo if you change from HTTPS from SSH or vice versa version of clone URLs
	- SSH Key and Git Token is actually used for private repos
	- Add package manager being used to # of packages log messages
	- add args options to package to enable things like `--cask` for brew and such
	- can now use/set the ssh key you create as the rwr ssh key for git cloning