### PR TITLE
feat: build for riscv64 and publish master prereleases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,101 @@
+name: RWR - Master Prerelease
+
+# Publishes a build of master on every merge, so there is always something
+# installable that reflects current master. These are explicitly not vetted
+# releases — see the release notes the job writes.
+#
+# goreleaser's own nightly support is a Pro feature, so this assembles a snapshot
+# build and publishes it through gh. The `nightly` tag is moved to each new commit
+# and the release is replaced rather than accumulating one per merge, so the
+# download URLs stay stable.
+
+on:
+  push:
+    branches: ["master"]
+  # Allows re-cutting the prerelease without pushing anything.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  # Merges can land faster than a build takes. Keep only the newest, so the
+  # published prerelease is always the newest commit rather than whichever job
+  # happened to finish last.
+  group: master-prerelease
+  cancel-in-progress: true
+
+jobs:
+  prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: ">=1.26.5"
+
+      # --snapshot builds without publishing, so the version comes from
+      # .goreleaser.yaml's snapshot template and carries the commit sha.
+      # Homebrew is skipped: the tap should only ever carry real releases.
+      - name: Build artifacts
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean --skip=homebrew
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          short_sha="$(git rev-parse --short HEAD)"
+
+          # Replace the previous prerelease rather than accumulating one per merge.
+          # --cleanup-tag lets the recreated release point at the new commit.
+          gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
+
+          cat > notes.md <<EOF
+          Build of \`master\` at [\`${short_sha}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}).
+
+          > [!WARNING]
+          > This is **not a release**. It is whatever master happened to be when it
+          > was built: it has passed CI, but it has not been vetted or version-tagged.
+          > For anything you rely on, use the
+          > [latest release](https://github.com/${GITHUB_REPOSITORY}/releases/latest).
+
+          Artifacts are versioned \`<next-patch>-master-${short_sha}\` so a downloaded
+          binary can be traced back to the commit it came from. This release and its
+          tag are replaced on every merge to master, so the download URLs are stable
+          but their contents change.
+          EOF
+
+          # Collect by find rather than globbing: an unmatched glob would be passed
+          # through literally and fail the upload under `set -e`.
+          mapfile -t artifacts < <(
+            find dist -maxdepth 1 -type f \
+              \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.deb' \
+                 -o -name '*.rpm' -o -name '*.apk' -o -name '*.pkg.tar.zst' \
+                 -o -name 'checksums.txt' \) | sort
+          )
+
+          if [ "${#artifacts[@]}" -eq 0 ]; then
+            echo "No artifacts were produced; refusing to publish an empty prerelease." >&2
+            exit 1
+          fi
+          printf 'Publishing %d artifacts\n' "${#artifacts[@]}"
+
+          gh release create nightly \
+            --prerelease \
+            --target "${GITHUB_SHA}" \
+            --title "master (${short_sha})" \
+            --notes-file notes.md \
+            "${artifacts[@]}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,8 +9,15 @@ before:
   hooks:
     - go mod tidy
 
+# Snapshot builds are unreleased builds of whatever the tree currently is. The
+# master prerelease workflow uses these, so the version carries the commit it was
+# built from — an artifact on disk can be traced back to master without relying on
+# the release page it came from.
+#
+# goreleaser's own `nightly` support is a Pro feature, so the master prerelease is
+# assembled from a snapshot build and published by .github/workflows/nightly.yml.
 snapshot:
-  version_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-master-{{ .ShortCommit }}"
 
 gomod:
   proxy: true
@@ -35,11 +42,17 @@ builds:
       - amd64
       - arm
       - arm64
+      - riscv64
     goarm:
       - "7"
     ignore:
       - goos: windows
         goarch: arm
+      # Go only supports riscv64 on linux (and openbsd, which we do not target).
+      - goos: windows
+        goarch: riscv64
+      - goos: darwin
+        goarch: riscv64
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
@@ -134,8 +147,14 @@ homebrew_casks:
     binary: rwr
     homepage: "https://github.com/fynxlabs/rwr"
     description: "Rinse, Wash, Repeat (RWR) - Configuration Management Tool"
+    # "auto" skips prereleases, which keeps the nightly master builds out of the
+    # tap — `brew install rwr` should only ever give you a real release.
+    skip_upload: "auto"
 
 release:
   name_template: "v{{ .Version }}"
+  # "auto" marks a release as a prerelease when its version carries a prerelease
+  # part, which the nightly version template always does.
+  prerelease: auto
   footer: |
     **Full Changelog**: https://github.com/fynxlabs/rwr/compare/{{ .PreviousTag }}...{{ if .IsNightly }}nightly{{ else }}{{ .Tag }}{{ end }}

--- a/README.md
+++ b/README.md
@@ -88,7 +88,35 @@ The following package types are available:
 - Binary archives (`.tar.gz`, `.zip`)
 - Debian packages (`.deb`)
 - RPM packages (`.rpm`)
+- Alpine packages (`.apk`)
+- Arch packages (`.pkg.tar.zst`)
 - Homebrew taps
+
+Builds are published for Linux, macOS and Windows on `x86_64`, `arm64` and
+`armv7`, plus Linux on `riscv64`. Arch Linux packages are not built for
+`riscv64`, since Arch has no official port; use the `.tar.gz`, `.deb`, `.rpm` or
+`.apk` there.
+
+### Master prereleases
+
+Every merge to `master` publishes a prerelease under the
+[`nightly`](https://github.com/fynxlabs/rwr/releases/tag/nightly) tag, so there is
+always an installable build of current `master`.
+
+> [!WARNING]
+> These are not releases. They are whatever `master` happened to be when they were
+> built — CI has passed, but they are not vetted or version-tagged. Use the
+> [latest release](https://github.com/fynxlabs/rwr/releases/latest) for anything
+> you depend on.
+
+The tag and its artifacts are replaced on every merge, so the download URLs stay
+stable while their contents change. Artifacts are versioned
+`<next-patch>-master-<short-sha>` so a binary you already have can be traced back
+to the commit it came from:
+
+```bash
+rwr version
+```
 
 ### From Releases
 

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ case "$ARCH" in
     arm64*)     ARCH="arm64";;
     armv7*)     ARCH="armv7";;
     aarch64*)   ARCH="arm64";;
+    riscv64*)   ARCH="riscv64";;
     *)          echo "Unsupported architecture: $ARCH"; exit 1;;
 esac
 


### PR DESCRIPTION
Two additions to the release pipeline. Independent of the other open PRs — this
one targets `master` directly.

## RISC-V builds

`riscv64` is added to the build matrix. Go only supports it on Linux (and
OpenBSD, which we do not target), so it is ignored for darwin and windows.

Verified with a **full snapshot run**, not just config validation:

```
dist/rwr_Linux_riscv64.tar.gz
dist/rwr_..._linux_riscv64.deb
dist/rwr_..._linux_riscv64.rpm
dist/rwr_..._linux_riscv64.apk
```

nfpm produces no **archlinux** package for riscv64 — correct, Arch has no
official riscv64 port — and skips it without failing the build.

`install.sh` mapped `uname -m` through a case with no riscv64 arm, so a RISC-V
machine was told its architecture was unsupported. It now maps to the
`rwr_Linux_riscv64.tar.gz` that goreleaser actually produces (verified the name
matches the real artifact).

## Master prereleases

Every merge to `master` publishes a build under a fixed **`nightly`** tag, so
there is always something installable reflecting current master.

goreleaser's own `nightly:` support is **Pro-only** (`field nightly not found in
type config.Project` on OSS), so this builds a `--snapshot` and publishes it with
`gh`.

Design choices worth a look:

- **The tag and release are replaced on each merge** rather than accumulating one
  per commit, so download URLs stay stable while contents change.
- **Artifacts carry the commit**: versioned `<next-patch>-master-<short-sha>` via
  the snapshot template, so a binary already on disk can be traced back to what
  built it without depending on the release page it came from.
- **Marked prerelease**, with notes stating plainly that it is not vetted.
- **Homebrew is skipped** for these builds — the tap should only ever carry real
  releases. Also set `release.prerelease: auto`, so a genuine prerelease tag
  (`v1.2.3-rc1`) gets marked as one too.
- **`cancel-in-progress` concurrency**: when merges land faster than a build
  takes, what gets published is the newest commit rather than whichever job
  finished last.
- The upload collects artifacts with `find` rather than globs — an unmatched glob
  would be passed through literally and fail the upload under `set -e`. It also
  refuses to publish an empty release.

`workflow_dispatch` is enabled so the prerelease can be re-cut without pushing.

## Verification

Full `goreleaser release --snapshot --clean --skip=homebrew` succeeds locally,
producing **25 artifacts**. The artifact-collection shell logic was dry-run
against that real `dist/`. All three workflow files parse. `go build`,
`go test ./...` pass.

## Noted, not fixed

`goreleaser check` reports two **pre-existing** deprecations, untouched here:
`homebrew_casks.binary`, and `directory: "Formula"` where casks expect `"Casks"`.
The directory one decides where the cask file lands in the tap, so it deserves
its own change rather than riding along with this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)