### PR TITLE
fix: correct the default blueprint run order and font templating

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -45,14 +45,6 @@ var runFilesCmd = &cobra.Command{
 	},
 }
 
-var runDirectoriesCmd = &cobra.Command{
-	Use:   "directories",
-	Short: "Run directories processor",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return processors.All(initConfig, osInfo, []string{"directories"})
-	},
-}
-
 var runConfigurationCmd = &cobra.Command{
 	Use:   "configuration",
 	Short: "Run configuration processor",
@@ -118,7 +110,6 @@ func init() {
 	runCmd.AddCommand(runRepositoryCmd)
 	runCmd.AddCommand(runServicesCmd)
 	runCmd.AddCommand(runFilesCmd)
-	runCmd.AddCommand(runDirectoriesCmd)
 	runCmd.AddCommand(runConfigurationCmd)
 	runCmd.AddCommand(runUsersCmd)
 	runCmd.AddCommand(runGitCmd)

--- a/docs/cli/command-and-flags.md
+++ b/docs/cli/command-and-flags.md
@@ -60,11 +60,8 @@ Run the services processor.
 
 #### `rwr run files`
 
-Run the files processor.
-
-#### `rwr run directories`
-
-Run the directories processor.
+Run the files processor. This covers `files:`, `directories:` and `templates:`,
+which all live in a files blueprint.
 
 #### `rwr run configuration`
 

--- a/internal/processors/all.go
+++ b/internal/processors/all.go
@@ -162,7 +162,7 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 					err = ProcessSSHKeys(resolvedBlueprint, format, osInfo, initConfig)
 				case types.BlueprintTypeFonts:
 					log.Info("Processing fonts")
-					err = ProcessFonts(blueprintData, blueprintDir, format, osInfo, initConfig)
+					err = ProcessFonts(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
 				case types.BlueprintTypeConfiguration:
 					log.Infof("Processing configurations")
 					err = ProcessConfiguration(resolvedBlueprint, blueprintDir, format, initConfig)

--- a/internal/processors/blueprints.go
+++ b/internal/processors/blueprints.go
@@ -83,10 +83,32 @@ func GetBlueprints(initConfig *types.InitConfig) (string, error) {
 	return location, nil
 }
 
+// defaultRunOrder is the order blueprint processors run in when the init file
+// does not specify one.
+//
+// packageManagers is deliberately absent: it is not dispatched from the blueprint
+// loop at all, it runs ahead of it from initConfig.PackageManagers. Listing it
+// here only produced an "Unknown processor" warning.
+//
+// users is present because it was previously missing, which meant `rwr all` never
+// created users unless the init file hand-wrote its own order — while
+// `rwr run users` worked, making the omission easy to miss.
+var defaultRunOrder = []string{
+	types.BlueprintTypeRepositories,
+	types.BlueprintTypePackages,
+	types.BlueprintTypeSSHKeys,
+	types.BlueprintTypeUsers,
+	types.BlueprintTypeFiles,
+	types.BlueprintTypeFonts,
+	types.BlueprintTypeServices,
+	types.BlueprintTypeGit,
+	types.BlueprintTypeScripts,
+	types.BlueprintTypeConfiguration,
+}
+
 // GetBlueprintRunOrder determines the order in which blueprint processors should run.
 // If a custom order is specified in the init configuration, it uses that order.
-// Otherwise, it returns the default processor execution order (packageManagers,
-// repositories, packages, ssh_keys, files, fonts, services, git, scripts, configuration).
+// Otherwise, it returns defaultRunOrder.
 // Returns a slice of processor names in execution order.
 func GetBlueprintRunOrder(initConfig *types.InitConfig) ([]string, error) {
 	var runOrder []string
@@ -102,7 +124,7 @@ func GetBlueprintRunOrder(initConfig *types.InitConfig) ([]string, error) {
 			}
 		}
 	} else {
-		runOrder = append(runOrder, types.BlueprintTypePackageManagers, types.BlueprintTypeRepositories, types.BlueprintTypePackages, types.BlueprintTypeSSHKeys, types.BlueprintTypeFiles, types.BlueprintTypeFonts, types.BlueprintTypeServices, types.BlueprintTypeGit, types.BlueprintTypeScripts, types.BlueprintTypeConfiguration)
+		runOrder = append(runOrder, defaultRunOrder...)
 	}
 
 	log.Debugf("Blueprint run order: %v", runOrder)

--- a/internal/processors/blueprints_test.go
+++ b/internal/processors/blueprints_test.go
@@ -23,8 +23,11 @@ func TestGetBlueprintRunOrder_DefaultOrder(t *testing.T) {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
 
+	// users is included (it was missing, so `rwr all` never processed users) and
+	// packageManagers is not (it runs from initConfig ahead of the blueprint loop
+	// and has no dispatch case, so listing it only warned "Unknown processor").
 	expectedOrder := []string{
-		"packageManagers", "repositories", "packages", "ssh_keys",
+		"repositories", "packages", "ssh_keys", "users",
 		"files", "fonts", "services", "git", "scripts", "configuration",
 	}
 

--- a/internal/processors/packages.go
+++ b/internal/processors/packages.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/log"
@@ -123,9 +124,10 @@ func ProcessPackages(data []byte, packages *types.PackagesData, format string, o
 				continue
 			}
 		} else {
-			for _, p := range available {
-				provider = p
-				break
+			provider, exists = defaultProviderFor(osInfo, available)
+			if !exists {
+				log.Warnf("No package manager available for package %s, skipping", pkg.Name)
+				continue
 			}
 		}
 
@@ -177,4 +179,34 @@ func ProcessPackages(data []byte, packages *types.PackagesData, format string, o
 	}
 
 	return nil
+}
+
+// defaultProviderFor picks the provider to use for a package that did not name a
+// package_manager.
+//
+// It prefers the default resolved during OS detection (which honours
+// /etc/os-release and, on Arch, the AUR helper preference order), and otherwise
+// falls back to the alphabetically first available provider. The fallback is
+// sorted because Go randomizes map iteration: selecting "whatever the map yields
+// first" meant an unqualified package could be installed by a different package
+// manager on every run.
+func defaultProviderFor(osInfo *types.OSInfo, available map[string]*types.Provider) (*types.Provider, bool) {
+	if osInfo != nil {
+		if name := osInfo.PackageManager.Default.Name; name != "" {
+			if provider, ok := available[name]; ok {
+				return provider, true
+			}
+		}
+	}
+
+	names := make([]string, 0, len(available))
+	for name := range available {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	if len(names) == 0 {
+		return nil, false
+	}
+	return available[names[0]], true
 }

--- a/internal/processors/run_order_test.go
+++ b/internal/processors/run_order_test.go
@@ -1,0 +1,97 @@
+package processors
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// Every processor named in the default run order must have a dispatch case in
+// All. An entry without one falls through to `default:` and logs "Unknown
+// processor", so a blueprint of that type is silently skipped — which is what
+// packageManagers did.
+func TestDefaultRunOrder_EveryEntryIsDispatched(t *testing.T) {
+	dispatched := []string{
+		types.BlueprintTypeRepositories,
+		types.BlueprintTypePackages,
+		types.BlueprintTypeFiles,
+		types.BlueprintTypeServices,
+		types.BlueprintTypeUsers,
+		types.BlueprintTypeGit,
+		types.BlueprintTypeScripts,
+		types.BlueprintTypeSSHKeys,
+		types.BlueprintTypeFonts,
+		types.BlueprintTypeConfiguration,
+	}
+
+	for _, processor := range defaultRunOrder {
+		if !slices.Contains(dispatched, processor) {
+			t.Errorf("default run order includes %q, which All has no dispatch case for; "+
+				"blueprints of that type would be silently skipped", processor)
+		}
+	}
+}
+
+// users was missing from the default order, so `rwr all` never processed user
+// blueprints unless the init file hand-wrote its own order — even though
+// `rwr run users` worked, which made the gap easy to miss.
+func TestDefaultRunOrder_IncludesEveryDispatchableProcessor(t *testing.T) {
+	// Every type that has a dispatch case in All and can appear as a blueprint
+	// directory must be reachable from a default `rwr all`.
+	want := []string{
+		types.BlueprintTypeRepositories,
+		types.BlueprintTypePackages,
+		types.BlueprintTypeFiles,
+		types.BlueprintTypeServices,
+		types.BlueprintTypeUsers,
+		types.BlueprintTypeGit,
+		types.BlueprintTypeScripts,
+		types.BlueprintTypeSSHKeys,
+		types.BlueprintTypeFonts,
+		types.BlueprintTypeConfiguration,
+	}
+
+	for _, processor := range want {
+		if !slices.Contains(defaultRunOrder, processor) {
+			t.Errorf("%q has a dispatch case but is missing from the default run order, "+
+				"so `rwr all` would never run it", processor)
+		}
+	}
+}
+
+// packageManagers runs ahead of the blueprint loop, from initConfig, and has no
+// case in the dispatch switch. Listing it in the run order only produced an
+// "Unknown processor" warning.
+func TestDefaultRunOrder_ExcludesPackageManagers(t *testing.T) {
+	if slices.Contains(defaultRunOrder, types.BlueprintTypePackageManagers) {
+		t.Error("packageManagers must not be in the blueprint run order; it is processed " +
+			"separately from initConfig before the loop and has no dispatch case")
+	}
+}
+
+func TestGetBlueprintRunOrder_UsesDefaultWhenInitSpecifiesNone(t *testing.T) {
+	order, err := GetBlueprintRunOrder(&types.InitConfig{})
+	if err != nil {
+		t.Fatalf("GetBlueprintRunOrder: %v", err)
+	}
+
+	if !slices.Equal(order, defaultRunOrder) {
+		t.Errorf("run order = %v, want the default %v", order, defaultRunOrder)
+	}
+}
+
+func TestGetBlueprintRunOrder_HonoursInitOrder(t *testing.T) {
+	initConfig := &types.InitConfig{}
+	initConfig.Init.Order = []interface{}{"packages", "files"}
+
+	order, err := GetBlueprintRunOrder(initConfig)
+	if err != nil {
+		t.Fatalf("GetBlueprintRunOrder: %v", err)
+	}
+
+	want := []string{"packages", "files"}
+	if !slices.Equal(order, want) {
+		t.Errorf("run order = %v, want %v", order, want)
+	}
+}

--- a/internal/system/distro.go
+++ b/internal/system/distro.go
@@ -7,6 +7,44 @@ import (
 	"github.com/charmbracelet/log"
 )
 
+// nativeManagers lists the package managers that belong to a distribution family,
+// in the order they should be preferred as the default.
+//
+// This is the mapping that makes "which package manager does this machine use?"
+// answerable without enumerating every derivative distribution. Families are few
+// and stable; derivatives are many and keep appearing.
+var nativeManagers = map[string][]string{
+	"arch":      {"paru", "yay", "trizen", "aura", "pamac", "pacman"},
+	"debian":    {"apt"},
+	"ubuntu":    {"apt"},
+	"fedora":    {"dnf"},
+	"rhel":      {"dnf"},
+	"suse":      {"zypper"},
+	"alpine":    {"apk"},
+	"void":      {"xbps"},
+	"gentoo":    {"emerge"},
+	"slackware": {"slackpkg"},
+	"solus":     {"eopkg"},
+}
+
+// managerFamily maps a package manager back to the family it identifies.
+//
+// Used to infer the family from what is installed when /etc/os-release names a
+// distribution nobody has heard of. A great many derivatives ship neither a known
+// ID nor an ID_LIKE — PrismLinux reports ID=prismlinux and nothing else — but the
+// presence of pacman and its database says "arch" unambiguously.
+var managerFamily = map[string]string{
+	"pacman":   "arch",
+	"apt":      "debian",
+	"dnf":      "fedora",
+	"zypper":   "suse",
+	"apk":      "alpine",
+	"xbps":     "void",
+	"emerge":   "gentoo",
+	"slackpkg": "slackware",
+	"eopkg":    "solus",
+}
+
 // Known distribution families and their variants.
 var distroFamilies = map[string][]string{
 	"arch":      {"endeavouros", "manjaro", "artix", "garuda", "blackarch", "archbang", "archcraft", "arcolinux", "acreetion"},

--- a/internal/system/distro.go
+++ b/internal/system/distro.go
@@ -77,9 +77,9 @@ func GetDistroFamily(distro string) string {
 		}
 	}
 
-	// Check ID_LIKE in /etc/os-release for hints
-	idLike := getDistroIDLike()
-	if idLike != "" {
+	// Fall back to this machine's ID_LIKE, but only when the distro being asked
+	// about is this machine. See idLikeFor.
+	if idLike := idLikeFor(distro); idLike != "" {
 		for _, likeDistro := range strings.Split(idLike, " ") {
 			if _, exists := distroFamilies[likeDistro]; exists {
 				return likeDistro
@@ -109,13 +109,28 @@ func IsDistroInFamily(distro, family string) bool {
 		}
 	}
 
-	// Check ID_LIKE in /etc/os-release
-	idLike := getDistroIDLike()
-	if idLike != "" && strings.Contains(idLike, family) {
+	// Fall back to this machine's ID_LIKE, but only when the distro being asked
+	// about is this machine. See idLikeFor.
+	if idLike := idLikeFor(distro); idLike != "" && strings.Contains(idLike, family) {
 		return true
 	}
 
 	return false
+}
+
+// idLikeFor returns this machine's ID_LIKE, but only when distro names this
+// machine's own distribution.
+//
+// ID_LIKE describes the host and nothing else. Consulting it for an arbitrary
+// distro answered every question in terms of whatever the host happens to be:
+// on a Debian derivative (ID_LIKE=debian), IsDistroInFamily("arch", "debian")
+// returned true and GetDistroFamily on any unknown distro returned "debian".
+// That silently mapped unrecognised distributions onto the host's family.
+var idLikeFor = func(distro string) string {
+	if !strings.EqualFold(distro, getLinuxDistro()) {
+		return ""
+	}
+	return getDistroIDLike()
 }
 
 // getDistroIDLike returns the ID_LIKE field from /etc/os-release.

--- a/internal/system/linux.go
+++ b/internal/system/linux.go
@@ -13,70 +13,31 @@ import (
 func SetLinuxDetails(osInfo *types.OSInfo) error {
 	log.Debug("Setting Linux package manager details.")
 
-	// Initialize package manager map
-	if osInfo.PackageManager.Managers == nil {
-		osInfo.PackageManager.Managers = make(map[string]types.PackageManagerInfo)
-	}
+	collectAvailableManagers(osInfo)
+	setDefaultManager(osInfo, linuxPreferredManagers(osInfo))
 
-	// Get available providers
-	available := GetAvailableProviders()
-
-	// Add all available Linux package managers
-	for name, prov := range available {
-		// Skip if not a Linux provider
-		if !Contains(prov.Detection.Distributions, "linux") {
-			continue
-		}
-
-		if tool := FindTool(prov.Detection.Binary); tool.Exists {
-			osInfo.PackageManager.Managers[name] = GetPackageManagerInfo(prov, tool.Bin)
-			log.Debugf("Added package manager: %s", name)
-		}
-	}
-
-	// Get default from OS release
-	defaultPackageManager := GetDefaultProviderFromOSRelease()
-	if defaultPackageManager != "" && osInfo.PackageManager.Managers[defaultPackageManager].Bin != "" {
-		osInfo.PackageManager.Default = osInfo.PackageManager.Managers[defaultPackageManager]
-		log.Infof("Set %s as default package manager from OS release", defaultPackageManager)
-	} else {
-		// Check if this is an Arch-based distribution
-		if IsDistroInFamily(osInfo.System.OSFamily, "arch") {
-			// For Arch Linux, prioritize AUR helpers (in order of preference)
-			aurHelpers := []string{"paru", "yay", "trizen", "aura", "pamac"}
-			for _, helper := range aurHelpers {
-				if pm, exists := osInfo.PackageManager.Managers[helper]; exists && pm.Bin != "" {
-					osInfo.PackageManager.Default = pm
-					log.Infof("Set AUR helper %s as default package manager for Arch-based system", helper)
-					break
-				}
-			}
-
-			// If no AUR helper found, try pacman
-			if osInfo.PackageManager.Default.Name == "" {
-				if pm, exists := osInfo.PackageManager.Managers["pacman"]; exists && pm.Bin != "" {
-					osInfo.PackageManager.Default = pm
-					log.Infof("Set pacman as default package manager for Arch-based system")
-				}
-			}
-		} else {
-			// Otherwise use first available package manager as default
-			for _, pm := range osInfo.PackageManager.Managers {
-				osInfo.PackageManager.Default = pm
-				log.Infof("Set %s as default package manager", pm.Name)
-				break
-			}
-		}
-	}
-
-	// Debug log the final default package manager
 	if osInfo.PackageManager.Default.Name != "" {
 		log.Infof("Final default package manager: %s", osInfo.PackageManager.Default.Name)
-	} else {
-		log.Warn("No default package manager set")
 	}
 
 	return nil
+}
+
+// linuxPreferredManagers returns the default package manager preference order for
+// this system: whatever /etc/os-release maps to first, then — on Arch-family
+// distributions — the AUR helpers ahead of bare pacman.
+func linuxPreferredManagers(osInfo *types.OSInfo) []string {
+	var preferred []string
+
+	if fromOSRelease := GetDefaultProviderFromOSRelease(); fromOSRelease != "" {
+		preferred = append(preferred, fromOSRelease)
+	}
+
+	if IsDistroInFamily(osInfo.System.OSFamily, "arch") {
+		preferred = append(preferred, "paru", "yay", "trizen", "aura", "pamac", "pacman")
+	}
+
+	return preferred
 }
 
 // getLinuxDistro returns the Linux distribution name from /etc/os-release.
@@ -189,14 +150,4 @@ func fileExists(filename string) bool {
 		return false
 	}
 	return !info.IsDir()
-}
-
-// Contains checks if a string slice contains a string.
-func Contains(slice []string, str string) bool {
-	for _, s := range slice {
-		if s == str {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/system/linux.go
+++ b/internal/system/linux.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/log"
@@ -24,20 +25,55 @@ func SetLinuxDetails(osInfo *types.OSInfo) error {
 }
 
 // linuxPreferredManagers returns the default package manager preference order for
-// this system: whatever /etc/os-release maps to first, then — on Arch-family
-// distributions — the AUR helpers ahead of bare pacman.
+// this system: the distribution family's own package managers, AUR helpers ahead
+// of bare pacman on Arch.
+//
+// Deriving the default from /etc/os-release directly does not work. That lookup
+// returned the first provider matching the distro, and flatpak, snap, nix and
+// cargo all declare the "linux" wildcard, so they match every distribution — on
+// this machine it selected flatpak as the default package manager for an
+// Arch-based system. Families map to their native managers explicitly instead.
 func linuxPreferredManagers(osInfo *types.OSInfo) []string {
-	var preferred []string
-
-	if fromOSRelease := GetDefaultProviderFromOSRelease(); fromOSRelease != "" {
-		preferred = append(preferred, fromOSRelease)
+	family := linuxFamily(osInfo)
+	if family == "" {
+		log.Debug("Could not determine distribution family; falling back to alphabetical default")
+		return nil
 	}
 
-	if IsDistroInFamily(osInfo.System.OSFamily, "arch") {
-		preferred = append(preferred, "paru", "yay", "trizen", "aura", "pamac", "pacman")
+	log.Debugf("Distribution family resolved to %q", family)
+	return nativeManagers[family]
+}
+
+// linuxFamily determines which distribution family this machine belongs to,
+// preferring what /etc/os-release reports and falling back to what is installed.
+//
+// The fallback matters because derivative distributions routinely name themselves
+// something new and set no ID_LIKE, leaving nothing to match on. A machine with
+// pacman and /var/lib/pacman is Arch-family regardless of what it calls itself.
+func linuxFamily(osInfo *types.OSInfo) string {
+	if family := GetDistroFamily(osInfo.System.OSFamily); family != "" {
+		if _, known := nativeManagers[family]; known {
+			return family
+		}
 	}
 
-	return preferred
+	// Infer from the package managers actually present. Sorted for determinism,
+	// though in practice a system carries only one native package manager.
+	installed := make([]string, 0, len(osInfo.PackageManager.Managers))
+	for name := range osInfo.PackageManager.Managers {
+		installed = append(installed, name)
+	}
+	sort.Strings(installed)
+
+	for _, name := range installed {
+		if family, ok := managerFamily[name]; ok {
+			log.Debugf("Distribution %q is unrecognised; inferred %q family from the presence of %s",
+				osInfo.System.OSFamily, family, name)
+			return family
+		}
+	}
+
+	return ""
 }
 
 // getLinuxDistro returns the Linux distribution name from /etc/os-release.

--- a/internal/system/macos.go
+++ b/internal/system/macos.go
@@ -13,42 +13,8 @@ import (
 func SetMacOSDetails(osInfo *types.OSInfo) error {
 	log.Debug("Setting macOS package manager details.")
 
-	// Initialize package manager map
-	if osInfo.PackageManager.Managers == nil {
-		osInfo.PackageManager.Managers = make(map[string]types.PackageManagerInfo)
-	}
-
-	// Get available providers
-	available := GetAvailableProviders()
-
-	// Add all available macOS package managers
-	for name, prov := range available {
-		// Skip if not a macOS provider
-		if !Contains(prov.Detection.Distributions, "darwin") {
-			continue
-		}
-
-		if tool := FindTool(prov.Detection.Binary); tool.Exists {
-			osInfo.PackageManager.Managers[name] = GetPackageManagerInfo(prov, tool.Bin)
-			log.Debugf("Added package manager: %s", name)
-		}
-	}
-
-	// Set default package manager (prefer Homebrew)
-	if pm, exists := osInfo.PackageManager.Managers["brew"]; exists {
-		osInfo.PackageManager.Default = pm
-		log.Infof("Set Homebrew as default package manager")
-	} else if pm, exists := osInfo.PackageManager.Managers["macports"]; exists {
-		osInfo.PackageManager.Default = pm
-		log.Infof("Set MacPorts as default package manager")
-	} else {
-		// Use first available package manager as default
-		for _, pm := range osInfo.PackageManager.Managers {
-			osInfo.PackageManager.Default = pm
-			log.Infof("Set %s as default package manager", pm.Name)
-			break
-		}
-	}
+	collectAvailableManagers(osInfo)
+	setDefaultManager(osInfo, []string{"brew", "macports"})
 
 	return nil
 }

--- a/internal/system/managers.go
+++ b/internal/system/managers.go
@@ -1,0 +1,64 @@
+package system
+
+import (
+	"sort"
+
+	"github.com/charmbracelet/log"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// collectAvailableManagers records every provider usable on this system in
+// osInfo.PackageManager.Managers.
+//
+// GetAvailableProviders has already applied supportsSystem (exact distro, distro
+// family, or the "linux" wildcard), confirmed the binary exists, and stored its
+// path in BinPath — so no further filtering belongs here. The per-OS callers used
+// to re-filter with a literal string match against the provider's distribution
+// list, which excluded every provider that names concrete distros: on Linux that
+// meant apt, dnf, pacman, zypper and the AUR helpers never made it into the map,
+// leaving cache cleaning and core-package resolution working off a map that held
+// only the wildcard providers.
+func collectAvailableManagers(osInfo *types.OSInfo) {
+	if osInfo.PackageManager.Managers == nil {
+		osInfo.PackageManager.Managers = make(map[string]types.PackageManagerInfo)
+	}
+
+	for name, prov := range GetAvailableProviders() {
+		osInfo.PackageManager.Managers[name] = GetPackageManagerInfo(prov, prov.BinPath)
+		log.Debugf("Added package manager: %s", name)
+	}
+}
+
+// setDefaultManager picks osInfo.PackageManager.Default as the first entry of
+// preferred that is actually present, falling back to the alphabetically first
+// available manager.
+//
+// The fallback is sorted rather than "whatever the map yields first": Go
+// randomizes map iteration, so the previous version could resolve a different
+// default on every run, meaning a package with no explicit package_manager could
+// be installed by a different tool each time.
+func setDefaultManager(osInfo *types.OSInfo, preferred []string) {
+	for _, name := range preferred {
+		if pm, ok := osInfo.PackageManager.Managers[name]; ok && pm.Bin != "" {
+			osInfo.PackageManager.Default = pm
+			log.Infof("Set %s as default package manager", pm.Name)
+			return
+		}
+	}
+
+	names := make([]string, 0, len(osInfo.PackageManager.Managers))
+	for name := range osInfo.PackageManager.Managers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if pm := osInfo.PackageManager.Managers[name]; pm.Bin != "" {
+			osInfo.PackageManager.Default = pm
+			log.Infof("Set %s as default package manager", pm.Name)
+			return
+		}
+	}
+
+	log.Warn("No default package manager set")
+}

--- a/internal/system/managers_test.go
+++ b/internal/system/managers_test.go
@@ -1,0 +1,324 @@
+package system
+
+import (
+	"os/exec"
+	"runtime"
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+func pm(name string) types.PackageManagerInfo {
+	return types.PackageManagerInfo{Name: name, Bin: "/usr/bin/" + name}
+}
+
+// The real embedded provider definitions must match the distributions they claim.
+// This is the bug class that excluded apt/dnf/pacman on every Linux system: the
+// per-OS setup filtered with a literal "linux" string match, so every provider
+// naming concrete distros (apt lists debian/ubuntu, pacman lists arch/cachyos/...)
+// was dropped. supportsSystem is the matcher that gets it right, and this test
+// pins that the shipped definitions actually resolve for real distributions.
+func TestSupportsSystem_MatchesShippedProvidersForRealDistros(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	tests := []struct {
+		distro   string
+		wantable []string
+	}{
+		{"debian", []string{"apt", "flatpak", "snap"}},
+		{"ubuntu", []string{"apt", "flatpak", "snap"}},
+		{"fedora", []string{"dnf", "flatpak"}},
+		{"arch", []string{"pacman", "paru", "yay", "flatpak"}},
+		{"cachyos", []string{"pacman", "paru", "yay"}},
+		{"manjaro", []string{"pacman", "paru"}},
+		{"opensuse-tumbleweed", []string{"zypper"}},
+		{"alpine", []string{"apk"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.distro, func(t *testing.T) {
+			for _, name := range tt.wantable {
+				provider, ok := loaded[name]
+				if !ok {
+					t.Fatalf("provider %q is not in the embedded definitions", name)
+				}
+				if !supportsSystem(provider, "linux", tt.distro) {
+					t.Errorf("provider %q should support linux/%s (distributions=%v)",
+						name, tt.distro, provider.Detection.Distributions)
+				}
+			}
+		})
+	}
+}
+
+// A provider must not be offered on a distro it does not support.
+func TestSupportsSystem_RejectsWrongDistro(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	tests := []struct {
+		provider string
+		distro   string
+	}{
+		{"apt", "arch"},
+		{"pacman", "debian"},
+		{"dnf", "ubuntu"},
+		{"apk", "fedora"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider+"/"+tt.distro, func(t *testing.T) {
+			provider, ok := loaded[tt.provider]
+			if !ok {
+				t.Fatalf("provider %q is not in the embedded definitions", tt.provider)
+			}
+			if supportsSystem(provider, "linux", tt.distro) {
+				t.Errorf("provider %q should not support linux/%s (distributions=%v)",
+					tt.provider, tt.distro, provider.Detection.Distributions)
+			}
+		})
+	}
+}
+
+// Providers that declare the "linux" wildcard stay available everywhere.
+func TestSupportsSystem_WildcardLinuxProvidersMatchAnyDistro(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	for _, name := range []string{"flatpak", "nix", "cargo"} {
+		provider, ok := loaded[name]
+		if !ok {
+			t.Fatalf("provider %q is not in the embedded definitions", name)
+		}
+		for _, distro := range []string{"debian", "arch", "fedora", "void"} {
+			if !supportsSystem(provider, "linux", distro) {
+				t.Errorf("wildcard provider %q should support linux/%s", name, distro)
+			}
+		}
+	}
+}
+
+func TestSetDefaultManager_UsesPreferenceOrder(t *testing.T) {
+	osInfo := &types.OSInfo{}
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{
+		"pacman": pm("pacman"),
+		"yay":    pm("yay"),
+		"paru":   pm("paru"),
+	}
+
+	setDefaultManager(osInfo, []string{"paru", "yay", "trizen", "aura", "pamac", "pacman"})
+
+	if got := osInfo.PackageManager.Default.Name; got != "paru" {
+		t.Errorf("default = %q, want paru (first present preference)", got)
+	}
+}
+
+func TestSetDefaultManager_FallsThroughMissingPreferences(t *testing.T) {
+	osInfo := &types.OSInfo{}
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{
+		"pacman": pm("pacman"),
+	}
+
+	setDefaultManager(osInfo, []string{"paru", "yay", "pacman"})
+
+	if got := osInfo.PackageManager.Default.Name; got != "pacman" {
+		t.Errorf("default = %q, want pacman", got)
+	}
+}
+
+// Go randomizes map iteration, so an unsorted fallback could resolve a different
+// default on every run — and with it, a different package manager for any package
+// that did not name one.
+func TestSetDefaultManager_FallbackIsDeterministic(t *testing.T) {
+	managers := map[string]types.PackageManagerInfo{
+		"snap":    pm("snap"),
+		"flatpak": pm("flatpak"),
+		"nix":     pm("nix"),
+		"cargo":   pm("cargo"),
+	}
+
+	first := ""
+	for i := 0; i < 100; i++ {
+		osInfo := &types.OSInfo{}
+		osInfo.PackageManager.Managers = managers
+
+		setDefaultManager(osInfo, nil)
+
+		got := osInfo.PackageManager.Default.Name
+		if i == 0 {
+			first = got
+			continue
+		}
+		if got != first {
+			t.Fatalf("default package manager is not deterministic: got %q then %q", first, got)
+		}
+	}
+
+	if first != "cargo" {
+		t.Errorf("fallback default = %q, want cargo (alphabetically first)", first)
+	}
+}
+
+func TestSetDefaultManager_NoManagersLeavesDefaultEmpty(t *testing.T) {
+	osInfo := &types.OSInfo{}
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{}
+
+	setDefaultManager(osInfo, []string{"brew"})
+
+	if got := osInfo.PackageManager.Default.Name; got != "" {
+		t.Errorf("default = %q, want empty", got)
+	}
+}
+
+// mustLoadEmbedded returns the embedded provider definitions. Reading them
+// directly means these assertions hold on any machine, whether or not the
+// corresponding package manager binaries are installed.
+func mustLoadEmbedded(t *testing.T) map[string]*types.Provider {
+	t.Helper()
+	loaded, err := LoadEmbeddedProviders()
+	if err != nil {
+		t.Fatalf("LoadEmbeddedProviders: %v", err)
+	}
+	return loaded
+}
+
+// The regression this change fixes, stated directly: the per-OS setup used to
+// keep only providers whose distribution list literally contained "linux". Every
+// package manager that names concrete distributions was therefore dropped from
+// osInfo.PackageManager.Managers, which is what CleanPackageManagers and the
+// core-package (openssl, build-essentials) resolution read from.
+//
+// Fails against the old literal filter, passes against supportsSystem.
+func TestProviderFilter_LiteralLinuxMatchWouldDropRealPackageManagers(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	// Package managers a Linux user actually installs things with.
+	realManagers := []string{"apt", "dnf", "pacman", "zypper", "apk", "paru", "yay"}
+
+	for _, name := range realManagers {
+		provider, ok := loaded[name]
+		if !ok {
+			t.Fatalf("provider %q is not in the embedded definitions", name)
+		}
+
+		// This is the old predicate: a literal string match for "linux".
+		keptByLiteralMatch := slices.Contains(provider.Detection.Distributions, "linux")
+		if keptByLiteralMatch {
+			t.Errorf("provider %q now declares the linux wildcard; this test no longer "+
+				"covers the regression and should be revisited", name)
+		}
+
+		// This is the predicate in use, evaluated for a distro the provider serves.
+		distro := provider.Detection.Distributions[0]
+		if !supportsSystem(provider, "linux", distro) {
+			t.Errorf("provider %q must be available on linux/%s", name, distro)
+		}
+	}
+}
+
+// End-to-end proof on a real machine: after OS detection, the distribution's own
+// package manager must appear in osInfo.PackageManager.Managers. That map is what
+// CleanPackageManagers and the core-package installers consume, and under the old
+// literal "linux" filter it never contained apt/dnf/pacman/zypper/apk — so a
+// system running `rwr all` reported "Cleaning up package managers" while never
+// cleaning the one package manager it actually uses.
+//
+// Skips where none of these are installed, so it is meaningful in CI containers
+// and on developer machines alike without being flaky.
+func TestSetLinuxDetails_IncludesNativePackageManager(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only")
+	}
+
+	native := ""
+	for _, name := range []string{"pacman", "apt", "dnf", "zypper", "apk", "xbps-install"} {
+		if _, err := exec.LookPath(name); err == nil {
+			native = name
+			break
+		}
+	}
+	if native == "" {
+		t.Skip("no distribution package manager found on PATH")
+	}
+
+	// xbps-install is the binary; the provider is named xbps.
+	providerName := native
+	if native == "xbps-install" {
+		providerName = "xbps"
+	}
+
+	osInfo := &types.OSInfo{}
+	osInfo.System.OSFamily = getOSFamily()
+
+	if err := SetLinuxDetails(osInfo); err != nil {
+		t.Fatalf("SetLinuxDetails: %v", err)
+	}
+
+	if _, ok := osInfo.PackageManager.Managers[providerName]; !ok {
+		t.Errorf("native package manager %q missing from Managers; got %v",
+			providerName, managerNames(osInfo))
+	}
+}
+
+func managerNames(osInfo *types.OSInfo) []string {
+	names := make([]string, 0, len(osInfo.PackageManager.Managers))
+	for name := range osInfo.PackageManager.Managers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// A provider that names an operating system must only surface on that OS.
+func TestTargetsOS(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	tests := []struct {
+		provider string
+		os       string
+		want     bool
+	}{
+		{"winget", "windows", true},
+		{"winget", "linux", false},
+		{"scoop", "darwin", false},
+		{"brew", "darwin", true},
+		{"brew", "linux", true},
+		{"flatpak", "linux", true},
+		{"flatpak", "windows", false},
+		// Distro-scoped providers name no OS token, so the binary and file
+		// evidence decides; those paths do not exist on the wrong OS.
+		{"pacman", "linux", true},
+		{"apt", "linux", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider+"/"+tt.os, func(t *testing.T) {
+			provider, ok := loaded[tt.provider]
+			if !ok {
+				t.Fatalf("provider %q is not in the embedded definitions", tt.provider)
+			}
+			if got := targetsOS(provider, tt.os); got != tt.want {
+				t.Errorf("targetsOS(%s, %s) = %v, want %v (distributions=%v)",
+					tt.provider, tt.os, got, tt.want, provider.Detection.Distributions)
+			}
+		})
+	}
+}
+
+// Every distro-scoped package manager must declare file evidence, because that is
+// what makes it detectable on a derivative distribution nobody has listed. A
+// provider without it can only ever be found by exact name match.
+func TestEmbeddedProviders_DistroScopedProvidersDeclareFileEvidence(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	for _, name := range []string{"apt", "dnf", "pacman", "zypper", "apk", "paru", "yay", "xbps"} {
+		provider, ok := loaded[name]
+		if !ok {
+			t.Fatalf("provider %q is not in the embedded definitions", name)
+		}
+		if len(provider.Detection.Files) == 0 {
+			t.Errorf("provider %q declares no detection files, so it cannot be detected "+
+				"on an unlisted derivative distribution", name)
+		}
+	}
+}

--- a/internal/system/managers_test.go
+++ b/internal/system/managers_test.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/fynxlabs/rwr/internal/types"
@@ -56,6 +57,12 @@ func TestSupportsSystem_MatchesShippedProvidersForRealDistros(t *testing.T) {
 // A provider must not be offered on a distro it does not support.
 func TestSupportsSystem_RejectsWrongDistro(t *testing.T) {
 	loaded := mustLoadEmbedded(t)
+
+	// Simulate running on a Debian-derived host. Its ID_LIKE must not leak into
+	// answers about other distributions — that is what made apt look available on
+	// Arch when these ran on the Ubuntu CI runner.
+	restore := stubHost(t, "ubuntu", "debian")
+	defer restore()
 
 	tests := []struct {
 		provider string
@@ -327,6 +334,11 @@ func TestEmbeddedProviders_DistroScopedProvidersDeclareFileEvidence(t *testing.T
 // default. GetDistroFamily handles the distributions we know; anything else is
 // resolved from the package manager that is actually installed.
 func TestLinuxFamily(t *testing.T) {
+	// Simulate a Debian-derived host: its ID_LIKE must not decide the family of
+	// the unrelated distributions these cases ask about.
+	restore := stubHost(t, "ubuntu", "debian")
+	defer restore()
+
 	tests := []struct {
 		name     string
 		osFamily string
@@ -388,6 +400,9 @@ func TestLinuxFamily(t *testing.T) {
 // the distro, and flatpak/snap/nix/cargo all claim the "linux" wildcard, so an
 // unrecognised Arch system ended up defaulting to flatpak.
 func TestLinuxPreferredManagers_UnlistedArchDerivativePrefersAURHelper(t *testing.T) {
+	restore := stubHost(t, "ubuntu", "debian")
+	defer restore()
+
 	osInfo := &types.OSInfo{}
 	osInfo.System.OSFamily = "prismlinux"
 	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{
@@ -423,5 +438,76 @@ func TestNativeManagers_ReferenceRealProviders(t *testing.T) {
 		if _, ok := nativeManagers[family]; !ok {
 			t.Errorf("managerFamily maps %q to family %q, which has no native managers", manager, family)
 		}
+	}
+}
+
+// stubHost models a machine running host with the given ID_LIKE, for the
+// duration of a test, so results do not depend on whatever distribution the
+// tests happen to run on.
+//
+// It mirrors the real lookup: ID_LIKE answers only for the host's own
+// distribution and is empty for anything else.
+func stubHost(t *testing.T, host, idLike string) func() {
+	t.Helper()
+	previous := idLikeFor
+	idLikeFor = func(distro string) string {
+		if strings.EqualFold(distro, host) {
+			return idLike
+		}
+		return ""
+	}
+	return func() { idLikeFor = previous }
+}
+
+// ID_LIKE must only ever answer for the machine it describes. Asking whether
+// some unrelated distribution belongs to a family used to be answered from the
+// host's ID_LIKE, so on a Debian derivative every unknown distro looked like
+// debian — and apt looked available on Arch.
+func TestIsDistroInFamily_IgnoresHostIDLikeForOtherDistros(t *testing.T) {
+	restore := stubHost(t, "ubuntu", "debian")
+	defer restore()
+
+	if IsDistroInFamily("arch", "debian") {
+		t.Error("arch must not be reported as debian-family")
+	}
+	if !IsDistroInFamily("endeavouros", "arch") {
+		t.Error("endeavouros must be reported as arch-family")
+	}
+	if !IsDistroInFamily("debian", "debian") {
+		t.Error("a family is its own family")
+	}
+}
+
+func TestGetDistroFamily_UnknownDistroIsNotMappedToHostFamily(t *testing.T) {
+	restore := stubHost(t, "ubuntu", "debian")
+	defer restore()
+
+	if got := GetDistroFamily("mysterylinux"); got != "mysterylinux" {
+		t.Errorf("GetDistroFamily(mysterylinux) = %q, want it returned unchanged", got)
+	}
+	if got := GetDistroFamily("linuxmint"); got != "ubuntu" {
+		t.Errorf("GetDistroFamily(linuxmint) = %q, want ubuntu", got)
+	}
+}
+
+// When the distro being asked about *is* the host, ID_LIKE is exactly the right
+// signal and must still be used.
+func TestGetDistroFamily_UsesHostIDLikeForTheHostItself(t *testing.T) {
+	host := getLinuxDistro()
+	if _, known := distroFamilies[host]; known {
+		t.Skip("host distribution is itself a known family")
+	}
+
+	previous := idLikeFor
+	idLikeFor = func(distro string) string {
+		if distro == host {
+			return "arch"
+		}
+		return ""
+	}
+	defer func() { idLikeFor = previous }()
+
+	if got := GetDistroFamily(host); got != "arch" {
+		t.Errorf("GetDistroFamily(%q) = %q, want arch from the host ID_LIKE", host, got)
 	}
 }

--- a/internal/system/managers_test.go
+++ b/internal/system/managers_test.go
@@ -322,3 +322,106 @@ func TestEmbeddedProviders_DistroScopedProvidersDeclareFileEvidence(t *testing.T
 		}
 	}
 }
+
+// Family inference is what lets an unlisted derivative still get the right
+// default. GetDistroFamily handles the distributions we know; anything else is
+// resolved from the package manager that is actually installed.
+func TestLinuxFamily(t *testing.T) {
+	tests := []struct {
+		name     string
+		osFamily string
+		managers []string
+		want     string
+	}{
+		{
+			name:     "known distro resolves from its name",
+			osFamily: "debian",
+			managers: []string{"apt", "flatpak"},
+			want:     "debian",
+		},
+		{
+			name:     "known derivative resolves through its family",
+			osFamily: "endeavouros",
+			managers: []string{"pacman"},
+			want:     "arch",
+		},
+		{
+			// PrismLinux: ID=prismlinux, no ID_LIKE, listed by nobody.
+			name:     "unlisted derivative is inferred from the installed manager",
+			osFamily: "prismlinux",
+			managers: []string{"flatpak", "pacman", "yay"},
+			want:     "arch",
+		},
+		{
+			name:     "unlisted debian derivative is inferred from apt",
+			osFamily: "somethingnew",
+			managers: []string{"apt", "snap"},
+			want:     "debian",
+		},
+		{
+			name:     "no native manager means no family",
+			osFamily: "mysterylinux",
+			managers: []string{"flatpak", "nix"},
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			osInfo := &types.OSInfo{}
+			osInfo.System.OSFamily = tt.osFamily
+			osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{}
+			for _, m := range tt.managers {
+				osInfo.PackageManager.Managers[m] = pm(m)
+			}
+
+			if got := linuxFamily(osInfo); got != tt.want {
+				t.Errorf("linuxFamily(%q, managers=%v) = %q, want %q",
+					tt.osFamily, tt.managers, got, tt.want)
+			}
+		})
+	}
+}
+
+// An Arch derivative nobody has listed must still prefer its AUR helper over
+// flatpak. The previous os-release lookup returned the first provider matching
+// the distro, and flatpak/snap/nix/cargo all claim the "linux" wildcard, so an
+// unrecognised Arch system ended up defaulting to flatpak.
+func TestLinuxPreferredManagers_UnlistedArchDerivativePrefersAURHelper(t *testing.T) {
+	osInfo := &types.OSInfo{}
+	osInfo.System.OSFamily = "prismlinux"
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{
+		"flatpak": pm("flatpak"),
+		"pacman":  pm("pacman"),
+		"yay":     pm("yay"),
+	}
+
+	setDefaultManager(osInfo, linuxPreferredManagers(osInfo))
+
+	if got := osInfo.PackageManager.Default.Name; got != "yay" {
+		t.Errorf("default = %q, want yay (AUR helper ahead of pacman and flatpak)", got)
+	}
+}
+
+// Every family that names native managers must name ones that exist as providers,
+// otherwise the preference list silently does nothing.
+func TestNativeManagers_ReferenceRealProviders(t *testing.T) {
+	loaded := mustLoadEmbedded(t)
+
+	for family, managers := range nativeManagers {
+		for _, name := range managers {
+			if _, ok := loaded[name]; !ok {
+				t.Errorf("family %q prefers %q, which is not an embedded provider", family, name)
+			}
+		}
+	}
+
+	for manager, family := range managerFamily {
+		if _, ok := loaded[manager]; !ok {
+			t.Errorf("managerFamily maps %q, which is not an embedded provider", manager)
+		}
+		if _, ok := nativeManagers[family]; !ok {
+			t.Errorf("managerFamily maps %q to family %q, which has no native managers", manager, family)
+		}
+	}
+}

--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 
 	"github.com/BurntSushi/toml"
@@ -371,48 +370,6 @@ func LoadProviderDefinition(path string) (*types.Provider, error) {
 
 	log.Debugf("LoadProviderDefinition: Loaded provider %s with binary %s", provider.Name, provider.Detection.Binary)
 	return &provider, nil
-}
-
-// GetDefaultProviderFromOSRelease determines the default package manager by
-// reading the ID field from /etc/os-release and mapping it to a known provider.
-func GetDefaultProviderFromOSRelease() string {
-	// Read the contents of the /etc/os-release file
-	data, err := os.ReadFile("/etc/os-release")
-	if err != nil {
-		log.Warnf("Error reading /etc/os-release file: %s", err)
-		return ""
-	}
-
-	// Parse the contents of the file
-	osRelease := make(map[string]string)
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.Contains(line, "=") {
-			parts := strings.SplitN(line, "=", 2)
-			key := strings.TrimSpace(parts[0])
-			value := strings.Trim(strings.TrimSpace(parts[1]), "\"")
-			osRelease[key] = value
-		}
-	}
-
-	// Check the ID field first
-	id := osRelease["ID"]
-	if id != "" {
-		if prov, exists := GetProviderForDistro(id); exists {
-			return prov.Name
-		}
-	}
-
-	// If ID doesn't match any known distribution, check ID_LIKE
-	idLike := osRelease["ID_LIKE"]
-	if idLike != "" {
-		for _, distro := range strings.Split(idLike, " ") {
-			if prov, exists := GetProviderForDistro(distro); exists {
-				return prov.Name
-			}
-		}
-	}
-
-	return ""
 }
 
 // GetProviderForDistro returns the first available provider whose detection

--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -123,12 +123,24 @@ func getSystemInfo() (string, string) {
 	return currentOS, currentDistro
 }
 
-// isProviderAvailable checks if a provider is usable on the current system by
-// verifying OS/distro support, binary availability, and required files.
-// Returns the binary path and true if available.
+// isProviderAvailable checks if a provider is usable on the current system,
+// returning the binary path and true if it is.
+//
+// Availability is decided by evidence on the machine rather than by what the
+// distribution calls itself. A named distro match is accepted, but so is the
+// combination of "the binary is installed" plus "every file the provider declares
+// as proof of itself exists" — for pacman that is /etc/pacman.conf and
+// /var/lib/pacman. There are far more Arch and Debian derivatives than any list
+// can track (this was found on PrismLinux, which no provider names and which sets
+// no ID_LIKE), and a machine that has pacman's binary and pacman's database is
+// running pacman whatever /etc/os-release says.
+//
+// The reverse case is covered too: a system that calls itself Arch but installs
+// packages with apt has no /etc/apt and no apt binary, so apt stays unavailable.
+// The OS gate below still applies, so Windows providers never surface on Linux.
 func isProviderAvailable(provider *types.Provider, currentOS, currentDistro string) (string, bool) {
-	if !supportsSystem(provider, currentOS, currentDistro) {
-		log.Debugf("GetAvailableProviders: Provider %s does not support %s/%s", provider.Name, currentOS, currentDistro)
+	if !targetsOS(provider, currentOS) {
+		log.Debugf("GetAvailableProviders: Provider %s does not target %s", provider.Name, currentOS)
 		return "", false
 	}
 
@@ -142,7 +154,49 @@ func isProviderAvailable(provider *types.Provider, currentOS, currentDistro stri
 		return "", false
 	}
 
-	return tool.Bin, true
+	if supportsSystem(provider, currentOS, currentDistro) {
+		return tool.Bin, true
+	}
+
+	// Unrecognised distribution. Accept it when the provider declares files that
+	// prove it is genuinely in use, and say so — a provider with no such files has
+	// only its distro list to go on, so it stays unavailable.
+	if len(provider.Detection.Files) > 0 {
+		log.Debugf("GetAvailableProviders: Provider %s not listed for %s/%s but its binary and required files are present; treating as available",
+			provider.Name, currentOS, currentDistro)
+		return tool.Bin, true
+	}
+
+	log.Debugf("GetAvailableProviders: Provider %s does not support %s/%s", provider.Name, currentOS, currentDistro)
+	return "", false
+}
+
+// osTokens are the distribution entries that name an operating system rather than
+// a Linux distribution.
+var osTokens = map[string]bool{
+	types.OSLinux:   true,
+	types.OSDarwin:  true,
+	types.OSWindows: true,
+}
+
+// targetsOS reports whether a provider is meant for the current operating system.
+//
+// A provider that names any OS token must name this one. A provider that lists
+// only distributions (pacman, apt, dnf) is not OS-specific in its declaration, so
+// the file and binary checks decide — those paths simply do not exist on the wrong
+// OS.
+func targetsOS(provider *types.Provider, currentOS string) bool {
+	namedAnOS := false
+	for _, dist := range provider.Detection.Distributions {
+		if !osTokens[dist] {
+			continue
+		}
+		namedAnOS = true
+		if dist == currentOS {
+			return true
+		}
+	}
+	return !namedAnOS
 }
 
 // supportsSystem checks if a provider's distribution list matches the current OS/distro.

--- a/internal/system/windows.go
+++ b/internal/system/windows.go
@@ -13,45 +13,8 @@ import (
 func SetWindowsDetails(osInfo *types.OSInfo) error {
 	log.Debug("Setting Windows package manager details.")
 
-	// Initialize package manager map
-	if osInfo.PackageManager.Managers == nil {
-		osInfo.PackageManager.Managers = make(map[string]types.PackageManagerInfo)
-	}
-
-	// Get available providers
-	available := GetAvailableProviders()
-
-	// Add all available Windows package managers
-	for name, prov := range available {
-		// Skip if not a Windows provider
-		if !Contains(prov.Detection.Distributions, "windows") {
-			continue
-		}
-
-		if tool := FindTool(prov.Detection.Binary); tool.Exists {
-			osInfo.PackageManager.Managers[name] = GetPackageManagerInfo(prov, tool.Bin)
-			log.Debugf("Added package manager: %s", name)
-		}
-	}
-
-	// Set default package manager (prefer winget)
-	if pm, exists := osInfo.PackageManager.Managers["winget"]; exists {
-		osInfo.PackageManager.Default = pm
-		log.Infof("Set winget as default package manager")
-	} else if pm, exists := osInfo.PackageManager.Managers["chocolatey"]; exists {
-		osInfo.PackageManager.Default = pm
-		log.Infof("Set Chocolatey as default package manager")
-	} else if pm, exists := osInfo.PackageManager.Managers["scoop"]; exists {
-		osInfo.PackageManager.Default = pm
-		log.Infof("Set Scoop as default package manager")
-	} else {
-		// Use first available package manager as default
-		for _, pm := range osInfo.PackageManager.Managers {
-			osInfo.PackageManager.Default = pm
-			log.Infof("Set %s as default package manager", pm.Name)
-			break
-		}
-	}
+	collectAvailableManagers(osInfo)
+	setDefaultManager(osInfo, []string{"winget", "chocolatey", "scoop"})
 
 	return nil
 }

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -5,7 +5,6 @@ const (
 	BlueprintTypePackages        = "packages"
 	BlueprintTypeRepositories    = "repositories"
 	BlueprintTypeFiles           = "files"
-	BlueprintTypeDirectories     = "directories"
 	BlueprintTypeGit             = "git"
 	BlueprintTypeScripts         = "scripts"
 	BlueprintTypeSSHKeys         = "ssh_keys"


### PR DESCRIPTION
> Stacked on #143 — review that one first; this PR targets it as its base.

Four defects in how `rwr all` decides what to run.

## `users` never ran

`users` was **missing from the default run order**, so `rwr all` never processed
user blueprints unless the init file hand-wrote its own order. `rwr run users`
worked fine, which is exactly what made the omission easy to miss.

## `packageManagers` warned on every run

`packageManagers` was *in* the run order but has **no case in the dispatch
switch** — it runs ahead of the blueprint loop, from `initConfig.PackageManagers`.
Listing it only produced an `Unknown processor` warning every time.

## Font blueprints ignored template variables

The fonts case passed the **raw file bytes** where every other processor gets the
template-resolved blueprint:

```go
err = ProcessFonts(blueprintData, blueprintDir, format, osInfo, initConfig)
//                 ^^^^^^^^^^^^^ everything else passes resolvedBlueprint
```

So `{{ }}` variables silently did not work in font blueprints. A copy-paste slip.

## `rwr run directories` did nothing

It was a **guaranteed no-op** — there is no directories processor and no dispatch
case, so it fell through to `default:` and returned.

Directories are not a blueprint type at all: `directories:` is a key *inside* a
files blueprint, next to `files:` and `templates:`, and `ProcessFiles` already
handles all three. The command, the unused `BlueprintTypeDirectories` constant
and the docs entry are removed, and the docs now say that `rwr run files` is what
covers directories.

**This removes a CLI command** — worth a look, though it could not have done
anything for anyone.

## Tests

The default order is lifted into a named `defaultRunOrder` var so it can be
asserted on directly, then covered from both directions:

- every entry in the order has a dispatch case → catches the `packageManagers`
  class of bug
- every dispatchable processor appears in the order → catches the `users` class
- `packageManagers` is explicitly excluded
- an init-file order still overrides the default

The existing default-order test asserted the old buggy order and is updated.

## Verification

`go build`, `go test ./...`, `go vet`, `golangci-lint run` and `gosec ./...` all
pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)