### PR TITLE
fix(examples): make the shipped examples actually parse and render

### DIFF
--- a/examples/linux/Arch/json/repositories/repositories.json
+++ b/examples/linux/Arch/json/repositories/repositories.json
@@ -66,7 +66,7 @@
       "profiles": ["personal", "custom"],
       "package_manager": "pacman",
       "action": "add",
-      "url": "file:///home/{{ .User.Username }}/local-repo"
+      "url": "file:///home/{{ .User.username }}/local-repo"
     },
     {
       "name": "archlinux32",

--- a/examples/linux/Arch/json/scripts/scripts.json
+++ b/examples/linux/Arch/json/scripts/scripts.json
@@ -4,36 +4,36 @@
       "name": "system_info",
       "action": "run",
       "content": "#!/bin/bash\necho \"System Information:\"\necho \"Hostname: $(hostname)\"\necho \"User: $USER\"\necho \"Distribution: $(lsb_release -d | cut -f2)\"\necho \"Kernel: $(uname -r)\"",
-      "log": "{{ .User.Home }}/.config/rwr/logs/system_info.log"
+      "log": "{{ .User.home }}/.config/rwr/logs/system_info.log"
     },
     {
       "name": "update_system",
       "action": "run",
       "elevated": true,
       "content": "#!/bin/bash\necho \"Updating package database...\"\npacman -Sy --noconfirm\necho \"System updated successfully\"",
-      "log": "{{ .User.Home }}/.config/rwr/logs/system_update.log"
+      "log": "{{ .User.home }}/.config/rwr/logs/system_update.log"
     },
     {
       "name": "setup_dev_environment",
       "profiles": ["dev", "work"],
       "action": "run",
-      "content": "#!/bin/bash\n# Create development directories\nmkdir -p \"{{ .User.Home }}/Projects\"\nmkdir -p \"{{ .User.Home }}/Projects/personal\"\nmkdir -p \"{{ .User.Home }}/Projects/work\"\nmkdir -p \"{{ .User.Home }}/.local/bin\"\n\n# Set up development aliases\necho 'alias ll=\"ls -alF\"' >> \"{{ .User.Home }}/.bashrc\"\necho 'alias la=\"ls -A\"' >> \"{{ .User.Home }}/.bashrc\"\necho 'alias l=\"ls -CF\"' >> \"{{ .User.Home }}/.bashrc\"\n\necho \"Development environment setup complete\"",
-      "log": "{{ .User.Home }}/.config/rwr/logs/dev_setup.log"
+      "content": "#!/bin/bash\n# Create development directories\nmkdir -p \"{{ .User.home }}/Projects\"\nmkdir -p \"{{ .User.home }}/Projects/personal\"\nmkdir -p \"{{ .User.home }}/Projects/work\"\nmkdir -p \"{{ .User.home }}/.local/bin\"\n\n# Set up development aliases\necho 'alias ll=\"ls -alF\"' >> \"{{ .User.home }}/.bashrc\"\necho 'alias la=\"ls -A\"' >> \"{{ .User.home }}/.bashrc\"\necho 'alias l=\"ls -CF\"' >> \"{{ .User.home }}/.bashrc\"\n\necho \"Development environment setup complete\"",
+      "log": "{{ .User.home }}/.config/rwr/logs/dev_setup.log"
     },
     {
       "name": "install_nvm",
       "profiles": ["dev", "nodejs"],
       "action": "run",
       "content": "#!/bin/bash\ncurl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash\nexport NVM_DIR=\"$HOME/.nvm\"\n[ -s \"$NVM_DIR/nvm.sh\" ] && \\. \"$NVM_DIR/nvm.sh\"\nnvm install --lts\nnvm use --lts\necho \"NVM and latest LTS Node.js installed\"",
-      "log": "{{ .User.Home }}/.config/rwr/logs/nvm_install.log"
+      "log": "{{ .User.home }}/.config/rwr/logs/nvm_install.log"
     },
     {
       "name": "gaming_optimizations",
       "profiles": ["gaming"],
       "action": "run",
       "elevated": true,
-      "content": "#!/bin/bash\n# Enable multilib repository\nsed -i '/^#\\[multilib\\]/,/^#Include = \\/etc\\/pacman.d\\/mirrorlist/ { s/^#//; }' /etc/pacman.conf\n\n# Update package database\npacman -Sy --noconfirm\n\n# Set up gaming group\ngroupadd -f gaming\nusermod -a -G gaming \"{{ .User.Username }}\"\n\necho \"Gaming optimizations applied\"",
-      "log": "{{ .User.Home }}/.config/rwr/logs/gaming_setup.log"
+      "content": "#!/bin/bash\n# Enable multilib repository\nsed -i '/^#\\[multilib\\]/,/^#Include = \\/etc\\/pacman.d\\/mirrorlist/ { s/^#//; }' /etc/pacman.conf\n\n# Update package database\npacman -Sy --noconfirm\n\n# Set up gaming group\ngroupadd -f gaming\nusermod -a -G gaming \"{{ .User.username }}\"\n\necho \"Gaming optimizations applied\"",
+      "log": "{{ .User.home }}/.config/rwr/logs/gaming_setup.log"
     },
     {
       "name": "security_setup",
@@ -41,31 +41,31 @@
       "action": "run",
       "elevated": true,
       "content": "#!/bin/bash\n# Configure firewall\nsystemctl enable ufw\nufw --force enable\nufw default deny incoming\nufw default allow outgoing\nufw allow ssh\n\n# Set up fail2ban\nsystemctl enable fail2ban\nsystemctl start fail2ban\n\necho \"Basic security setup complete\"",
-      "log": "{{ .User.Home }}/.config/rwr/logs/security_setup.log"
+      "log": "{{ .User.home }}/.config/rwr/logs/security_setup.log"
     },
     {
       "name": "setup_postgresql_user",
       "profiles": ["database", "dev"],
       "action": "run",
       "elevated": true,
-      "content": "#!/bin/bash\n# Create PostgreSQL user\nsudo -u postgres createuser -s \"{{ .User.Username }}\"\nsudo -u postgres createdb \"{{ .User.Username }}\"\n\necho \"PostgreSQL user setup complete\"",
-      "log": "{{ .User.Home }}/.config/rwr/logs/postgresql_setup.log"
+      "content": "#!/bin/bash\n# Create PostgreSQL user\nsudo -u postgres createuser -s \"{{ .User.username }}\"\nsudo -u postgres createdb \"{{ .User.username }}\"\n\necho \"PostgreSQL user setup complete\"",
+      "log": "{{ .User.home }}/.config/rwr/logs/postgresql_setup.log"
     },
     {
       "name": "run_custom_setup",
       "profiles": ["personal"],
       "action": "run",
-      "source": "{{ .User.Home }}/Scripts/personal_setup.sh",
-      "args": "--user {{ .User.Username }} --home {{ .User.Home }}",
-      "log": "{{ .User.Home }}/.config/rwr/logs/custom_setup.log"
+      "source": "{{ .User.home }}/Scripts/personal_setup.sh",
+      "args": "--user {{ .User.username }} --home {{ .User.home }}",
+      "log": "{{ .User.home }}/.config/rwr/logs/custom_setup.log"
     },
     {
       "name": "docker_user_setup",
       "profiles": ["dev", "docker"],
       "action": "run",
       "elevated": true,
-      "content": "#!/bin/bash\n# Add user to docker group\nusermod -a -G docker \"{{ .User.Username }}\"\n\n# Enable and start Docker service\nsystemctl enable docker\nsystemctl start docker\n\necho \"Docker user setup complete. Please log out and back in for group changes to take effect.\"",
-      "log": "{{ .User.Home }}/.config/rwr/logs/docker_setup.log"
+      "content": "#!/bin/bash\n# Add user to docker group\nusermod -a -G docker \"{{ .User.username }}\"\n\n# Enable and start Docker service\nsystemctl enable docker\nsystemctl start docker\n\necho \"Docker user setup complete. Please log out and back in for group changes to take effect.\"",
+      "log": "{{ .User.home }}/.config/rwr/logs/docker_setup.log"
     },
     {
       "name": "system_cleanup",
@@ -73,7 +73,7 @@
       "action": "run",
       "elevated": true,
       "content": "#!/bin/bash\n# Clean package cache\npacman -Sc --noconfirm\n\n# Clean orphaned packages\npacman -Rns $(pacman -Qtdq) --noconfirm 2>/dev/null || echo \"No orphaned packages found\"\n\n# Clear systemd journal logs older than 30 days\njournalctl --vacuum-time=30d\n\necho \"System cleanup complete\"",
-      "log": "{{ .User.Home }}/.config/rwr/logs/system_cleanup.log"
+      "log": "{{ .User.home }}/.config/rwr/logs/system_cleanup.log"
     }
   ]
 }

--- a/examples/linux/Arch/json/ssh_keys/ssh_keys.json
+++ b/examples/linux/Arch/json/ssh_keys/ssh_keys.json
@@ -3,8 +3,8 @@
     {
       "name": "id_ed25519",
       "type": "ed25519",
-      "path": "{{ .User.Home }}/.ssh/",
-      "comment": "{{ .User.Username }}@personal",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@personal",
       "no_passphrase": false,
       "copy_to_github": false
     },
@@ -12,8 +12,8 @@
       "name": "id_work",
       "profiles": ["work"],
       "type": "ed25519",
-      "path": "{{ .User.Home }}/.ssh/",
-      "comment": "{{ .User.Username }}@company.com",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@company.com",
       "no_passphrase": false,
       "copy_to_github": false
     },
@@ -21,18 +21,18 @@
       "name": "id_github",
       "profiles": ["dev", "github"],
       "type": "ed25519",
-      "path": "{{ .User.Home }}/.ssh/",
-      "comment": "{{ .User.Username }}@github",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@github",
       "no_passphrase": true,
       "copy_to_github": true,
-      "github_title": "{{ .User.Username }} Development Machine"
+      "github_title": "{{ .User.username }} Development Machine"
     },
     {
       "name": "id_rsa_legacy",
       "profiles": ["legacy", "work"],
       "type": "rsa",
-      "path": "{{ .User.Home }}/.ssh/",
-      "comment": "{{ .User.Username }}@legacy-systems",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@legacy-systems",
       "no_passphrase": false,
       "copy_to_github": false
     },
@@ -40,8 +40,8 @@
       "name": "id_deploy",
       "profiles": ["deploy", "work"],
       "type": "ed25519",
-      "path": "{{ .User.Home }}/.ssh/",
-      "comment": "{{ .User.Username }}@deployment",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@deployment",
       "no_passphrase": true,
       "copy_to_github": false
     },
@@ -49,8 +49,8 @@
       "name": "id_gaming",
       "profiles": ["gaming"],
       "type": "ed25519",
-      "path": "{{ .User.Home }}/.ssh/",
-      "comment": "{{ .User.Username }}@gaming-rig",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@gaming-rig",
       "no_passphrase": true,
       "copy_to_github": false
     },
@@ -58,8 +58,8 @@
       "name": "id_backup",
       "profiles": ["backup", "personal"],
       "type": "ed25519",
-      "path": "{{ .User.Home }}/.ssh/",
-      "comment": "{{ .User.Username }}@backup-server",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@backup-server",
       "no_passphrase": false,
       "copy_to_github": false
     },
@@ -67,8 +67,8 @@
       "name": "id_rwr",
       "profiles": ["dev", "work"],
       "type": "ed25519",
-      "path": "{{ .User.Home }}/.ssh/",
-      "comment": "{{ .User.Username }}@rwr-management",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@rwr-management",
       "no_passphrase": true,
       "copy_to_github": false,
       "set_as_rwr_ssh_key": true
@@ -77,8 +77,8 @@
       "name": "id_cloud",
       "profiles": ["aws", "gcp", "azure", "cloud"],
       "type": "ed25519",
-      "path": "{{ .User.Home }}/.ssh/",
-      "comment": "{{ .User.Username }}@cloud-services",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@cloud-services",
       "no_passphrase": false,
       "copy_to_github": false
     },
@@ -86,8 +86,8 @@
       "name": "id_docker",
       "profiles": ["docker", "dev"],
       "type": "ed25519",
-      "path": "{{ .User.Home }}/.ssh/",
-      "comment": "{{ .User.Username }}@docker-host",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@docker-host",
       "no_passphrase": true,
       "copy_to_github": false
     }

--- a/examples/linux/Arch/toml/repositories/repositories.toml
+++ b/examples/linux/Arch/toml/repositories/repositories.toml
@@ -73,7 +73,7 @@ name = "local-packages"
 profiles = ["personal", "custom"]
 package_manager = "pacman"
 action = "add"
-url = "file:///home/{{ .User.Username }}/local-repo"
+url = "file:///home/{{ .User.username }}/local-repo"
 
 # Alternative architecture repository
 [[repositories]]

--- a/examples/linux/Arch/toml/scripts/scripts.toml
+++ b/examples/linux/Arch/toml/scripts/scripts.toml
@@ -10,7 +10,7 @@ echo "User: $USER"
 echo "Distribution: $(lsb_release -d | cut -f2)"
 echo "Kernel: $(uname -r)"
 """
-log = "{{ .User.Home }}/.config/rwr/logs/system_info.log"
+log = "{{ .User.home }}/.config/rwr/logs/system_info.log"
 
 [[scripts]]
 name = "update_system"
@@ -22,7 +22,7 @@ echo "Updating package database..."
 pacman -Sy --noconfirm
 echo "System updated successfully"
 """
-log = "{{ .User.Home }}/.config/rwr/logs/system_update.log"
+log = "{{ .User.home }}/.config/rwr/logs/system_update.log"
 
 # Development environment setup
 [[scripts]]
@@ -32,19 +32,19 @@ action = "run"
 content = """
 #!/bin/bash
 # Create development directories
-mkdir -p "{{ .User.Home }}/Projects"
-mkdir -p "{{ .User.Home }}/Projects/personal"
-mkdir -p "{{ .User.Home }}/Projects/work"
-mkdir -p "{{ .User.Home }}/.local/bin"
+mkdir -p "{{ .User.home }}/Projects"
+mkdir -p "{{ .User.home }}/Projects/personal"
+mkdir -p "{{ .User.home }}/Projects/work"
+mkdir -p "{{ .User.home }}/.local/bin"
 
 # Set up development aliases
-echo 'alias ll="ls -alF"' >> "{{ .User.Home }}/.bashrc"
-echo 'alias la="ls -A"' >> "{{ .User.Home }}/.bashrc"
-echo 'alias l="ls -CF"' >> "{{ .User.Home }}/.bashrc"
+echo 'alias ll="ls -alF"' >> "{{ .User.home }}/.bashrc"
+echo 'alias la="ls -A"' >> "{{ .User.home }}/.bashrc"
+echo 'alias l="ls -CF"' >> "{{ .User.home }}/.bashrc"
 
 echo "Development environment setup complete"
 """
-log = "{{ .User.Home }}/.config/rwr/logs/dev_setup.log"
+log = "{{ .User.home }}/.config/rwr/logs/dev_setup.log"
 
 # Install development tools from source
 [[scripts]]
@@ -60,7 +60,7 @@ nvm install --lts
 nvm use --lts
 echo "NVM and latest LTS Node.js installed"
 """
-log = "{{ .User.Home }}/.config/rwr/logs/nvm_install.log"
+log = "{{ .User.home }}/.config/rwr/logs/nvm_install.log"
 
 # Gaming optimizations
 [[scripts]]
@@ -78,11 +78,11 @@ pacman -Sy --noconfirm
 
 # Set up gaming group
 groupadd -f gaming
-usermod -a -G gaming "{{ .User.Username }}"
+usermod -a -G gaming "{{ .User.username }}"
 
 echo "Gaming optimizations applied"
 """
-log = "{{ .User.Home }}/.config/rwr/logs/gaming_setup.log"
+log = "{{ .User.home }}/.config/rwr/logs/gaming_setup.log"
 
 # Security hardening
 [[scripts]]
@@ -105,7 +105,7 @@ systemctl start fail2ban
 
 echo "Basic security setup complete"
 """
-log = "{{ .User.Home }}/.config/rwr/logs/security_setup.log"
+log = "{{ .User.home }}/.config/rwr/logs/security_setup.log"
 
 # Database setup
 [[scripts]]
@@ -116,21 +116,21 @@ elevated = true
 content = """
 #!/bin/bash
 # Create PostgreSQL user
-sudo -u postgres createuser -s "{{ .User.Username }}"
-sudo -u postgres createdb "{{ .User.Username }}"
+sudo -u postgres createuser -s "{{ .User.username }}"
+sudo -u postgres createdb "{{ .User.username }}"
 
 echo "PostgreSQL user setup complete"
 """
-log = "{{ .User.Home }}/.config/rwr/logs/postgresql_setup.log"
+log = "{{ .User.home }}/.config/rwr/logs/postgresql_setup.log"
 
 # External script execution
 [[scripts]]
 name = "run_custom_setup"
 profiles = ["personal"]
 action = "run"
-source = "{{ .User.Home }}/Scripts/personal_setup.sh"
-args = "--user {{ .User.Username }} --home {{ .User.Home }}"
-log = "{{ .User.Home }}/.config/rwr/logs/custom_setup.log"
+source = "{{ .User.home }}/Scripts/personal_setup.sh"
+args = "--user {{ .User.username }} --home {{ .User.home }}"
+log = "{{ .User.home }}/.config/rwr/logs/custom_setup.log"
 
 # Docker setup for development
 [[scripts]]
@@ -141,7 +141,7 @@ elevated = true
 content = """
 #!/bin/bash
 # Add user to docker group
-usermod -a -G docker "{{ .User.Username }}"
+usermod -a -G docker "{{ .User.username }}"
 
 # Enable and start Docker service
 systemctl enable docker
@@ -149,7 +149,7 @@ systemctl start docker
 
 echo "Docker user setup complete. Please log out and back in for group changes to take effect."
 """
-log = "{{ .User.Home }}/.config/rwr/logs/docker_setup.log"
+log = "{{ .User.home }}/.config/rwr/logs/docker_setup.log"
 
 # Cleanup script
 [[scripts]]
@@ -170,4 +170,4 @@ journalctl --vacuum-time=30d
 
 echo "System cleanup complete"
 """
-log = "{{ .User.Home }}/.config/rwr/logs/system_cleanup.log"
+log = "{{ .User.home }}/.config/rwr/logs/system_cleanup.log"

--- a/examples/linux/Arch/toml/ssh_keys/ssh_keys.toml
+++ b/examples/linux/Arch/toml/ssh_keys/ssh_keys.toml
@@ -2,8 +2,8 @@
 [[ssh_keys]]
 name = "id_ed25519"
 type = "ed25519"
-path = "{{ .User.Home }}/.ssh/"
-comment = "{{ .User.Username }}@personal"
+path = "{{ .User.home }}/.ssh/"
+comment = "{{ .User.username }}@personal"
 no_passphrase = false
 copy_to_github = false
 
@@ -12,8 +12,8 @@ copy_to_github = false
 name = "id_work"
 profiles = ["work"]
 type = "ed25519"
-path = "{{ .User.Home }}/.ssh/"
-comment = "{{ .User.Username }}@company.com"
+path = "{{ .User.home }}/.ssh/"
+comment = "{{ .User.username }}@company.com"
 no_passphrase = false
 copy_to_github = false
 
@@ -22,19 +22,19 @@ copy_to_github = false
 name = "id_github"
 profiles = ["dev", "github"]
 type = "ed25519"
-path = "{{ .User.Home }}/.ssh/"
-comment = "{{ .User.Username }}@github"
+path = "{{ .User.home }}/.ssh/"
+comment = "{{ .User.username }}@github"
 no_passphrase = true
 copy_to_github = true
-github_title = "{{ .User.Username }} Development Machine"
+github_title = "{{ .User.username }} Development Machine"
 
 # Legacy RSA key for older systems
 [[ssh_keys]]
 name = "id_rsa_legacy"
 profiles = ["legacy", "work"]
 type = "rsa"
-path = "{{ .User.Home }}/.ssh/"
-comment = "{{ .User.Username }}@legacy-systems"
+path = "{{ .User.home }}/.ssh/"
+comment = "{{ .User.username }}@legacy-systems"
 no_passphrase = false
 copy_to_github = false
 
@@ -43,8 +43,8 @@ copy_to_github = false
 name = "id_deploy"
 profiles = ["deploy", "work"]
 type = "ed25519"
-path = "{{ .User.Home }}/.ssh/"
-comment = "{{ .User.Username }}@deployment"
+path = "{{ .User.home }}/.ssh/"
+comment = "{{ .User.username }}@deployment"
 no_passphrase = true
 copy_to_github = false
 
@@ -53,8 +53,8 @@ copy_to_github = false
 name = "id_gaming"
 profiles = ["gaming"]
 type = "ed25519"
-path = "{{ .User.Home }}/.ssh/"
-comment = "{{ .User.Username }}@gaming-rig"
+path = "{{ .User.home }}/.ssh/"
+comment = "{{ .User.username }}@gaming-rig"
 no_passphrase = true
 copy_to_github = false
 
@@ -63,8 +63,8 @@ copy_to_github = false
 name = "id_backup"
 profiles = ["backup", "personal"]
 type = "ed25519"
-path = "{{ .User.Home }}/.ssh/"
-comment = "{{ .User.Username }}@backup-server"
+path = "{{ .User.home }}/.ssh/"
+comment = "{{ .User.username }}@backup-server"
 no_passphrase = false
 copy_to_github = false
 
@@ -73,8 +73,8 @@ copy_to_github = false
 name = "id_rwr"
 profiles = ["dev", "work"]
 type = "ed25519"
-path = "{{ .User.Home }}/.ssh/"
-comment = "{{ .User.Username }}@rwr-management"
+path = "{{ .User.home }}/.ssh/"
+comment = "{{ .User.username }}@rwr-management"
 no_passphrase = true
 copy_to_github = false
 set_as_rwr_ssh_key = true
@@ -84,8 +84,8 @@ set_as_rwr_ssh_key = true
 name = "id_cloud"
 profiles = ["aws", "gcp", "azure", "cloud"]
 type = "ed25519"
-path = "{{ .User.Home }}/.ssh/"
-comment = "{{ .User.Username }}@cloud-services"
+path = "{{ .User.home }}/.ssh/"
+comment = "{{ .User.username }}@cloud-services"
 no_passphrase = false
 copy_to_github = false
 
@@ -94,7 +94,7 @@ copy_to_github = false
 name = "id_docker"
 profiles = ["docker", "dev"]
 type = "ed25519"
-path = "{{ .User.Home }}/.ssh/"
-comment = "{{ .User.Username }}@docker-host"
+path = "{{ .User.home }}/.ssh/"
+comment = "{{ .User.username }}@docker-host"
 no_passphrase = true
 copy_to_github = false

--- a/examples/linux/Arch/yaml/bootstrap.yaml
+++ b/examples/linux/Arch/yaml/bootstrap.yaml
@@ -5,15 +5,15 @@ packages:
     action: install
 
 directories:
-  - name: {{ .User.home }}/git
+  - name: "{{ .User.home }}/git"
     action: create
-    owner: {{ .User.username }}
-    group: {{ .User.username }}
+    owner: "{{ .User.username }}"
+    group: "{{ .User.username }}"
 
 ssh_keys:
   - name: github
     type: ed25519
-    path: {{ .User.home }}/.ssh/
+    path: "{{ .User.home }}/.ssh/"
     comment: "{{ .User.username }}@example.com"
     no_passphrase: true
     copy_to_github: false

--- a/examples/linux/Arch/yaml/files/files.yaml
+++ b/examples/linux/Arch/yaml/files/files.yaml
@@ -2,7 +2,7 @@ files:
   # Base configuration files - always created (no profiles field)
   - name: .bashrc
     action: create
-    target: "{{ .User.Home }}/"
+    target: "{{ .User.home }}/"
     content: |
       # Custom .bashrc content
       alias ll='ls -alF'
@@ -13,7 +13,7 @@ files:
 
   - name: .vimrc
     action: create
-    target: "{{ .User.Home }}/"
+    target: "{{ .User.home }}/"
     content: |
       " Basic vim configuration
       set number
@@ -28,7 +28,7 @@ files:
     profiles:
       - work
     action: create
-    target: "{{ .User.Home }}/"
+    target: "{{ .User.home }}/"
     content: |
       [user]
           name = Work User
@@ -43,15 +43,15 @@ files:
       - work
     action: copy
     source: ./src/ssh/work_config
-    target: "{{ .User.Home }}/.ssh/config"
-    mode: 600
+    target: "{{ .User.home }}/.ssh/config"
+    mode: 0600
 
   # Development profile configuration files
   - name: .gitconfig-dev
     profiles:
       - dev
     action: create
-    target: "{{ .User.Home }}/"
+    target: "{{ .User.home }}/"
     content: |
       [user]
           name = Developer
@@ -68,7 +68,7 @@ files:
       - dev
       - work
     action: create
-    target: "{{ .User.Home }}/"
+    target: "{{ .User.home }}/"
     content: |
       # Zsh configuration
       export ZSH="$HOME/.oh-my-zsh"
@@ -82,14 +82,14 @@ files:
       - gaming
     action: copy
     source: ./src/gamemode.ini
-    target: "{{ .User.Home }}/.config/gamemode/"
+    target: "{{ .User.home }}/.config/gamemode/"
 
   # Personal profile files
   - name: .aliases
     profiles:
       - personal
     action: create
-    target: "{{ .User.Home }}/"
+    target: "{{ .User.home }}/"
     content: |
       # Personal aliases
       alias music='vlc ~/Music'
@@ -100,67 +100,67 @@ directories:
   # Base directories - always created
   - name: .config
     action: create
-    target: "{{ .User.Home }}/"
-    mode: 755
+    target: "{{ .User.home }}/"
+    mode: 0755
 
   - name: .local/bin
     action: create
-    target: "{{ .User.Home }}/"
-    mode: 755
+    target: "{{ .User.home }}/"
+    mode: 0755
 
   # Work profile directories
   - name: work
     profiles:
       - work
     action: create
-    target: "{{ .User.Home }}/"
-    mode: 755
+    target: "{{ .User.home }}/"
+    mode: 0755
 
   - name: .ssh
     profiles:
       - work
       - dev
     action: create
-    target: "{{ .User.Home }}/"
-    mode: 700
+    target: "{{ .User.home }}/"
+    mode: 0700
 
   # Development profile directories
   - name: projects
     profiles:
       - dev
     action: create
-    target: "{{ .User.Home }}/"
-    mode: 755
+    target: "{{ .User.home }}/"
+    mode: 0755
 
   - name: .config/nvim
     profiles:
       - dev
     action: create
-    target: "{{ .User.Home }}/"
-    mode: 755
+    target: "{{ .User.home }}/"
+    mode: 0755
 
   # Gaming profile directories
   - name: .config/gamemode
     profiles:
       - gaming
     action: create
-    target: "{{ .User.Home }}/"
-    mode: 755
+    target: "{{ .User.home }}/"
+    mode: 0755
 
   - name: Games
     profiles:
       - gaming
       - personal
     action: create
-    target: "{{ .User.Home }}/"
-    mode: 755
+    target: "{{ .User.home }}/"
+    mode: 0755
 
 templates:
   # Base template files
   - name: .profile
     action: copy
     source: ./src/.profile
-    target: "{{ .User.Home }}/"
+    target: "{{ .User.home }}/"
 
   # Work profile templates
   - name: work-environment
@@ -168,10 +168,10 @@ templates:
       - work
     action: copy
     source: ./src/work-environment.j2
-    target: "{{ .User.Home }}/.work-env"
+    target: "{{ .User.home }}/.work-env"
     variables:
-      company: '{{ .Flags.Company | default "MyCompany" }}'
-      department: '{{ .Flags.Department | default "Engineering" }}'
+      company: "{{ .UserDefined.company }}"
+      department: "{{ .UserDefined.department }}"
 
   # Development profile templates
   - name: nvim-config
@@ -179,10 +179,10 @@ templates:
       - dev
     action: copy
     source: ./src/nvim/init.lua.j2
-    target: "{{ .User.Home }}/.config/nvim/init.lua"
+    target: "{{ .User.home }}/.config/nvim/init.lua"
     variables:
-      theme: '{{ .Flags.Theme | default "dracula" }}'
-      plugins: '{{ .Flags.Plugins | default "basic" }}'
+      theme: "{{ .UserDefined.editor_theme }}"
+      plugins: "{{ .UserDefined.editor_plugins }}"
 
   # Personal profile templates
   - name: personal-scripts
@@ -190,5 +190,5 @@ templates:
       - personal
     action: copy
     source: ./src/personal-scripts.j2
-    target: "{{ .User.Home }}/.local/bin/personal-tools"
-    mode: 755
+    target: "{{ .User.home }}/.local/bin/personal-tools"
+    mode: 0755

--- a/examples/linux/Arch/yaml/git/git.yaml
+++ b/examples/linux/Arch/yaml/git/git.yaml
@@ -3,13 +3,13 @@ git:
   - name: dotfiles
     action: clone
     url: https://github.com/user/dotfiles.git
-    path: "{{ .User.Home }}/.dotfiles"
+    path: "{{ .User.home }}/.dotfiles"
     private: false
 
   - name: configs
     action: clone
     url: https://github.com/user/configs.git
-    path: "{{ .User.Home }}/configs"
+    path: "{{ .User.home }}/configs"
     private: false
 
   # Work profile repositories
@@ -18,7 +18,7 @@ git:
       - work
     action: clone
     url: https://github.com/company/work-configs.git
-    path: "{{ .User.Home }}/work/configs"
+    path: "{{ .User.home }}/work/configs"
     private: true
 
   - name: company-tools
@@ -26,7 +26,7 @@ git:
       - work
     action: clone
     url: https://github.com/company/internal-tools.git
-    path: "{{ .User.Home }}/work/tools"
+    path: "{{ .User.home }}/work/tools"
     private: true
 
   # Development profile repositories
@@ -35,7 +35,7 @@ git:
       - dev
     action: clone
     url: https://github.com/user/awesome-project.git
-    path: "{{ .User.Home }}/projects/awesome-project"
+    path: "{{ .User.home }}/projects/awesome-project"
     private: false
 
   - name: learning-rust
@@ -43,7 +43,7 @@ git:
       - dev
     action: clone
     url: https://github.com/rust-lang/book.git
-    path: "{{ .User.Home }}/projects/rust-book"
+    path: "{{ .User.home }}/projects/rust-book"
     private: false
 
   - name: rwr
@@ -52,7 +52,7 @@ git:
       - work
     action: clone
     url: https://github.com/FynxLabs/rwr.git
-    path: "{{ .User.Home }}/projects/rwr"
+    path: "{{ .User.home }}/projects/rwr"
     private: false
 
   # Gaming profile repositories
@@ -61,7 +61,7 @@ git:
       - gaming
     action: clone
     url: https://github.com/user/gaming-configs.git
-    path: "{{ .User.Home }}/.config/gaming"
+    path: "{{ .User.home }}/.config/gaming"
     private: false
 
   - name: game-mods
@@ -69,7 +69,7 @@ git:
       - gaming
     action: clone
     url: https://github.com/user/game-modifications.git
-    path: "{{ .User.Home }}/Games/mods"
+    path: "{{ .User.home }}/Games/mods"
     private: false
 
   # Personal profile repositories
@@ -78,7 +78,7 @@ git:
       - personal
     action: clone
     url: https://github.com/user/personal-scripts.git
-    path: "{{ .User.Home }}/scripts"
+    path: "{{ .User.home }}/scripts"
     private: true
 
   - name: photo-organizer
@@ -86,7 +86,7 @@ git:
       - personal
     action: clone
     url: https://github.com/user/photo-organizer.git
-    path: "{{ .User.Home }}/tools/photo-organizer"
+    path: "{{ .User.home }}/tools/photo-organizer"
     private: false
 
   # Security profile repositories
@@ -96,7 +96,7 @@ git:
       - work
     action: clone
     url: https://github.com/security/tools.git
-    path: "{{ .User.Home }}/security/tools"
+    path: "{{ .User.home }}/security/tools"
     private: true
 
   # Database profile repositories
@@ -107,5 +107,5 @@ git:
       - dev
     action: clone
     url: https://github.com/company/database-migrations.git
-    path: "{{ .User.Home }}/database/migrations"
+    path: "{{ .User.home }}/database/migrations"
     private: true

--- a/examples/linux/Arch/yaml/init.yaml
+++ b/examples/linux/Arch/yaml/init.yaml
@@ -16,3 +16,13 @@ packageManagers:
     action: install
   - name: brew
     action: install
+
+# Values referenced by the profile-gated templates in files/files.yaml.
+# RWR registers no template functions, so there is no `default` filter — a value a
+# template needs has to exist here (or come from an RWR_* environment variable).
+variables:
+  userDefined:
+    company: "MyCompany"
+    department: "Engineering"
+    editor_theme: "dracula"
+    editor_plugins: "basic"

--- a/examples/linux/Arch/yaml/repositories/repositories.yaml
+++ b/examples/linux/Arch/yaml/repositories/repositories.yaml
@@ -79,7 +79,7 @@ repositories:
       - custom
     package_manager: pacman
     action: add
-    url: "file:///home/{{ .User.Username }}/local-repo"
+    url: "file:///home/{{ .User.username }}/local-repo"
 
   # Alternative architecture repository
   - name: archlinux32

--- a/examples/linux/Arch/yaml/scripts/scripts.yaml
+++ b/examples/linux/Arch/yaml/scripts/scripts.yaml
@@ -9,7 +9,7 @@ scripts:
       echo "User: $USER"
       echo "Distribution: $(lsb_release -d | cut -f2)"
       echo "Kernel: $(uname -r)"
-    log: "{{ .User.Home }}/.config/rwr/logs/system_info.log"
+    log: "{{ .User.home }}/.config/rwr/logs/system_info.log"
 
   - name: update_system
     action: run
@@ -19,7 +19,7 @@ scripts:
       echo "Updating package database..."
       pacman -Sy --noconfirm
       echo "System updated successfully"
-    log: "{{ .User.Home }}/.config/rwr/logs/system_update.log"
+    log: "{{ .User.home }}/.config/rwr/logs/system_update.log"
 
   # Development environment setup
   - name: setup_dev_environment
@@ -30,18 +30,18 @@ scripts:
     content: |
       #!/bin/bash
       # Create development directories
-      mkdir -p "{{ .User.Home }}/Projects"
-      mkdir -p "{{ .User.Home }}/Projects/personal"
-      mkdir -p "{{ .User.Home }}/Projects/work"
-      mkdir -p "{{ .User.Home }}/.local/bin"
+      mkdir -p "{{ .User.home }}/Projects"
+      mkdir -p "{{ .User.home }}/Projects/personal"
+      mkdir -p "{{ .User.home }}/Projects/work"
+      mkdir -p "{{ .User.home }}/.local/bin"
 
       # Set up development aliases
-      echo 'alias ll="ls -alF"' >> "{{ .User.Home }}/.bashrc"
-      echo 'alias la="ls -A"' >> "{{ .User.Home }}/.bashrc"
-      echo 'alias l="ls -CF"' >> "{{ .User.Home }}/.bashrc"
+      echo 'alias ll="ls -alF"' >> "{{ .User.home }}/.bashrc"
+      echo 'alias la="ls -A"' >> "{{ .User.home }}/.bashrc"
+      echo 'alias l="ls -CF"' >> "{{ .User.home }}/.bashrc"
 
       echo "Development environment setup complete"
-    log: "{{ .User.Home }}/.config/rwr/logs/dev_setup.log"
+    log: "{{ .User.home }}/.config/rwr/logs/dev_setup.log"
 
   # Install development tools from source
   - name: install_nvm
@@ -57,7 +57,7 @@ scripts:
       nvm install --lts
       nvm use --lts
       echo "NVM and latest LTS Node.js installed"
-    log: "{{ .User.Home }}/.config/rwr/logs/nvm_install.log"
+    log: "{{ .User.home }}/.config/rwr/logs/nvm_install.log"
 
   # Gaming optimizations
   - name: gaming_optimizations
@@ -75,10 +75,10 @@ scripts:
 
       # Set up gaming group
       groupadd -f gaming
-      usermod -a -G gaming "{{ .User.Username }}"
+      usermod -a -G gaming "{{ .User.username }}"
 
       echo "Gaming optimizations applied"
-    log: "{{ .User.Home }}/.config/rwr/logs/gaming_setup.log"
+    log: "{{ .User.home }}/.config/rwr/logs/gaming_setup.log"
 
   # Security hardening
   - name: security_setup
@@ -101,7 +101,7 @@ scripts:
       systemctl start fail2ban
 
       echo "Basic security setup complete"
-    log: "{{ .User.Home }}/.config/rwr/logs/security_setup.log"
+    log: "{{ .User.home }}/.config/rwr/logs/security_setup.log"
 
   # Database setup
   - name: setup_postgresql_user
@@ -113,20 +113,20 @@ scripts:
     content: |
       #!/bin/bash
       # Create PostgreSQL user
-      sudo -u postgres createuser -s "{{ .User.Username }}"
-      sudo -u postgres createdb "{{ .User.Username }}"
+      sudo -u postgres createuser -s "{{ .User.username }}"
+      sudo -u postgres createdb "{{ .User.username }}"
 
       echo "PostgreSQL user setup complete"
-    log: "{{ .User.Home }}/.config/rwr/logs/postgresql_setup.log"
+    log: "{{ .User.home }}/.config/rwr/logs/postgresql_setup.log"
 
   # External script execution
   - name: run_custom_setup
     profiles:
       - personal
     action: run
-    source: "{{ .User.Home }}/Scripts/personal_setup.sh"
-    args: "--user {{ .User.Username }} --home {{ .User.Home }}"
-    log: "{{ .User.Home }}/.config/rwr/logs/custom_setup.log"
+    source: "{{ .User.home }}/Scripts/personal_setup.sh"
+    args: "--user {{ .User.username }} --home {{ .User.home }}"
+    log: "{{ .User.home }}/.config/rwr/logs/custom_setup.log"
 
   # Docker setup for development
   - name: docker_user_setup
@@ -138,14 +138,14 @@ scripts:
     content: |
       #!/bin/bash
       # Add user to docker group
-      usermod -a -G docker "{{ .User.Username }}"
+      usermod -a -G docker "{{ .User.username }}"
 
       # Enable and start Docker service
       systemctl enable docker
       systemctl start docker
 
       echo "Docker user setup complete. Please log out and back in for group changes to take effect."
-    log: "{{ .User.Home }}/.config/rwr/logs/docker_setup.log"
+    log: "{{ .User.home }}/.config/rwr/logs/docker_setup.log"
 
   # Cleanup script
   - name: system_cleanup
@@ -165,4 +165,4 @@ scripts:
       journalctl --vacuum-time=30d
 
       echo "System cleanup complete"
-    log: "{{ .User.Home }}/.config/rwr/logs/system_cleanup.log"
+    log: "{{ .User.home }}/.config/rwr/logs/system_cleanup.log"

--- a/examples/linux/Arch/yaml/ssh_keys/ssh_keys.yaml
+++ b/examples/linux/Arch/yaml/ssh_keys/ssh_keys.yaml
@@ -2,8 +2,8 @@ ssh_keys:
   # Default personal SSH key - always created
   - name: id_ed25519
     type: ed25519
-    path: "{{ .User.Home }}/.ssh/"
-    comment: "{{ .User.Username }}@personal"
+    path: "{{ .User.home }}/.ssh/"
+    comment: "{{ .User.username }}@personal"
     no_passphrase: false
     copy_to_github: false
 
@@ -12,8 +12,8 @@ ssh_keys:
     profiles:
       - work
     type: ed25519
-    path: "{{ .User.Home }}/.ssh/"
-    comment: "{{ .User.Username }}@company.com"
+    path: "{{ .User.home }}/.ssh/"
+    comment: "{{ .User.username }}@company.com"
     no_passphrase: false
     copy_to_github: false
 
@@ -23,11 +23,11 @@ ssh_keys:
       - dev
       - github
     type: ed25519
-    path: "{{ .User.Home }}/.ssh/"
-    comment: "{{ .User.Username }}@github"
+    path: "{{ .User.home }}/.ssh/"
+    comment: "{{ .User.username }}@github"
     no_passphrase: true
     copy_to_github: true
-    github_title: "{{ .User.Username }} Development Machine"
+    github_title: "{{ .User.username }} Development Machine"
 
   # Legacy RSA key for older systems
   - name: id_rsa_legacy
@@ -35,8 +35,8 @@ ssh_keys:
       - legacy
       - work
     type: rsa
-    path: "{{ .User.Home }}/.ssh/"
-    comment: "{{ .User.Username }}@legacy-systems"
+    path: "{{ .User.home }}/.ssh/"
+    comment: "{{ .User.username }}@legacy-systems"
     no_passphrase: false
     copy_to_github: false
 
@@ -46,8 +46,8 @@ ssh_keys:
       - deploy
       - work
     type: ed25519
-    path: "{{ .User.Home }}/.ssh/"
-    comment: "{{ .User.Username }}@deployment"
+    path: "{{ .User.home }}/.ssh/"
+    comment: "{{ .User.username }}@deployment"
     no_passphrase: true
     copy_to_github: false
 
@@ -56,8 +56,8 @@ ssh_keys:
     profiles:
       - gaming
     type: ed25519
-    path: "{{ .User.Home }}/.ssh/"
-    comment: "{{ .User.Username }}@gaming-rig"
+    path: "{{ .User.home }}/.ssh/"
+    comment: "{{ .User.username }}@gaming-rig"
     no_passphrase: true
     copy_to_github: false
 
@@ -67,8 +67,8 @@ ssh_keys:
       - backup
       - personal
     type: ed25519
-    path: "{{ .User.Home }}/.ssh/"
-    comment: "{{ .User.Username }}@backup-server"
+    path: "{{ .User.home }}/.ssh/"
+    comment: "{{ .User.username }}@backup-server"
     no_passphrase: false
     copy_to_github: false
 
@@ -78,8 +78,8 @@ ssh_keys:
       - dev
       - work
     type: ed25519
-    path: "{{ .User.Home }}/.ssh/"
-    comment: "{{ .User.Username }}@rwr-management"
+    path: "{{ .User.home }}/.ssh/"
+    comment: "{{ .User.username }}@rwr-management"
     no_passphrase: true
     copy_to_github: false
     set_as_rwr_ssh_key: true
@@ -92,8 +92,8 @@ ssh_keys:
       - azure
       - cloud
     type: ed25519
-    path: "{{ .User.Home }}/.ssh/"
-    comment: "{{ .User.Username }}@cloud-services"
+    path: "{{ .User.home }}/.ssh/"
+    comment: "{{ .User.username }}@cloud-services"
     no_passphrase: false
     copy_to_github: false
 
@@ -103,7 +103,7 @@ ssh_keys:
       - docker
       - dev
     type: ed25519
-    path: "{{ .User.Home }}/.ssh/"
-    comment: "{{ .User.Username }}@docker-host"
+    path: "{{ .User.home }}/.ssh/"
+    comment: "{{ .User.username }}@docker-host"
     no_passphrase: true
     copy_to_github: false

--- a/examples/linux/Arch/yaml/users/users.yaml
+++ b/examples/linux/Arch/yaml/users/users.yaml
@@ -1,13 +1,13 @@
 users:
   # Base user modification - always applied (no profiles field)
-  - name: "{{ .User.Username }}"
+  - name: "{{ .User.username }}"
     action: modify
     add_groups:
       - wheel
       - users
 
   # Development profile user modifications
-  - name: "{{ .User.Username }}"
+  - name: "{{ .User.username }}"
     profiles:
       - dev
     action: modify
@@ -17,7 +17,7 @@ users:
       - git
 
   # Work profile user modifications
-  - name: "{{ .User.Username }}"
+  - name: "{{ .User.username }}"
     profiles:
       - work
     action: modify
@@ -27,7 +27,7 @@ users:
       - developers
 
   # Gaming profile user modifications
-  - name: "{{ .User.Username }}"
+  - name: "{{ .User.username }}"
     profiles:
       - gaming
     action: modify

--- a/examples/linux/Fedora/json/files/files.json
+++ b/examples/linux/Fedora/json/files/files.json
@@ -3,20 +3,20 @@
     {
       "name": ".bashrc",
       "action": "create",
-      "target": "{{ .User.Home }}/",
+      "target": "{{ .User.home }}/",
       "content": "# Custom .bashrc content\nalias ll='ls -alF'\nexport PATH=$PATH:$HOME/.local/bin"
     },
     {
       "name": ".gitignore",
       "action": "copy",
-      "target": "{{ .User.Home }}/",
+      "target": "{{ .User.home }}/",
       "source": "./src/"
     },
     {
       "name": ".vimrc",
       "profiles": ["dev"],
       "action": "create",
-      "target": "{{ .User.Home }}/",
+      "target": "{{ .User.home }}/",
       "content": "set number\nset tabstop=4\nset shiftwidth=4\nset expandtab"
     }
   ],
@@ -24,15 +24,15 @@
     {
       "name": "Projects",
       "action": "create",
-      "target": "{{ .User.Home }}/",
-      "mode": "0755"
+      "target": "{{ .User.home }}/",
+      "mode": 493
     },
     {
       "name": ".config/code",
       "profiles": ["dev"],
       "action": "create",
-      "target": "{{ .User.Home }}/",
-      "mode": "0755"
+      "target": "{{ .User.home }}/",
+      "mode": 493
     }
   ],
   "templates": [
@@ -40,7 +40,7 @@
       "name": ".profile",
       "action": "copy",
       "source": "./src/",
-      "target": "{{ .User.Home }}/"
+      "target": "{{ .User.home }}/"
     }
   ]
 }

--- a/examples/linux/Fedora/json/scripts/scripts.json
+++ b/examples/linux/Fedora/json/scripts/scripts.json
@@ -10,14 +10,14 @@
       "name": "setup_dev_environment",
       "profiles": ["dev"],
       "action": "run",
-      "content": "#!/bin/bash\nmkdir -p \"{{ .User.Home }}/Projects\"\necho 'alias ll=\"ls -alF\"' >> \"{{ .User.Home }}/.bashrc\"\necho \"Development environment setup complete\""
+      "content": "#!/bin/bash\nmkdir -p \"{{ .User.home }}/Projects\"\necho 'alias ll=\"ls -alF\"' >> \"{{ .User.home }}/.bashrc\"\necho \"Development environment setup complete\""
     },
     {
       "name": "docker_user_setup",
       "profiles": ["docker"],
       "action": "run",
       "elevated": true,
-      "content": "#!/bin/bash\nusermod -a -G docker \"{{ .User.Username }}\"\nsystemctl enable docker\nsystemctl start docker\necho \"Docker setup complete\""
+      "content": "#!/bin/bash\nusermod -a -G docker \"{{ .User.username }}\"\nsystemctl enable docker\nsystemctl start docker\necho \"Docker setup complete\""
     }
   ]
 }

--- a/examples/linux/Fedora/json/ssh_keys/ssh_keys.json
+++ b/examples/linux/Fedora/json/ssh_keys/ssh_keys.json
@@ -1,7 +1,12 @@
-ssh_keys:
-  - name: id_rsa
-    type: ed25519
-    path: {{ .User.home }}/.ssh/
-    comment: "{{ .User.username }}@github"
-    no_passphrase: true
-    copy_to_github: false
+{
+  "ssh_keys": [
+    {
+      "name": "id_rsa",
+      "type": "ed25519",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@github",
+      "no_passphrase": true,
+      "copy_to_github": false
+    }
+  ]
+}

--- a/examples/linux/Fedora/toml/scripts/scripts.toml
+++ b/examples/linux/Fedora/toml/scripts/scripts.toml
@@ -16,8 +16,8 @@ profiles = ["dev"]
 action = "run"
 content = """
 #!/bin/bash
-mkdir -p "{{ .User.Home }}/Projects"
-echo 'alias ll="ls -alF"' >> "{{ .User.Home }}/.bashrc"
+mkdir -p "{{ .User.home }}/Projects"
+echo 'alias ll="ls -alF"' >> "{{ .User.home }}/.bashrc"
 echo "Development environment setup complete"
 """
 
@@ -29,7 +29,7 @@ action = "run"
 elevated = true
 content = """
 #!/bin/bash
-usermod -a -G docker "{{ .User.Username }}"
+usermod -a -G docker "{{ .User.username }}"
 systemctl enable docker
 systemctl start docker
 echo "Docker setup complete"

--- a/examples/linux/Fedora/yaml/bootstrap.yaml
+++ b/examples/linux/Fedora/yaml/bootstrap.yaml
@@ -5,15 +5,15 @@ packages:
     action: install
 
 directories:
-  - name: {{ .User.home }}/git
+  - name: "{{ .User.home }}/git"
     action: create
-    owner: {{ .User.username }}
-    group: {{ .User.username }}
+    owner: "{{ .User.username }}"
+    group: "{{ .User.username }}"
 
 ssh_keys:
   - name: github
     type: ed25519
-    path: {{ .User.home }}/.ssh/
+    path: "{{ .User.home }}/.ssh/"
     comment: "{{ .User.username }}@example.com"
     no_passphrase: true
     copy_to_github: false

--- a/examples/linux/Fedora/yaml/files/files.yaml
+++ b/examples/linux/Fedora/yaml/files/files.yaml
@@ -2,7 +2,7 @@ files:
   # Base configuration files
   - name: .bashrc
     action: create
-    target: "{{ .User.Home }}/"
+    target: "{{ .User.home }}/"
     content: |
       # Custom .bashrc content
       alias ll='ls -alF'
@@ -10,7 +10,7 @@ files:
 
   - name: .gitignore
     action: copy
-    target: "{{ .User.Home }}/"
+    target: "{{ .User.home }}/"
     source: "./src/"
 
   # Development configuration
@@ -18,7 +18,7 @@ files:
     profiles:
       - dev
     action: create
-    target: "{{ .User.Home }}/"
+    target: "{{ .User.home }}/"
     content: |
       set number
       set tabstop=4
@@ -29,20 +29,20 @@ directories:
   # Base directories
   - name: Projects
     action: create
-    target: "{{ .User.Home }}/"
-    mode: "0755"
+    target: "{{ .User.home }}/"
+    mode: 0755
 
   # Development directories
   - name: .config/code
     profiles:
       - dev
     action: create
-    target: "{{ .User.Home }}/"
-    mode: "0755"
+    target: "{{ .User.home }}/"
+    mode: 0755
 
 templates:
   # Profile template
   - name: .profile
     action: copy
     source: "./src/"
-    target: "{{ .User.Home }}/"
+    target: "{{ .User.home }}/"

--- a/examples/linux/Fedora/yaml/git/git.yaml
+++ b/examples/linux/Fedora/yaml/git/git.yaml
@@ -2,5 +2,5 @@ git:
   - name: rwr
     action: clone
     url: https://github.com/FynxLabs/rwr.git
-    path: {{ .User.home }}/git/rwr
+    path: "{{ .User.home }}/git/rwr"
     private: false

--- a/examples/linux/Fedora/yaml/scripts/scripts.yaml
+++ b/examples/linux/Fedora/yaml/scripts/scripts.yaml
@@ -15,8 +15,8 @@ scripts:
     action: run
     content: |
       #!/bin/bash
-      mkdir -p "{{ .User.Home }}/Projects"
-      echo 'alias ll="ls -alF"' >> "{{ .User.Home }}/.bashrc"
+      mkdir -p "{{ .User.home }}/Projects"
+      echo 'alias ll="ls -alF"' >> "{{ .User.home }}/.bashrc"
       echo "Development environment setup complete"
 
   # Docker setup
@@ -27,7 +27,7 @@ scripts:
     elevated: true
     content: |
       #!/bin/bash
-      usermod -a -G docker "{{ .User.Username }}"
+      usermod -a -G docker "{{ .User.username }}"
       systemctl enable docker
       systemctl start docker
       echo "Docker setup complete"

--- a/examples/linux/Fedora/yaml/ssh_keys/ssh_keys.yaml
+++ b/examples/linux/Fedora/yaml/ssh_keys/ssh_keys.yaml
@@ -1,7 +1,7 @@
 ssh_keys:
   - name: id_rsa
     type: ed25519
-    path: {{ .User.home }}/.ssh/
+    path: "{{ .User.home }}/.ssh/"
     comment: "{{ .User.username }}@github"
     no_passphrase: true
     copy_to_github: false

--- a/examples/linux/Fedora/yaml/users/users.yaml
+++ b/examples/linux/Fedora/yaml/users/users.yaml
@@ -1,5 +1,5 @@
 users:
-  - name: {{ .User.username }}
+  - name: "{{ .User.username }}"
     action: modify
     add_groups:
       - docker

--- a/examples/linux/Ubuntu/json/files/files.json
+++ b/examples/linux/Ubuntu/json/files/files.json
@@ -4,29 +4,29 @@
       "src": "/etc/apt/apt.conf.d/99custom",
       "dest": "/etc/apt/apt.conf.d/99custom",
       "content": "APT::Get::Assume-Yes \"true\";\nAPT::Install-Suggests \"false\";\n",
-      "mode": "644",
+      "mode": 420,
       "owner": "root",
       "group": "root"
     },
     {
       "src": "~/.bashrc",
-      "dest": "{{.User.Home}}/.bashrc",
+      "dest": "{{.User.home}}/.bashrc",
       "content": "export EDITOR=vim\nexport PATH=$PATH:~/.local/bin\nalias ll='ls -la'\nalias grep='grep --color=auto'\n",
-      "mode": "644"
+      "mode": 420
     },
     {
       "src": "~/.gitconfig",
-      "dest": "{{.User.Home}}/.gitconfig",
+      "dest": "{{.User.home}}/.gitconfig",
       "content": "[user]\n    name = Developer\n    email = dev@example.com\n[core]\n    editor = vim\n",
       "profiles": ["dev"],
-      "mode": "644"
+      "mode": 420
     },
     {
       "src": "/etc/nginx/sites-available/default",
       "dest": "/etc/nginx/sites-available/default",
       "content": "server {\n    listen 80 default_server;\n    root /var/www/html;\n    index index.html;\n}\n",
       "profiles": ["server"],
-      "mode": "644",
+      "mode": 420,
       "owner": "root",
       "group": "root"
     }

--- a/examples/linux/Ubuntu/json/scripts/scripts.json
+++ b/examples/linux/Ubuntu/json/scripts/scripts.json
@@ -2,31 +2,26 @@
   "scripts": [
     {
       "name": "update-system",
-      "content": "#!/bin/bash\napt update && apt upgrade -y\napt autoremove -y\n",
-      "mode": "755"
+      "content": "#!/bin/bash\napt update && apt upgrade -y\napt autoremove -y\n"
     },
     {
       "name": "setup-firewall",
-      "content": "#!/bin/bash\nufw --force reset\nufw default deny incoming\nufw default allow outgoing\nufw allow ssh\nufw --force enable\n",
-      "mode": "755"
+      "content": "#!/bin/bash\nufw --force reset\nufw default deny incoming\nufw default allow outgoing\nufw allow ssh\nufw --force enable\n"
     },
     {
       "name": "setup-dev-env",
-      "content": "#!/bin/bash\ncurl -fsSL https://get.docker.com -o get-docker.sh\nsh get-docker.sh\nusermod -aG docker {{.User.Username}}\nsystemctl enable docker\n",
-      "profiles": ["dev"],
-      "mode": "755"
+      "content": "#!/bin/bash\ncurl -fsSL https://get.docker.com -o get-docker.sh\nsh get-docker.sh\nusermod -aG docker {{.User.username}}\nsystemctl enable docker\n",
+      "profiles": ["dev"]
     },
     {
       "name": "configure-server",
       "content": "#!/bin/bash\nsystemctl enable apache2\nsystemctl enable mysql\na2enmod rewrite\nsystemctl restart apache2\n",
-      "profiles": ["server"],
-      "mode": "755"
+      "profiles": ["server"]
     },
     {
       "name": "setup-desktop",
       "content": "#!/bin/bash\ngsettings set org.gnome.desktop.interface gtk-theme 'Adwaita-dark'\ngsettings set org.gnome.shell.extensions.dash-to-dock dock-position BOTTOM\n",
-      "profiles": ["desktop"],
-      "mode": "755"
+      "profiles": ["desktop"]
     }
   ]
 }

--- a/examples/linux/Ubuntu/json/ssh_keys/ssh_keys.json
+++ b/examples/linux/Ubuntu/json/ssh_keys/ssh_keys.json
@@ -1,7 +1,12 @@
-ssh_keys:
-  - name: id_rsa
-    type: ed25519
-    path: {{ .User.home }}/.ssh/
-    comment: "{{ .User.username }}@github"
-    no_passphrase: true
-    copy_to_github: false
+{
+  "ssh_keys": [
+    {
+      "name": "id_rsa",
+      "type": "ed25519",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@github",
+      "no_passphrase": true,
+      "copy_to_github": false
+    }
+  ]
+}

--- a/examples/linux/Ubuntu/toml/files/files.toml
+++ b/examples/linux/Ubuntu/toml/files/files.toml
@@ -5,24 +5,24 @@ dest = "/etc/apt/apt.conf.d/99custom"
 content = """APT::Get::Assume-Yes "true";
 APT::Install-Suggests "false";
 """
-mode = "644"
+mode = 0o644
 owner = "root"
 group = "root"
 
 [[files]]
 src = "~/.bashrc"
-dest = "{{.User.Home}}/.bashrc"
+dest = "{{.User.home}}/.bashrc"
 content = """export EDITOR=vim
 export PATH=$PATH:~/.local/bin
 alias ll='ls -la'
 alias grep='grep --color=auto'
 """
-mode = "644"
+mode = 0o644
 
 # Development configuration for dev profile
 [[files]]
 src = "~/.gitconfig"
-dest = "{{.User.Home}}/.gitconfig"
+dest = "{{.User.home}}/.gitconfig"
 content = """[user]
     name = Developer
     email = dev@example.com
@@ -30,7 +30,7 @@ content = """[user]
     editor = vim
 """
 profiles = ["dev"]
-mode = "644"
+mode = 0o644
 
 # Server configuration for server profile
 [[files]]
@@ -43,6 +43,6 @@ content = """server {
 }
 """
 profiles = ["server"]
-mode = "644"
+mode = 0o644
 owner = "root"
 group = "root"

--- a/examples/linux/Ubuntu/toml/scripts/scripts.toml
+++ b/examples/linux/Ubuntu/toml/scripts/scripts.toml
@@ -5,7 +5,6 @@ content = """#!/bin/bash
 apt update && apt upgrade -y
 apt autoremove -y
 """
-mode = "755"
 
 [[scripts]]
 name = "setup-firewall"
@@ -16,7 +15,6 @@ ufw default allow outgoing
 ufw allow ssh
 ufw --force enable
 """
-mode = "755"
 
 # Development setup for dev profile
 [[scripts]]
@@ -24,11 +22,10 @@ name = "setup-dev-env"
 content = """#!/bin/bash
 curl -fsSL https://get.docker.com -o get-docker.sh
 sh get-docker.sh
-usermod -aG docker {{.User.Username}}
+usermod -aG docker {{.User.username}}
 systemctl enable docker
 """
 profiles = ["dev"]
-mode = "755"
 
 # Server setup for server profile
 [[scripts]]
@@ -40,7 +37,6 @@ a2enmod rewrite
 systemctl restart apache2
 """
 profiles = ["server"]
-mode = "755"
 
 # Desktop customization for desktop profile
 [[scripts]]
@@ -50,4 +46,3 @@ gsettings set org.gnome.desktop.interface gtk-theme 'Adwaita-dark'
 gsettings set org.gnome.shell.extensions.dash-to-dock dock-position BOTTOM
 """
 profiles = ["desktop"]
-mode = "755"

--- a/examples/linux/Ubuntu/yaml/bootstrap.yaml
+++ b/examples/linux/Ubuntu/yaml/bootstrap.yaml
@@ -5,15 +5,15 @@ packages:
     action: install
 
 directories:
-  - name: {{ .User.home }}/git
+  - name: "{{ .User.home }}/git"
     action: create
-    owner: {{ .User.username }}
-    group: {{ .User.username }}
+    owner: "{{ .User.username }}"
+    group: "{{ .User.username }}"
 
 ssh_keys:
   - name: github
     type: ed25519
-    path: {{ .User.home }}/.ssh/
+    path: "{{ .User.home }}/.ssh/"
     comment: "{{ .User.username }}@example.com"
     no_passphrase: true
     copy_to_github: false

--- a/examples/linux/Ubuntu/yaml/files/files.yaml
+++ b/examples/linux/Ubuntu/yaml/files/files.yaml
@@ -5,22 +5,22 @@ files:
     content: |
       APT::Get::Assume-Yes "true";
       APT::Install-Suggests "false";
-    mode: "644"
+    mode: 0644
     owner: root
     group: root
 
   - src: ~/.bashrc
-    dest: "{{.User.Home}}/.bashrc"
+    dest: "{{.User.home}}/.bashrc"
     content: |
       export EDITOR=vim
       export PATH=$PATH:~/.local/bin
       alias ll='ls -la'
       alias grep='grep --color=auto'
-    mode: "644"
+    mode: 0644
 
   # Development configuration for dev profile
   - src: ~/.gitconfig
-    dest: "{{.User.Home}}/.gitconfig"
+    dest: "{{.User.home}}/.gitconfig"
     content: |
       [user]
           name = Developer
@@ -28,7 +28,7 @@ files:
       [core]
           editor = vim
     profiles: [dev]
-    mode: "644"
+    mode: 0644
 
   # Server configuration for server profile
   - src: /etc/nginx/sites-available/default
@@ -40,6 +40,6 @@ files:
           index index.html;
       }
     profiles: [server]
-    mode: "644"
+    mode: 0644
     owner: root
     group: root

--- a/examples/linux/Ubuntu/yaml/git/git.yaml
+++ b/examples/linux/Ubuntu/yaml/git/git.yaml
@@ -2,5 +2,5 @@ git:
   - name: rwr
     action: clone
     url: https://github.com/FynxLabs/rwr.git
-    path: {{ .User.home }}/git/rwr
+    path: "{{ .User.home }}/git/rwr"
     private: false

--- a/examples/linux/Ubuntu/yaml/scripts/scripts.yaml
+++ b/examples/linux/Ubuntu/yaml/scripts/scripts.yaml
@@ -5,7 +5,6 @@ scripts:
       #!/bin/bash
       apt update && apt upgrade -y
       apt autoremove -y
-    mode: "755"
 
   - name: setup-firewall
     content: |
@@ -15,7 +14,6 @@ scripts:
       ufw default allow outgoing
       ufw allow ssh
       ufw --force enable
-    mode: "755"
 
   # Development setup for dev profile
   - name: setup-dev-env
@@ -23,10 +21,9 @@ scripts:
       #!/bin/bash
       curl -fsSL https://get.docker.com -o get-docker.sh
       sh get-docker.sh
-      usermod -aG docker {{.User.Username}}
+      usermod -aG docker {{.User.username}}
       systemctl enable docker
     profiles: [dev]
-    mode: "755"
 
   # Server setup for server profile
   - name: configure-server
@@ -37,7 +34,6 @@ scripts:
       a2enmod rewrite
       systemctl restart apache2
     profiles: [server]
-    mode: "755"
 
   # Desktop customization for desktop profile
   - name: setup-desktop
@@ -46,4 +42,3 @@ scripts:
       gsettings set org.gnome.desktop.interface gtk-theme 'Adwaita-dark'
       gsettings set org.gnome.shell.extensions.dash-to-dock dock-position BOTTOM
     profiles: [desktop]
-    mode: "755"

--- a/examples/linux/Ubuntu/yaml/ssh_keys/ssh_keys.yaml
+++ b/examples/linux/Ubuntu/yaml/ssh_keys/ssh_keys.yaml
@@ -1,7 +1,7 @@
 ssh_keys:
   - name: id_rsa
     type: ed25519
-    path: {{ .User.home }}/.ssh/
+    path: "{{ .User.home }}/.ssh/"
     comment: "{{ .User.username }}@github"
     no_passphrase: true
     copy_to_github: false

--- a/examples/macos/json/scripts/scripts.json
+++ b/examples/macos/json/scripts/scripts.json
@@ -2,31 +2,26 @@
   "scripts": [
     {
       "name": "update-system",
-      "content": "#!/bin/bash\nbrew update && brew upgrade\nbrew cleanup\n",
-      "mode": "755"
+      "content": "#!/bin/bash\nbrew update && brew upgrade\nbrew cleanup\n"
     },
     {
       "name": "setup-developer-tools",
       "content": "#!/bin/bash\nxcode-select --install\nsudo xcodebuild -license accept\n",
-      "profiles": ["dev"],
-      "mode": "755"
+      "profiles": ["dev"]
     },
     {
       "name": "configure-dock",
       "content": "#!/bin/bash\ndefaults write com.apple.dock autohide -bool true\ndefaults write com.apple.dock tilesize -int 48\nkillall Dock\n",
-      "profiles": ["desktop"],
-      "mode": "755"
+      "profiles": ["desktop"]
     },
     {
       "name": "setup-homebrew-permissions",
-      "content": "#!/bin/bash\nsudo chown -R $(whoami) /usr/local/var/homebrew\nsudo chmod u+w /usr/local/var/homebrew\n",
-      "mode": "755"
+      "content": "#!/bin/bash\nsudo chown -R $(whoami) /usr/local/var/homebrew\nsudo chmod u+w /usr/local/var/homebrew\n"
     },
     {
       "name": "configure-git",
       "content": "#!/bin/bash\ngit config --global init.defaultBranch main\ngit config --global pull.rebase false\n",
-      "profiles": ["dev"],
-      "mode": "755"
+      "profiles": ["dev"]
     }
   ]
 }

--- a/examples/macos/json/ssh_keys/ssh_keys.json
+++ b/examples/macos/json/ssh_keys/ssh_keys.json
@@ -1,7 +1,12 @@
-ssh_keys:
-  - name: id_rsa
-    type: ed25519
-    path: {{ .User.home }}/.ssh/
-    comment: "{{ .User.username }}@github"
-    no_passphrase: true
-    copy_to_github: false
+{
+  "ssh_keys": [
+    {
+      "name": "id_rsa",
+      "type": "ed25519",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@github",
+      "no_passphrase": true,
+      "copy_to_github": false
+    }
+  ]
+}

--- a/examples/macos/toml/scripts/scripts.toml
+++ b/examples/macos/toml/scripts/scripts.toml
@@ -5,7 +5,6 @@ content = """#!/bin/bash
 brew update && brew upgrade
 brew cleanup
 """
-mode = "755"
 
 [[scripts]]
 name = "setup-homebrew-permissions"
@@ -13,7 +12,6 @@ content = """#!/bin/bash
 sudo chown -R $(whoami) /usr/local/var/homebrew
 sudo chmod u+w /usr/local/var/homebrew
 """
-mode = "755"
 
 # Development setup for dev profile
 [[scripts]]
@@ -23,7 +21,6 @@ xcode-select --install
 sudo xcodebuild -license accept
 """
 profiles = ["dev"]
-mode = "755"
 
 [[scripts]]
 name = "configure-git"
@@ -32,7 +29,6 @@ git config --global init.defaultBranch main
 git config --global pull.rebase false
 """
 profiles = ["dev"]
-mode = "755"
 
 # Desktop customization for desktop profile
 [[scripts]]
@@ -43,4 +39,3 @@ defaults write com.apple.dock tilesize -int 48
 killall Dock
 """
 profiles = ["desktop"]
-mode = "755"

--- a/examples/macos/yaml/bootstrap.yaml
+++ b/examples/macos/yaml/bootstrap.yaml
@@ -5,15 +5,15 @@ packages:
     action: install
 
 directories:
-  - name: {{ .User.home }}/git
+  - name: "{{ .User.home }}/git"
     action: create
-    owner: {{ .User.username }}
-    group: {{ .User.username }}
+    owner: "{{ .User.username }}"
+    group: "{{ .User.username }}"
 
 ssh_keys:
   - name: github
     type: ed25519
-    path: {{ .User.home }}/.ssh/
+    path: "{{ .User.home }}/.ssh/"
     comment: "{{ .User.username }}@example.com"
     no_passphrase: true
     copy_to_github: false

--- a/examples/macos/yaml/files/files.yaml
+++ b/examples/macos/yaml/files/files.yaml
@@ -1,24 +1,24 @@
 files:
   - name: .bashrc
     action: create
-    target: {{ .User.home }}/
+    target: "{{ .User.home }}/"
     content: |
       # Custom .bashrc content
       alias ll='ls -alF'
       export PATH=$PATH:$HOME/.local/bin
   - name: .gitignore
     action: copy
-    target: {{ .User.home }}/
+    target: "{{ .User.home }}/"
     source: ./src/
 
 directories:
   - name: .config
     action: copy
     source: ./src/
-    target: {{ .User.home }}/
+    target: "{{ .User.home }}/"
 
 templates:
   - name: .profile
     action: copy
     source: ./src/
-    target: {{ .User.home }}/
+    target: "{{ .User.home }}/"

--- a/examples/macos/yaml/git/git.yaml
+++ b/examples/macos/yaml/git/git.yaml
@@ -2,5 +2,5 @@ git:
   - name: rwr
     action: clone
     url: https://github.com/FynxLabs/rwr.git
-    path: {{ .User.home }}/git/rwr
+    path: "{{ .User.home }}/git/rwr"
     private: false

--- a/examples/macos/yaml/scripts/scripts.yaml
+++ b/examples/macos/yaml/scripts/scripts.yaml
@@ -14,8 +14,8 @@ scripts:
     action: run
     content: |
       #!/bin/bash
-      mkdir -p "{{ .User.Home }}/Projects"
-      echo 'alias ll="ls -alF"' >> "{{ .User.Home }}/.zshrc"
+      mkdir -p "{{ .User.home }}/Projects"
+      echo 'alias ll="ls -alF"' >> "{{ .User.home }}/.zshrc"
       echo "Development environment setup complete"
 
   # Docker setup

--- a/examples/macos/yaml/ssh_keys/ssh_keys.yaml
+++ b/examples/macos/yaml/ssh_keys/ssh_keys.yaml
@@ -1,7 +1,7 @@
 ssh_keys:
   - name: id_rsa
     type: ed25519
-    path: {{ .User.home }}/.ssh/
+    path: "{{ .User.home }}/.ssh/"
     comment: "{{ .User.username }}@github"
     no_passphrase: true
     copy_to_github: false

--- a/examples/windows/json/files/files.json
+++ b/examples/windows/json/files/files.json
@@ -4,34 +4,34 @@
       "src": "C:\\Windows\\System32\\drivers\\etc\\hosts",
       "dest": "C:\\Windows\\System32\\drivers\\etc\\hosts",
       "content": "127.0.0.1       localhost\n::1             localhost\n",
-      "mode": "644"
+      "mode": 420
     },
     {
       "src": "C:\\ProgramData\\chocolatey\\config\\chocolatey.config",
       "dest": "C:\\ProgramData\\chocolatey\\config\\chocolatey.config",
       "content": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<chocolatey>\n  <config>\n    <add key=\"cacheLocation\" value=\"C:\\temp\\chocolatey\" />\n  </config>\n</chocolatey>\n",
-      "mode": "644"
+      "mode": 420
     },
     {
-      "src": "C:\\Users\\{{.User.Username}}\\.gitconfig",
-      "dest": "C:\\Users\\{{.User.Username}}\\.gitconfig",
+      "src": "C:\\Users\\{{.User.username}}\\.gitconfig",
+      "dest": "C:\\Users\\{{.User.username}}\\.gitconfig",
       "content": "[user]\n    name = Developer\n    email = dev@example.com\n[core]\n    autocrlf = true\n    editor = code\n",
       "profiles": ["dev"],
-      "mode": "644"
+      "mode": 420
     },
     {
-      "src": "C:\\Users\\{{.User.Username}}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1",
-      "dest": "C:\\Users\\{{.User.Username}}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1",
+      "src": "C:\\Users\\{{.User.username}}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1",
+      "dest": "C:\\Users\\{{.User.username}}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1",
       "content": "Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned\nSet-Alias -Name ll -Value Get-ChildItem\n",
       "profiles": ["work"],
-      "mode": "644"
+      "mode": 420
     },
     {
-      "src": "C:\\Users\\{{.User.Username}}\\AppData\\Local\\Steam\\config\\config.vdf",
-      "dest": "C:\\Users\\{{.User.Username}}\\AppData\\Local\\Steam\\config\\config.vdf",
+      "src": "C:\\Users\\{{.User.username}}\\AppData\\Local\\Steam\\config\\config.vdf",
+      "dest": "C:\\Users\\{{.User.username}}\\AppData\\Local\\Steam\\config\\config.vdf",
       "content": "\"InstallConfigStore\"\n{\n    \"Software\"\n    {\n        \"valve\"\n        {\n            \"Steam\"\n            {\n                \"AutoLaunchGameListOnStart\"    \"0\"\n            }\n        }\n    }\n}\n",
       "profiles": ["gaming"],
-      "mode": "644"
+      "mode": 420
     }
   ]
 }

--- a/examples/windows/json/scripts/scripts.json
+++ b/examples/windows/json/scripts/scripts.json
@@ -2,37 +2,31 @@
   "scripts": [
     {
       "name": "update-system",
-      "content": "@echo off\nchoco upgrade all -y\nwinget upgrade --all\n",
-      "mode": "755"
+      "content": "@echo off\nchoco upgrade all -y\nwinget upgrade --all\n"
     },
     {
       "name": "setup-chocolatey",
-      "content": "@echo off\npowershell -Command \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))\"\n",
-      "mode": "755"
+      "content": "@echo off\npowershell -Command \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))\"\n"
     },
     {
       "name": "setup-wsl",
       "content": "@echo off\ndism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart\ndism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart\nwsl --set-default-version 2\n",
-      "profiles": ["dev"],
-      "mode": "755"
+      "profiles": ["dev"]
     },
     {
       "name": "configure-rdp",
       "content": "@echo off\nreg add \"HKLM\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\" /v fDenyTSConnections /t REG_DWORD /d 0 /f\nnetsh advfirewall firewall set rule group=\"remote desktop\" new enable=Yes\n",
-      "profiles": ["work"],
-      "mode": "755"
+      "profiles": ["work"]
     },
     {
       "name": "optimize-gaming",
       "content": "@echo off\npowercfg -setactive 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c\nbcdedit /set useplatformclock true\nbcdedit /set disabledynamictick yes\n",
-      "profiles": ["gaming"],
-      "mode": "755"
+      "profiles": ["gaming"]
     },
     {
       "name": "cleanup-system",
       "content": "@echo off\ncleanmgr /sagerun:1\ndism /online /cleanup-image /startcomponentcleanup\n",
-      "profiles": ["minimal"],
-      "mode": "755"
+      "profiles": ["minimal"]
     }
   ]
 }

--- a/examples/windows/json/ssh_keys/ssh_keys.json
+++ b/examples/windows/json/ssh_keys/ssh_keys.json
@@ -1,7 +1,12 @@
-ssh_keys:
-  - name: id_rsa
-    type: ed25519
-    path: {{ .User.home }}/.ssh/
-    comment: "{{ .User.username }}@github"
-    no_passphrase: true
-    copy_to_github: false
+{
+  "ssh_keys": [
+    {
+      "name": "id_rsa",
+      "type": "ed25519",
+      "path": "{{ .User.home }}/.ssh/",
+      "comment": "{{ .User.username }}@github",
+      "no_passphrase": true,
+      "copy_to_github": false
+    }
+  ]
+}

--- a/examples/windows/toml/files/files.toml
+++ b/examples/windows/toml/files/files.toml
@@ -5,7 +5,7 @@ dest = "C:\\Windows\\System32\\drivers\\etc\\hosts"
 content = """127.0.0.1       localhost
 ::1             localhost
 """
-mode = "644"
+mode = 0o644
 
 [[files]]
 src = "C:\\ProgramData\\chocolatey\\config\\chocolatey.config"
@@ -17,12 +17,12 @@ content = """<?xml version="1.0" encoding="utf-8"?>
   </config>
 </chocolatey>
 """
-mode = "644"
+mode = 0o644
 
 # Development configuration for dev profile
 [[files]]
-src = "C:\\Users\\{{.User.Username}}\\.gitconfig"
-dest = "C:\\Users\\{{.User.Username}}\\.gitconfig"
+src = "C:\\Users\\{{.User.username}}\\.gitconfig"
+dest = "C:\\Users\\{{.User.username}}\\.gitconfig"
 content = """[user]
     name = Developer
     email = dev@example.com
@@ -31,22 +31,22 @@ content = """[user]
     editor = code
 """
 profiles = ["dev"]
-mode = "644"
+mode = 0o644
 
 # Work configuration for work profile
 [[files]]
-src = "C:\\Users\\{{.User.Username}}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1"
-dest = "C:\\Users\\{{.User.Username}}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1"
+src = "C:\\Users\\{{.User.username}}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1"
+dest = "C:\\Users\\{{.User.username}}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1"
 content = """Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
 Set-Alias -Name ll -Value Get-ChildItem
 """
 profiles = ["work"]
-mode = "644"
+mode = 0o644
 
 # Gaming configuration for gaming profile
 [[files]]
-src = "C:\\Users\\{{.User.Username}}\\AppData\\Local\\Steam\\config\\config.vdf"
-dest = "C:\\Users\\{{.User.Username}}\\AppData\\Local\\Steam\\config\\config.vdf"
+src = "C:\\Users\\{{.User.username}}\\AppData\\Local\\Steam\\config\\config.vdf"
+dest = "C:\\Users\\{{.User.username}}\\AppData\\Local\\Steam\\config\\config.vdf"
 content = """"InstallConfigStore"
 {
     "Software"
@@ -62,4 +62,4 @@ content = """"InstallConfigStore"
 }
 """
 profiles = ["gaming"]
-mode = "644"
+mode = 0o644

--- a/examples/windows/toml/scripts/scripts.toml
+++ b/examples/windows/toml/scripts/scripts.toml
@@ -5,14 +5,12 @@ content = """@echo off
 choco upgrade all -y
 winget upgrade --all
 """
-mode = "755"
 
 [[scripts]]
 name = "setup-chocolatey"
 content = """@echo off
 powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
 """
-mode = "755"
 
 # Development setup for dev profile
 [[scripts]]
@@ -23,7 +21,6 @@ dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /nores
 wsl --set-default-version 2
 """
 profiles = ["dev"]
-mode = "755"
 
 # Work setup for work profile
 [[scripts]]
@@ -33,7 +30,6 @@ reg add "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server" /v fDenyTSCo
 netsh advfirewall firewall set rule group="remote desktop" new enable=Yes
 """
 profiles = ["work"]
-mode = "755"
 
 # Gaming setup for gaming profile
 [[scripts]]
@@ -44,7 +40,6 @@ bcdedit /set useplatformclock true
 bcdedit /set disabledynamictick yes
 """
 profiles = ["gaming"]
-mode = "755"
 
 # Minimal system cleanup for minimal profile
 [[scripts]]
@@ -54,4 +49,3 @@ cleanmgr /sagerun:1
 dism /online /cleanup-image /startcomponentcleanup
 """
 profiles = ["minimal"]
-mode = "755"

--- a/examples/windows/yaml/bootstrap.yaml
+++ b/examples/windows/yaml/bootstrap.yaml
@@ -5,15 +5,15 @@ packages:
     action: install
 
 directories:
-  - name: {{ .User.home }}/git
+  - name: "{{ .User.home }}/git"
     action: create
-    owner: {{ .User.username }}
-    group: {{ .User.username }}
+    owner: "{{ .User.username }}"
+    group: "{{ .User.username }}"
 
 ssh_keys:
   - name: github
     type: ed25519
-    path: {{ .User.home }}/.ssh/
+    path: "{{ .User.home }}/.ssh/"
     comment: "{{ .User.username }}@example.com"
     no_passphrase: true
     copy_to_github: false

--- a/examples/windows/yaml/files/files.yaml
+++ b/examples/windows/yaml/files/files.yaml
@@ -5,7 +5,7 @@ files:
     content: |
       127.0.0.1       localhost
       ::1             localhost
-    mode: "644"
+    mode: 0644
 
   - src: C:\ProgramData\chocolatey\config\chocolatey.config
     dest: C:\ProgramData\chocolatey\config\chocolatey.config
@@ -16,11 +16,11 @@ files:
           <add key="cacheLocation" value="C:\temp\chocolatey" />
         </config>
       </chocolatey>
-    mode: "644"
+    mode: 0644
 
   # Development configuration for dev profile
-  - src: C:\Users\{{.User.Username}}\.gitconfig
-    dest: C:\Users\{{.User.Username}}\.gitconfig
+  - src: C:\Users\{{.User.username}}\.gitconfig
+    dest: C:\Users\{{.User.username}}\.gitconfig
     content: |
       [user]
           name = Developer
@@ -29,20 +29,20 @@ files:
           autocrlf = true
           editor = code
     profiles: [dev]
-    mode: "644"
+    mode: 0644
 
   # Work configuration for work profile
-  - src: C:\Users\{{.User.Username}}\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
-    dest: C:\Users\{{.User.Username}}\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
+  - src: C:\Users\{{.User.username}}\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
+    dest: C:\Users\{{.User.username}}\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
     content: |
       Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
       Set-Alias -Name ll -Value Get-ChildItem
     profiles: [work]
-    mode: "644"
+    mode: 0644
 
   # Gaming configuration for gaming profile
-  - src: C:\Users\{{.User.Username}}\AppData\Local\Steam\config\config.vdf
-    dest: C:\Users\{{.User.Username}}\AppData\Local\Steam\config\config.vdf
+  - src: C:\Users\{{.User.username}}\AppData\Local\Steam\config\config.vdf
+    dest: C:\Users\{{.User.username}}\AppData\Local\Steam\config\config.vdf
     content: |
       "InstallConfigStore"
       {
@@ -58,4 +58,4 @@ files:
           }
       }
     profiles: [gaming]
-    mode: "644"
+    mode: 0644

--- a/examples/windows/yaml/git/git.yaml
+++ b/examples/windows/yaml/git/git.yaml
@@ -2,5 +2,5 @@ git:
   - name: rwr
     action: clone
     url: https://github.com/FynxLabs/rwr.git
-    path: {{ .User.home }}/git/rwr
+    path: "{{ .User.home }}/git/rwr"
     private: false

--- a/examples/windows/yaml/scripts/scripts.yaml
+++ b/examples/windows/yaml/scripts/scripts.yaml
@@ -5,13 +5,11 @@ scripts:
       @echo off
       choco upgrade all -y
       winget upgrade --all
-    mode: "755"
 
   - name: setup-chocolatey
     content: |
       @echo off
       powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
-    mode: "755"
 
   # Development setup for dev profile
   - name: setup-wsl
@@ -21,7 +19,6 @@ scripts:
       dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart
       wsl --set-default-version 2
     profiles: [dev]
-    mode: "755"
 
   # Work setup for work profile
   - name: configure-rdp
@@ -30,7 +27,6 @@ scripts:
       reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnections /t REG_DWORD /d 0 /f
       netsh advfirewall firewall set rule group="remote desktop" new enable=Yes
     profiles: [work]
-    mode: "755"
 
   # Gaming setup for gaming profile
   - name: optimize-gaming
@@ -40,7 +36,6 @@ scripts:
       bcdedit /set useplatformclock true
       bcdedit /set disabledynamictick yes
     profiles: [gaming]
-    mode: "755"
 
   # Minimal system cleanup for minimal profile
   - name: cleanup-system
@@ -49,4 +44,3 @@ scripts:
       cleanmgr /sagerun:1
       dism /online /cleanup-image /startcomponentcleanup
     profiles: [minimal]
-    mode: "755"

--- a/examples/windows/yaml/ssh_keys/ssh_keys.yaml
+++ b/examples/windows/yaml/ssh_keys/ssh_keys.yaml
@@ -1,7 +1,7 @@
 ssh_keys:
   - name: id_rsa
     type: ed25519
-    path: {{ .User.home }}/.ssh/
+    path: "{{ .User.home }}/.ssh/"
     comment: "{{ .User.username }}@github"
     no_passphrase: true
     copy_to_github: false

--- a/internal/validate/examples_test.go
+++ b/internal/validate/examples_test.go
@@ -1,0 +1,121 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// examplesDir locates the repository's examples/ tree from this package.
+func examplesDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join("..", "..", "examples")
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("examples directory not found: %v", err)
+	}
+	return dir
+}
+
+func walkExamples(t *testing.T, fn func(path, ext string, data []byte)) {
+	t.Helper()
+	root := examplesDir(t)
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		ext := strings.TrimPrefix(filepath.Ext(path), ".")
+		switch ext {
+		case "yaml", "yml", "json", "toml":
+		default:
+			return nil
+		}
+		data, readErr := os.ReadFile(path) // #nosec G304 -- test walks the repo's own examples tree
+		if readErr != nil {
+			t.Errorf("%s: %v", path, readErr)
+			return nil
+		}
+		fn(path, ext, data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking examples: %v", err)
+	}
+}
+
+// Every shipped example must parse in the format its extension claims.
+//
+// Nineteen of them did not: fifteen YAML files started a value with an unquoted
+// `{{`, which YAML reads as a flow mapping, and four files with a .json extension
+// contained YAML. Nothing caught it because no test ever read the examples.
+func TestExamples_ParseInTheirDeclaredFormat(t *testing.T) {
+	walkExamples(t, func(path, ext string, data []byte) {
+		// Templates are resolved before parsing at runtime, so do the same here;
+		// a file is allowed to contain template syntax, not to be unparseable.
+		resolved, err := helpers.ResolveTemplate(data, exampleVariables())
+		if err != nil {
+			t.Errorf("%s: template does not parse: %v", path, err)
+			return
+		}
+
+		var out map[string]interface{}
+		if err := helpers.UnmarshalBlueprint(resolved, ext, &out); err != nil {
+			t.Errorf("%s: does not parse as %s: %v", path, ext, err)
+		}
+	})
+}
+
+// The examples may only use template variables that actually exist. A missing key
+// renders as the literal "<no value>" rather than erroring, so a typo silently
+// produces paths like "<no value>/.bashrc" — which is how 214 uses of
+// {{ .User.Home }} (capital H, where the map key is "home") went unnoticed.
+func TestExamples_UseOnlyRealTemplateVariables(t *testing.T) {
+	walkExamples(t, func(path, ext string, data []byte) {
+		resolved, err := helpers.ResolveTemplate(data, exampleVariables())
+		if err != nil {
+			return // reported by the parse test
+		}
+		if strings.Contains(string(resolved), "<no value>") {
+			t.Errorf("%s: renders \"<no value>\" — it references a template variable "+
+				"that does not exist (check casing: the keys are lowercase-first)", path)
+		}
+	})
+}
+
+// exampleVariables mirrors what Initialize builds, with every user-defined value
+// the examples reference. A template referring to something absent renders
+// "<no value>", which the test above rejects.
+func exampleVariables() types.Variables {
+	return types.Variables{
+		User: types.UserInfo{
+			Username:  "example",
+			FirstName: "Example",
+			LastName:  "User",
+			FullName:  "Example User",
+			GroupName: "example",
+			Home:      "/home/example",
+			Shell:     "/bin/bash",
+		},
+		System: types.System{
+			OS:        "linux",
+			OSFamily:  "arch",
+			OSVersion: "rolling",
+			OSArch:    "amd64",
+		},
+		UserDefined: map[string]interface{}{
+			"project_name":   "example-project",
+			"repo_url":       "https://github.com/example/dotfiles.git",
+			"company":        "MyCompany",
+			"department":     "Engineering",
+			"editor_theme":   "dracula",
+			"editor_plugins": "basic",
+		},
+	}
+}


### PR DESCRIPTION
Nothing ever read the `examples/` tree, so nothing caught that a lot of it could
not work. Found by combing the examples against what the code actually supports.

## 19 files did not parse at all

Not "wrong config" — unparseable.

**15 YAML files** start a value with an unquoted `{{`, which YAML reads as the
start of a flow mapping, so the file fails before RWR ever sees it:

```yaml
path: {{ .User.home }}/git/rwr     # YAML error: expected mapping
```

Across bootstrap, git, ssh_keys, files and users examples on every platform.
Those scalars are now quoted.

**4 files with a `.json` extension contain YAML** — `ssh_keys.json` under macos,
windows, Fedora and Ubuntu. Not malformed JSON; actual YAML text. Now real JSON.

## 214 template references use the wrong case

`UserInfo.ToMap()` emits lowercase-first keys (`home`, `username`, `firstName`,
…), and `ResolveTemplate` executes with `missingkey=invalid`, so a wrong key does
**not** error — it renders the literal `<no value>`. Confirmed by calling
`ResolveTemplate` directly:

```
{{ .User.Home }}  ->  <no value>/.bashrc
{{ .User.home }}  ->  /home/levi/.bashrc
```

27 files would have written dotfiles to `<no value>/.bashrc`. Note the examples
were already inconsistent — bootstrap files and `alternative_layouts` used the
correct lowercase form — which suggests the capitalised ones had never been run.

## `| default "..."` does not exist

RWR registers no template `FuncMap`, so this is a **parse error that aborts the
whole run**, not a fallback:

```
error parsing template: function "default" not defined
```

Four uses in the Arch files example meant that example could never run at all.
They now use `{{ .UserDefined.* }}`, with the values defined in the Arch init
file — demonstrating the mechanism RWR actually has.

## File modes were wrong two different ways

- Quoted `mode: "644"` cannot decode into `File.Mode` (an `int`) → the whole
  blueprint fails.
- Unquoted `mode: 755` is **decimal** — `0o1363`, not `rwxr-xr-x`.

Modes are now octal in YAML and TOML, and the decimal equivalent in JSON, which
has no octal literal. `mode` on **scripts** was removed rather than corrected:
`Script` has no `Mode` field, so it was silently dropped, and an example should
not teach a setting that does nothing.

## Test

`internal/validate/examples_test.go` walks the whole tree and asserts every file
parses in the format its extension claims, and that nothing renders `<no value>`.
That second check is the only way this class of bug is visible, since a missing
key is not an error.

**31 failures against master. Clean here.**

## Deliberately not fixed — each wants its own change

- **`examples/alternative_layouts/`** relies on blueprint type being detected from
  file *content*. The code uses the **path** (`getProcessorType` in
  `blueprints.go`), so those examples are silent no-ops — and `examples/README.md`
  plus two more READMEs document the wrong model.
- **`examples/imports/`** has no init file, and its import paths do not resolve:
  most processors resolve imports against `Init.Location`, not the file's own
  directory.
- **Ubuntu and Windows files/users/services** use field names that do not exist
  (`src`/`dest`, `username`, `create_home`, `names`) and are ~100% no-ops. They
  need rewriting, not patching.
- **The yaml/json/toml triples have drifted** into materially different content
  (e.g. Arch files: 194 lines of YAML vs 31 of JSON).

## Verification

`go build`, `go test ./...`, `golangci-lint run` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)