### PR TITLE
feat(examples): cover every blueprint type per platform, checked in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,44 @@ jobs:
       - name: Test
         run: go test -v ./...
 
+  # The examples are the closest thing to a compatibility contract with users:
+  # every blueprint field they use is a field somebody's real blueprint uses too.
+  # Breaking one silently is easy, because the decoders RWR uses ignore unknown
+  # keys — a renamed field turns every blueprint using it into a no-op rather
+  # than an error. These checks make that a failed build instead.
+  examples:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: ">=1.26.5"
+
+      # Asserts every example parses in its declared format, resolves without
+      # referencing a template variable that does not exist, decodes strictly
+      # into its blueprint struct with no unknown keys, and that the yaml, json
+      # and toml copies describe the same thing.
+      - name: Validate example blueprints
+        run: go test -v ./internal/validate/ -run TestExamples_
+
+      # Runs the real binary over every example tree, the way a user would.
+      - name: Run rwr validate over every example tree
+        run: |
+          set -euo pipefail
+          go build -o rwr .
+          status=0
+          while IFS= read -r init; do
+            tree="$(dirname "$init")"
+            echo "::group::rwr validate $tree"
+            ./rwr validate --blueprints "$tree" || status=1
+            echo "::endgroup::"
+          done < <(find examples -name 'init.*' | sort)
+          exit "$status"
+
   security:
     runs-on: ubuntu-latest
     permissions:

--- a/docs/schema-versioning.md
+++ b/docs/schema-versioning.md
@@ -1,0 +1,133 @@
+# Blueprint schema versioning
+
+Blueprints declare which version of the schema they are written in, so RWR can
+change a blueprint format without silently misreading configuration that was
+written against the old one.
+
+## Versions are per blueprint type
+
+There is no single schema number covering everything. Each blueprint type —
+`packages`, `files`, `services`, and so on — carries its own version.
+
+That is deliberate. If one shared number covered the whole schema, a breaking
+change to `packages` would move `files`, `git`, `scripts` and everything else to
+v2 as well, even though none of them changed. Do that a few times and you are on
+v11 with no way to tell which resource actually changed at each step.
+
+With per-type versions, a breaking change to `packages` produces exactly one
+change: `packages` is now v2. Everything else is still v1, and blueprints for
+those types keep working untouched.
+
+## Declaring a version
+
+**In the init file**, applying to the whole tree:
+
+```yaml
+blueprints:
+  format: yaml
+  location: "."
+  schema_version: 1
+```
+
+**In an individual blueprint file**, overriding the tree for that file only:
+
+```yaml
+schema_version: 2
+packages:
+  - name: git
+    action: install
+```
+
+The most specific declaration wins:
+
+1. the blueprint file's own `schema_version`
+2. the init file's `schema_version`
+3. the latest version supported for that blueprint type
+
+## Nothing declared means latest
+
+A blueprint that declares no version is read as the **latest** version RWR
+supports for that type.
+
+This keeps the common case free of boilerplate: a blueprint written today gets
+today's schema without having to say so. The version field is what you add when
+you want to be *pinned*, not something you must add to get started.
+
+The trade-off is that an undeclared blueprint follows the schema forward across
+upgrades. If a tree needs to stay on a particular version — because you are not
+ready to migrate, or you want it to behave identically on every machine
+regardless of the RWR version installed — declare it:
+
+```yaml
+blueprints:
+  schema_version: 1
+```
+
+That one line pins the whole tree, and individual files can still opt forward.
+
+Note this is per type: when `packages` gains a v2, an undeclared `packages`
+blueprint is read as v2, while `files` — which did not change — is still read as
+v1.
+
+## Migrating one resource type
+
+When `packages` gains a v2, a tree can move one file at a time:
+
+```yaml
+# init.yaml — the tree is still v1
+blueprints:
+  schema_version: 1
+```
+
+```yaml
+# packages/dev-tools.yaml — this file is v2
+schema_version: 2
+packages:
+  - name: git
+    action: install
+```
+
+```yaml
+# packages/base.yaml — still v1, still works
+packages:
+  - name: curl
+    action: install
+```
+
+Both files are read correctly in the same run. There is no flag day.
+
+## Unsupported versions are an error
+
+A blueprint asking for a version this build does not implement fails, naming the
+version it wanted:
+
+```
+packages: schema version 2 is not supported by this build (supports 1) —
+upgrade rwr, or write this blueprint in a supported version
+```
+
+This is intentionally a hard failure. RWR installs packages, writes files and
+runs scripts as root; reading a v2 blueprint as though it were v1 would mean
+acting on a misunderstanding of what the file asked for. Refusing is the safer
+outcome.
+
+A tree-wide version has to be supported by *every* blueprint type, since it
+applies to all of them. If only some types have a v2, declare it per file
+instead — the error says so.
+
+## Adding a version (for contributors)
+
+Each version of a blueprint type is its own struct describing exactly what that
+version accepts on disk. Decoding picks the struct by resolved version and then
+converts it to the canonical type the processors consume, so nothing past the
+decoder knows more than one version exists.
+
+To add a v2 for a type, in `internal/types/`:
+
+1. Define the struct for the new wire format, e.g. `packagesV2`.
+2. Give it a `Canonical()` that maps it onto `PackagesData`.
+3. Register it in `schemaRegistry` under `{BlueprintTypePackages: {2: ...}}`.
+4. Add `2` to that type's entry in `supportedSchemaVersions`.
+
+Nothing else changes. The processors keep consuming `PackagesData` and no other
+blueprint type is affected.

--- a/examples/alternative_layouts/flattened/json/init.json
+++ b/examples/alternative_layouts/flattened/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "packages",

--- a/examples/alternative_layouts/flattened/toml/init.toml
+++ b/examples/alternative_layouts/flattened/toml/init.toml
@@ -1,7 +1,13 @@
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
-order = ["packages", "git", "files", "scripts"]
+order = [
+    "packages",
+    "git",
+    "files",
+    "scripts",
+]
 
 [variables.userDefined]
 project_name = "flattened-setup"

--- a/examples/alternative_layouts/flattened/yaml/init.yaml
+++ b/examples/alternative_layouts/flattened/yaml/init.yaml
@@ -1,13 +1,13 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
-    - packages
-    - git
-    - files
-    - scripts
-
+  - packages
+  - git
+  - files
+  - scripts
 variables:
   userDefined:
-    project_name: "flattened-setup"
-    repo_url: "https://github.com/user/dotfiles.git"
+    project_name: flattened-setup
+    repo_url: https://github.com/user/dotfiles.git

--- a/examples/alternative_layouts/minimal_files/json/init.json
+++ b/examples/alternative_layouts/minimal_files/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "packages",

--- a/examples/alternative_layouts/minimal_files/toml/init.toml
+++ b/examples/alternative_layouts/minimal_files/toml/init.toml
@@ -1,7 +1,13 @@
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
-order = ["packages", "git", "files", "scripts"]
+order = [
+    "packages",
+    "git",
+    "files",
+    "scripts",
+]
 
 [variables.userDefined]
 project_name = "minimal-setup"

--- a/examples/alternative_layouts/minimal_files/yaml/init.yaml
+++ b/examples/alternative_layouts/minimal_files/yaml/init.yaml
@@ -1,13 +1,13 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
-    - packages
-    - git
-    - files
-    - scripts
-
+  - packages
+  - git
+  - files
+  - scripts
 variables:
   userDefined:
-    project_name: "minimal-setup"
-    repo_url: "https://github.com/user/dotfiles.git"
+    project_name: minimal-setup
+    repo_url: https://github.com/user/dotfiles.git

--- a/examples/linux/Arch/json/configuration/configuration.json
+++ b/examples/linux/Arch/json/configuration/configuration.json
@@ -1,0 +1,21 @@
+{
+  "configurations": [
+    {
+      "name": "interface-theme",
+      "action": "set",
+      "tool": "gsettings",
+      "schema": "org.gnome.desktop.interface",
+      "settings": {
+        "gtk-theme": "Adwaita-dark",
+        "color-scheme": "prefer-dark"
+      }
+    },
+    {
+      "name": "terminal-font",
+      "action": "set",
+      "tool": "dconf",
+      "key": "/org/gnome/desktop/interface/monospace-font-name",
+      "value": "FiraCode Nerd Font 11"
+    }
+  ]
+}

--- a/examples/linux/Arch/json/files/files.json
+++ b/examples/linux/Arch/json/files/files.json
@@ -4,29 +4,183 @@
       "name": ".bashrc",
       "action": "create",
       "target": "{{ .User.home }}/",
-      "content": "# Custom .bashrc content\nalias ll='ls -alF'\nexport PATH=$PATH:$HOME/.local/bin\n"
+      "content": "# Custom .bashrc content\nalias ll='ls -alF'\nalias la='ls -A'\nalias l='ls -CF'\nexport PATH=$PATH:$HOME/.local/bin\nexport EDITOR=nvim\n"
     },
     {
-      "name": ".gitignore",
-      "action": "copy",
+      "name": ".vimrc",
+      "action": "create",
       "target": "{{ .User.home }}/",
-      "source": "./src/"
+      "content": "\" Basic vim configuration\nset number\nset relativenumber\nset tabstop=4\nset shiftwidth=4\nset expandtab\nsyntax on\n"
+    },
+    {
+      "name": ".gitconfig-work",
+      "profiles": [
+        "work"
+      ],
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "content": "[user]\n    name = Work User\n    email = user@company.com\n[core]\n    editor = code --wait\n[push]\n    default = simple\n"
+    },
+    {
+      "name": "work-ssh-config",
+      "profiles": [
+        "work"
+      ],
+      "action": "copy",
+      "source": "./src/ssh/work_config",
+      "target": "{{ .User.home }}/.ssh/config",
+      "mode": 384
+    },
+    {
+      "name": ".gitconfig-dev",
+      "profiles": [
+        "dev"
+      ],
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "content": "[user]\n    name = Developer\n    email = dev@personal.com\n[core]\n    editor = nvim\n[alias]\n    st = status\n    co = checkout\n    br = branch\n"
+    },
+    {
+      "name": ".zshrc",
+      "profiles": [
+        "dev",
+        "work"
+      ],
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "content": "# Zsh configuration\nexport ZSH=\"$HOME/.oh-my-zsh\"\nZSH_THEME=\"robbyrussell\"\nplugins=(git docker kubectl)\nsource $ZSH/oh-my-zsh.sh\n"
+    },
+    {
+      "name": "gamemode.ini",
+      "profiles": [
+        "gaming"
+      ],
+      "action": "copy",
+      "source": "./src/gamemode.ini",
+      "target": "{{ .User.home }}/.config/gamemode/"
+    },
+    {
+      "name": ".aliases",
+      "profiles": [
+        "personal"
+      ],
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "content": "# Personal aliases\nalias music='vlc ~/Music'\nalias photos='gimp'\nalias backup='rsync -av ~/Documents/ ~/Backup/'\n"
     }
   ],
   "directories": [
     {
       "name": ".config",
-      "action": "copy",
-      "source": "./src/",
-      "target": "{{ .User.home }}/"
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "mode": 493
+    },
+    {
+      "name": ".local/bin",
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "mode": 493
+    },
+    {
+      "name": "work",
+      "profiles": [
+        "work"
+      ],
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "mode": 493
+    },
+    {
+      "name": ".ssh",
+      "profiles": [
+        "work",
+        "dev"
+      ],
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "mode": 448
+    },
+    {
+      "name": "projects",
+      "profiles": [
+        "dev"
+      ],
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "mode": 493
+    },
+    {
+      "name": ".config/nvim",
+      "profiles": [
+        "dev"
+      ],
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "mode": 493
+    },
+    {
+      "name": ".config/gamemode",
+      "profiles": [
+        "gaming"
+      ],
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "mode": 493
+    },
+    {
+      "name": "Games",
+      "profiles": [
+        "gaming",
+        "personal"
+      ],
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "mode": 493
     }
   ],
   "templates": [
     {
       "name": ".profile",
       "action": "copy",
-      "source": "./src/",
+      "source": "./src/.profile",
       "target": "{{ .User.home }}/"
+    },
+    {
+      "name": "work-environment",
+      "profiles": [
+        "work"
+      ],
+      "action": "copy",
+      "source": "./src/work-environment.j2",
+      "target": "{{ .User.home }}/.work-env",
+      "variables": {
+        "company": "{{ .UserDefined.company }}",
+        "department": "{{ .UserDefined.department }}"
+      }
+    },
+    {
+      "name": "nvim-config",
+      "profiles": [
+        "dev"
+      ],
+      "action": "copy",
+      "source": "./src/nvim/init.lua.j2",
+      "target": "{{ .User.home }}/.config/nvim/init.lua",
+      "variables": {
+        "theme": "{{ .UserDefined.editor_theme }}",
+        "plugins": "{{ .UserDefined.editor_plugins }}"
+      }
+    },
+    {
+      "name": "personal-scripts",
+      "profiles": [
+        "personal"
+      ],
+      "action": "copy",
+      "source": "./src/personal-scripts.j2",
+      "target": "{{ .User.home }}/.local/bin/personal-tools",
+      "mode": 493
     }
   ]
 }

--- a/examples/linux/Arch/json/fonts/fonts.json
+++ b/examples/linux/Arch/json/fonts/fonts.json
@@ -1,0 +1,25 @@
+{
+  "fonts": [
+    {
+      "name": "FiraCode",
+      "action": "install",
+      "provider": "nerd",
+      "location": "user"
+    },
+    {
+      "name": "JetBrainsMono",
+      "action": "install",
+      "provider": "nerd",
+      "location": "user"
+    },
+    {
+      "names": [
+        "Hack",
+        "SourceCodePro"
+      ],
+      "action": "install",
+      "provider": "nerd",
+      "location": "system"
+    }
+  ]
+}

--- a/examples/linux/Arch/json/git/git.json
+++ b/examples/linux/Arch/json/git/git.json
@@ -1,11 +1,132 @@
 {
   "git": [
     {
+      "name": "dotfiles",
+      "action": "clone",
+      "url": "https://github.com/user/dotfiles.git",
+      "path": "{{ .User.home }}/.dotfiles",
+      "private": false
+    },
+    {
+      "name": "configs",
+      "action": "clone",
+      "url": "https://github.com/user/configs.git",
+      "path": "{{ .User.home }}/configs",
+      "private": false
+    },
+    {
+      "name": "work-configs",
+      "profiles": [
+        "work"
+      ],
+      "action": "clone",
+      "url": "https://github.com/company/work-configs.git",
+      "path": "{{ .User.home }}/work/configs",
+      "private": true
+    },
+    {
+      "name": "company-tools",
+      "profiles": [
+        "work"
+      ],
+      "action": "clone",
+      "url": "https://github.com/company/internal-tools.git",
+      "path": "{{ .User.home }}/work/tools",
+      "private": true
+    },
+    {
+      "name": "awesome-project",
+      "profiles": [
+        "dev"
+      ],
+      "action": "clone",
+      "url": "https://github.com/user/awesome-project.git",
+      "path": "{{ .User.home }}/projects/awesome-project",
+      "private": false
+    },
+    {
+      "name": "learning-rust",
+      "profiles": [
+        "dev"
+      ],
+      "action": "clone",
+      "url": "https://github.com/rust-lang/book.git",
+      "path": "{{ .User.home }}/projects/rust-book",
+      "private": false
+    },
+    {
       "name": "rwr",
+      "profiles": [
+        "dev",
+        "work"
+      ],
       "action": "clone",
       "url": "https://github.com/FynxLabs/rwr.git",
-      "path": "{{ .User.home }}/git/rwr",
+      "path": "{{ .User.home }}/projects/rwr",
       "private": false
+    },
+    {
+      "name": "gaming-configs",
+      "profiles": [
+        "gaming"
+      ],
+      "action": "clone",
+      "url": "https://github.com/user/gaming-configs.git",
+      "path": "{{ .User.home }}/.config/gaming",
+      "private": false
+    },
+    {
+      "name": "game-mods",
+      "profiles": [
+        "gaming"
+      ],
+      "action": "clone",
+      "url": "https://github.com/user/game-modifications.git",
+      "path": "{{ .User.home }}/Games/mods",
+      "private": false
+    },
+    {
+      "name": "personal-scripts",
+      "profiles": [
+        "personal"
+      ],
+      "action": "clone",
+      "url": "https://github.com/user/personal-scripts.git",
+      "path": "{{ .User.home }}/scripts",
+      "private": true
+    },
+    {
+      "name": "photo-organizer",
+      "profiles": [
+        "personal"
+      ],
+      "action": "clone",
+      "url": "https://github.com/user/photo-organizer.git",
+      "path": "{{ .User.home }}/tools/photo-organizer",
+      "private": false
+    },
+    {
+      "name": "security-tools",
+      "profiles": [
+        "security",
+        "work"
+      ],
+      "action": "clone",
+      "url": "https://github.com/security/tools.git",
+      "path": "{{ .User.home }}/security/tools",
+      "private": true
+    },
+    {
+      "name": "db-migrations",
+      "profiles": [
+        "database",
+        "work",
+        "dev"
+      ],
+      "action": "clone",
+      "url": "https://github.com/company/database-migrations.git",
+      "path": "{{ .User.home }}/database/migrations",
+      "private": true
     }
   ]
 }

--- a/examples/linux/Arch/json/init.json
+++ b/examples/linux/Arch/json/init.json
@@ -3,15 +3,16 @@
     "format": "json",
     "location": ".",
     "order": [
-      "bootstrap",
       "repositories",
       "packages",
       "files",
+      "fonts",
       "services",
       "git",
       "scripts",
       "users",
-      "ssh_keys"
+      "ssh_keys",
+      "configuration"
     ]
   },
   "packageManagers": [
@@ -23,5 +24,13 @@
       "name": "brew",
       "action": "install"
     }
-  ]
+  ],
+  "variables": {
+    "userDefined": {
+      "company": "MyCompany",
+      "department": "Engineering",
+      "editor_theme": "dracula",
+      "editor_plugins": "basic"
+    }
+  }
 }

--- a/examples/linux/Arch/json/init.json
+++ b/examples/linux/Arch/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "repositories",

--- a/examples/linux/Arch/json/scripts/scripts.json
+++ b/examples/linux/Arch/json/scripts/scripts.json
@@ -3,57 +3,73 @@
     {
       "name": "system_info",
       "action": "run",
-      "content": "#!/bin/bash\necho \"System Information:\"\necho \"Hostname: $(hostname)\"\necho \"User: $USER\"\necho \"Distribution: $(lsb_release -d | cut -f2)\"\necho \"Kernel: $(uname -r)\"",
+      "content": "#!/bin/bash\necho \"System Information:\"\necho \"Hostname: $(hostname)\"\necho \"User: $USER\"\necho \"Distribution: $(lsb_release -d | cut -f2)\"\necho \"Kernel: $(uname -r)\"\n",
       "log": "{{ .User.home }}/.config/rwr/logs/system_info.log"
     },
     {
       "name": "update_system",
       "action": "run",
       "elevated": true,
-      "content": "#!/bin/bash\necho \"Updating package database...\"\npacman -Sy --noconfirm\necho \"System updated successfully\"",
+      "content": "#!/bin/bash\necho \"Updating package database...\"\npacman -Sy --noconfirm\necho \"System updated successfully\"\n",
       "log": "{{ .User.home }}/.config/rwr/logs/system_update.log"
     },
     {
       "name": "setup_dev_environment",
-      "profiles": ["dev", "work"],
+      "profiles": [
+        "dev",
+        "work"
+      ],
       "action": "run",
-      "content": "#!/bin/bash\n# Create development directories\nmkdir -p \"{{ .User.home }}/Projects\"\nmkdir -p \"{{ .User.home }}/Projects/personal\"\nmkdir -p \"{{ .User.home }}/Projects/work\"\nmkdir -p \"{{ .User.home }}/.local/bin\"\n\n# Set up development aliases\necho 'alias ll=\"ls -alF\"' >> \"{{ .User.home }}/.bashrc\"\necho 'alias la=\"ls -A\"' >> \"{{ .User.home }}/.bashrc\"\necho 'alias l=\"ls -CF\"' >> \"{{ .User.home }}/.bashrc\"\n\necho \"Development environment setup complete\"",
+      "content": "#!/bin/bash\n# Create development directories\nmkdir -p \"{{ .User.home }}/Projects\"\nmkdir -p \"{{ .User.home }}/Projects/personal\"\nmkdir -p \"{{ .User.home }}/Projects/work\"\nmkdir -p \"{{ .User.home }}/.local/bin\"\n\n# Set up development aliases\necho 'alias ll=\"ls -alF\"' >> \"{{ .User.home }}/.bashrc\"\necho 'alias la=\"ls -A\"' >> \"{{ .User.home }}/.bashrc\"\necho 'alias l=\"ls -CF\"' >> \"{{ .User.home }}/.bashrc\"\n\necho \"Development environment setup complete\"\n",
       "log": "{{ .User.home }}/.config/rwr/logs/dev_setup.log"
     },
     {
       "name": "install_nvm",
-      "profiles": ["dev", "nodejs"],
+      "profiles": [
+        "dev",
+        "nodejs"
+      ],
       "action": "run",
-      "content": "#!/bin/bash\ncurl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash\nexport NVM_DIR=\"$HOME/.nvm\"\n[ -s \"$NVM_DIR/nvm.sh\" ] && \\. \"$NVM_DIR/nvm.sh\"\nnvm install --lts\nnvm use --lts\necho \"NVM and latest LTS Node.js installed\"",
+      "content": "#!/bin/bash\ncurl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash\nexport NVM_DIR=\"$HOME/.nvm\"\n[ -s \"$NVM_DIR/nvm.sh\" ] && \\. \"$NVM_DIR/nvm.sh\"\nnvm install --lts\nnvm use --lts\necho \"NVM and latest LTS Node.js installed\"\n",
       "log": "{{ .User.home }}/.config/rwr/logs/nvm_install.log"
     },
     {
       "name": "gaming_optimizations",
-      "profiles": ["gaming"],
+      "profiles": [
+        "gaming"
+      ],
       "action": "run",
       "elevated": true,
-      "content": "#!/bin/bash\n# Enable multilib repository\nsed -i '/^#\\[multilib\\]/,/^#Include = \\/etc\\/pacman.d\\/mirrorlist/ { s/^#//; }' /etc/pacman.conf\n\n# Update package database\npacman -Sy --noconfirm\n\n# Set up gaming group\ngroupadd -f gaming\nusermod -a -G gaming \"{{ .User.username }}\"\n\necho \"Gaming optimizations applied\"",
+      "content": "#!/bin/bash\n# Enable multilib repository\nsed -i '/^#\\[multilib\\]/,/^#Include = \\/etc\\/pacman.d\\/mirrorlist/ { s/^#//; }' /etc/pacman.conf\n\n# Update package database\npacman -Sy --noconfirm\n\n# Set up gaming group\ngroupadd -f gaming\nusermod -a -G gaming \"{{ .User.username }}\"\n\necho \"Gaming optimizations applied\"\n",
       "log": "{{ .User.home }}/.config/rwr/logs/gaming_setup.log"
     },
     {
       "name": "security_setup",
-      "profiles": ["security", "work"],
+      "profiles": [
+        "security",
+        "work"
+      ],
       "action": "run",
       "elevated": true,
-      "content": "#!/bin/bash\n# Configure firewall\nsystemctl enable ufw\nufw --force enable\nufw default deny incoming\nufw default allow outgoing\nufw allow ssh\n\n# Set up fail2ban\nsystemctl enable fail2ban\nsystemctl start fail2ban\n\necho \"Basic security setup complete\"",
+      "content": "#!/bin/bash\n# Configure firewall\nsystemctl enable ufw\nufw --force enable\nufw default deny incoming\nufw default allow outgoing\nufw allow ssh\n\n# Set up fail2ban\nsystemctl enable fail2ban\nsystemctl start fail2ban\n\necho \"Basic security setup complete\"\n",
       "log": "{{ .User.home }}/.config/rwr/logs/security_setup.log"
     },
     {
       "name": "setup_postgresql_user",
-      "profiles": ["database", "dev"],
+      "profiles": [
+        "database",
+        "dev"
+      ],
       "action": "run",
       "elevated": true,
-      "content": "#!/bin/bash\n# Create PostgreSQL user\nsudo -u postgres createuser -s \"{{ .User.username }}\"\nsudo -u postgres createdb \"{{ .User.username }}\"\n\necho \"PostgreSQL user setup complete\"",
+      "content": "#!/bin/bash\n# Create PostgreSQL user\nsudo -u postgres createuser -s \"{{ .User.username }}\"\nsudo -u postgres createdb \"{{ .User.username }}\"\n\necho \"PostgreSQL user setup complete\"\n",
       "log": "{{ .User.home }}/.config/rwr/logs/postgresql_setup.log"
     },
     {
       "name": "run_custom_setup",
-      "profiles": ["personal"],
+      "profiles": [
+        "personal"
+      ],
       "action": "run",
       "source": "{{ .User.home }}/Scripts/personal_setup.sh",
       "args": "--user {{ .User.username }} --home {{ .User.home }}",
@@ -61,18 +77,23 @@
     },
     {
       "name": "docker_user_setup",
-      "profiles": ["dev", "docker"],
+      "profiles": [
+        "dev",
+        "docker"
+      ],
       "action": "run",
       "elevated": true,
-      "content": "#!/bin/bash\n# Add user to docker group\nusermod -a -G docker \"{{ .User.username }}\"\n\n# Enable and start Docker service\nsystemctl enable docker\nsystemctl start docker\n\necho \"Docker user setup complete. Please log out and back in for group changes to take effect.\"",
+      "content": "#!/bin/bash\n# Add user to docker group\nusermod -a -G docker \"{{ .User.username }}\"\n\n# Enable and start Docker service\nsystemctl enable docker\nsystemctl start docker\n\necho \"Docker user setup complete. Please log out and back in for group changes to take effect.\"\n",
       "log": "{{ .User.home }}/.config/rwr/logs/docker_setup.log"
     },
     {
       "name": "system_cleanup",
-      "profiles": ["maintenance"],
+      "profiles": [
+        "maintenance"
+      ],
       "action": "run",
       "elevated": true,
-      "content": "#!/bin/bash\n# Clean package cache\npacman -Sc --noconfirm\n\n# Clean orphaned packages\npacman -Rns $(pacman -Qtdq) --noconfirm 2>/dev/null || echo \"No orphaned packages found\"\n\n# Clear systemd journal logs older than 30 days\njournalctl --vacuum-time=30d\n\necho \"System cleanup complete\"",
+      "content": "#!/bin/bash\n# Clean package cache\npacman -Sc --noconfirm\n\n# Clean orphaned packages\npacman -Rns $(pacman -Qtdq) --noconfirm 2>/dev/null || echo \"No orphaned packages found\"\n\n# Clear systemd journal logs older than 30 days\njournalctl --vacuum-time=30d\n\necho \"System cleanup complete\"\n",
       "log": "{{ .User.home }}/.config/rwr/logs/system_cleanup.log"
     }
   ]

--- a/examples/linux/Arch/json/services/services.json
+++ b/examples/linux/Arch/json/services/services.json
@@ -1,13 +1,85 @@
 {
   "services": [
     {
-      "name": "docker",
+      "name": "sshd",
       "action": "enable",
       "elevated": true
     },
     {
       "name": "docker",
+      "profiles": [
+        "work"
+      ],
+      "action": "enable",
+      "elevated": true
+    },
+    {
+      "name": "docker",
+      "profiles": [
+        "work"
+      ],
       "action": "start",
+      "elevated": true
+    },
+    {
+      "name": "postgresql",
+      "profiles": [
+        "dev"
+      ],
+      "action": "enable",
+      "elevated": true
+    },
+    {
+      "name": "redis",
+      "profiles": [
+        "dev",
+        "database"
+      ],
+      "action": "enable",
+      "elevated": true
+    },
+    {
+      "name": "nginx",
+      "profiles": [
+        "work",
+        "dev"
+      ],
+      "action": "enable",
+      "elevated": true
+    },
+    {
+      "name": "bluetooth",
+      "profiles": [
+        "personal",
+        "desktop"
+      ],
+      "action": "enable",
+      "elevated": true
+    },
+    {
+      "name": "cups",
+      "profiles": [
+        "personal",
+        "office"
+      ],
+      "action": "enable",
+      "elevated": true
+    },
+    {
+      "name": "fail2ban",
+      "profiles": [
+        "security",
+        "server"
+      ],
+      "action": "enable",
+      "elevated": true
+    },
+    {
+      "name": "ufw",
+      "profiles": [
+        "security"
+      ],
+      "action": "enable",
       "elevated": true
     }
   ]

--- a/examples/linux/Arch/json/users/users.json
+++ b/examples/linux/Arch/json/users/users.json
@@ -1,12 +1,121 @@
 {
-  "ssh_keys": [
+  "users": [
     {
-      "name": "id_rsa",
-      "type": "ed25519",
-      "path": "{{ .User.home }}/.ssh/",
-      "comment": "{{ .User.username }}@github",
-      "no_passphrase": true,
-      "copy_to_github": false
+      "name": "{{ .User.username }}",
+      "action": "modify",
+      "add_groups": [
+        "wheel",
+        "users"
+      ]
+    },
+    {
+      "name": "{{ .User.username }}",
+      "profiles": [
+        "dev"
+      ],
+      "action": "modify",
+      "add_groups": [
+        "docker",
+        "developers",
+        "git"
+      ]
+    },
+    {
+      "name": "{{ .User.username }}",
+      "profiles": [
+        "work"
+      ],
+      "action": "modify",
+      "add_groups": [
+        "docker",
+        "sudo",
+        "developers"
+      ]
+    },
+    {
+      "name": "{{ .User.username }}",
+      "profiles": [
+        "gaming"
+      ],
+      "action": "modify",
+      "add_groups": [
+        "games",
+        "audio",
+        "video"
+      ]
+    },
+    {
+      "name": "developer",
+      "profiles": [
+        "dev",
+        "work"
+      ],
+      "action": "create",
+      "shell": "/bin/zsh",
+      "home": "/home/developer",
+      "groups": [
+        "developers",
+        "docker"
+      ]
+    },
+    {
+      "name": "gamer",
+      "profiles": [
+        "gaming"
+      ],
+      "action": "create",
+      "shell": "/bin/bash",
+      "home": "/home/gamer",
+      "groups": [
+        "games",
+        "audio",
+        "video"
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "name": "users",
+      "action": "create"
+    },
+    {
+      "name": "developers",
+      "profiles": [
+        "dev",
+        "work"
+      ],
+      "action": "create"
+    },
+    {
+      "name": "docker",
+      "profiles": [
+        "dev",
+        "work"
+      ],
+      "action": "create"
+    },
+    {
+      "name": "games",
+      "profiles": [
+        "gaming"
+      ],
+      "action": "create"
+    },
+    {
+      "name": "security",
+      "profiles": [
+        "security",
+        "work"
+      ],
+      "action": "create"
+    },
+    {
+      "name": "database",
+      "profiles": [
+        "database",
+        "dev"
+      ],
+      "action": "create"
     }
   ]
 }

--- a/examples/linux/Arch/toml/configuration/configuration.toml
+++ b/examples/linux/Arch/toml/configuration/configuration.toml
@@ -1,0 +1,16 @@
+[[configurations]]
+name = "interface-theme"
+action = "set"
+tool = "gsettings"
+schema = "org.gnome.desktop.interface"
+
+[configurations.settings]
+gtk-theme = "Adwaita-dark"
+color-scheme = "prefer-dark"
+
+[[configurations]]
+name = "terminal-font"
+action = "set"
+tool = "dconf"
+key = "/org/gnome/desktop/interface/monospace-font-name"
+value = "FiraCode Nerd Font 11"

--- a/examples/linux/Arch/toml/files/files.toml
+++ b/examples/linux/Arch/toml/files/files.toml
@@ -2,26 +2,176 @@
 name = ".bashrc"
 action = "create"
 target = "{{ .User.home }}/"
-content = """
-# Custom .bashrc content
-alias ll='ls -alF'
-export PATH=$PATH:$HOME/.local/bin
-"""
+content = "# Custom .bashrc content\nalias ll='ls -alF'\nalias la='ls -A'\nalias l='ls -CF'\nexport PATH=$PATH:$HOME/.local/bin\nexport EDITOR=nvim\n"
 
 [[files]]
-name = ".gitignore"
-action = "copy"
+name = ".vimrc"
+action = "create"
 target = "{{ .User.home }}/"
-source = "./src/"
+content = "\" Basic vim configuration\nset number\nset relativenumber\nset tabstop=4\nset shiftwidth=4\nset expandtab\nsyntax on\n"
+
+[[files]]
+name = ".gitconfig-work"
+profiles = [
+    "work",
+]
+action = "create"
+target = "{{ .User.home }}/"
+content = "[user]\n    name = Work User\n    email = user@company.com\n[core]\n    editor = code --wait\n[push]\n    default = simple\n"
+
+[[files]]
+name = "work-ssh-config"
+profiles = [
+    "work",
+]
+action = "copy"
+source = "./src/ssh/work_config"
+target = "{{ .User.home }}/.ssh/config"
+mode = 384
+
+[[files]]
+name = ".gitconfig-dev"
+profiles = [
+    "dev",
+]
+action = "create"
+target = "{{ .User.home }}/"
+content = "[user]\n    name = Developer\n    email = dev@personal.com\n[core]\n    editor = nvim\n[alias]\n    st = status\n    co = checkout\n    br = branch\n"
+
+[[files]]
+name = ".zshrc"
+profiles = [
+    "dev",
+    "work",
+]
+action = "create"
+target = "{{ .User.home }}/"
+content = "# Zsh configuration\nexport ZSH=\"$HOME/.oh-my-zsh\"\nZSH_THEME=\"robbyrussell\"\nplugins=(git docker kubectl)\nsource $ZSH/oh-my-zsh.sh\n"
+
+[[files]]
+name = "gamemode.ini"
+profiles = [
+    "gaming",
+]
+action = "copy"
+source = "./src/gamemode.ini"
+target = "{{ .User.home }}/.config/gamemode/"
+
+[[files]]
+name = ".aliases"
+profiles = [
+    "personal",
+]
+action = "create"
+target = "{{ .User.home }}/"
+content = "# Personal aliases\nalias music='vlc ~/Music'\nalias photos='gimp'\nalias backup='rsync -av ~/Documents/ ~/Backup/'\n"
 
 [[directories]]
 name = ".config"
-action = "copy"
-source = "./src/"
+action = "create"
 target = "{{ .User.home }}/"
+mode = 493
+
+[[directories]]
+name = ".local/bin"
+action = "create"
+target = "{{ .User.home }}/"
+mode = 493
+
+[[directories]]
+name = "work"
+profiles = [
+    "work",
+]
+action = "create"
+target = "{{ .User.home }}/"
+mode = 493
+
+[[directories]]
+name = ".ssh"
+profiles = [
+    "work",
+    "dev",
+]
+action = "create"
+target = "{{ .User.home }}/"
+mode = 448
+
+[[directories]]
+name = "projects"
+profiles = [
+    "dev",
+]
+action = "create"
+target = "{{ .User.home }}/"
+mode = 493
+
+[[directories]]
+name = ".config/nvim"
+profiles = [
+    "dev",
+]
+action = "create"
+target = "{{ .User.home }}/"
+mode = 493
+
+[[directories]]
+name = ".config/gamemode"
+profiles = [
+    "gaming",
+]
+action = "create"
+target = "{{ .User.home }}/"
+mode = 493
+
+[[directories]]
+name = "Games"
+profiles = [
+    "gaming",
+    "personal",
+]
+action = "create"
+target = "{{ .User.home }}/"
+mode = 493
 
 [[templates]]
 name = ".profile"
 action = "copy"
-source = "./src/"
+source = "./src/.profile"
 target = "{{ .User.home }}/"
+
+[[templates]]
+name = "work-environment"
+profiles = [
+    "work",
+]
+action = "copy"
+source = "./src/work-environment.j2"
+target = "{{ .User.home }}/.work-env"
+
+[templates.variables]
+company = "{{ .UserDefined.company }}"
+department = "{{ .UserDefined.department }}"
+
+[[templates]]
+name = "nvim-config"
+profiles = [
+    "dev",
+]
+action = "copy"
+source = "./src/nvim/init.lua.j2"
+target = "{{ .User.home }}/.config/nvim/init.lua"
+
+[templates.variables]
+theme = "{{ .UserDefined.editor_theme }}"
+plugins = "{{ .UserDefined.editor_plugins }}"
+
+[[templates]]
+name = "personal-scripts"
+profiles = [
+    "personal",
+]
+action = "copy"
+source = "./src/personal-scripts.j2"
+target = "{{ .User.home }}/.local/bin/personal-tools"
+mode = 493

--- a/examples/linux/Arch/toml/fonts/fonts.toml
+++ b/examples/linux/Arch/toml/fonts/fonts.toml
@@ -1,0 +1,17 @@
+[[fonts]]
+name = "FiraCode"
+action = "install"
+provider = "nerd"
+location = "user"
+
+[[fonts]]
+name = "JetBrainsMono"
+action = "install"
+provider = "nerd"
+location = "user"
+
+[[fonts]]
+names = ["Hack", "SourceCodePro"]
+action = "install"
+provider = "nerd"
+location = "system"

--- a/examples/linux/Arch/toml/git/git.toml
+++ b/examples/linux/Arch/toml/git/git.toml
@@ -1,6 +1,127 @@
 [[git]]
+name = "dotfiles"
+action = "clone"
+url = "https://github.com/user/dotfiles.git"
+path = "{{ .User.home }}/.dotfiles"
+private = false
+
+[[git]]
+name = "configs"
+action = "clone"
+url = "https://github.com/user/configs.git"
+path = "{{ .User.home }}/configs"
+private = false
+
+[[git]]
+name = "work-configs"
+profiles = [
+    "work",
+]
+action = "clone"
+url = "https://github.com/company/work-configs.git"
+path = "{{ .User.home }}/work/configs"
+private = true
+
+[[git]]
+name = "company-tools"
+profiles = [
+    "work",
+]
+action = "clone"
+url = "https://github.com/company/internal-tools.git"
+path = "{{ .User.home }}/work/tools"
+private = true
+
+[[git]]
+name = "awesome-project"
+profiles = [
+    "dev",
+]
+action = "clone"
+url = "https://github.com/user/awesome-project.git"
+path = "{{ .User.home }}/projects/awesome-project"
+private = false
+
+[[git]]
+name = "learning-rust"
+profiles = [
+    "dev",
+]
+action = "clone"
+url = "https://github.com/rust-lang/book.git"
+path = "{{ .User.home }}/projects/rust-book"
+private = false
+
+[[git]]
 name = "rwr"
+profiles = [
+    "dev",
+    "work",
+]
 action = "clone"
 url = "https://github.com/FynxLabs/rwr.git"
-path = "{{ .User.home }}/git/rwr"
+path = "{{ .User.home }}/projects/rwr"
 private = false
+
+[[git]]
+name = "gaming-configs"
+profiles = [
+    "gaming",
+]
+action = "clone"
+url = "https://github.com/user/gaming-configs.git"
+path = "{{ .User.home }}/.config/gaming"
+private = false
+
+[[git]]
+name = "game-mods"
+profiles = [
+    "gaming",
+]
+action = "clone"
+url = "https://github.com/user/game-modifications.git"
+path = "{{ .User.home }}/Games/mods"
+private = false
+
+[[git]]
+name = "personal-scripts"
+profiles = [
+    "personal",
+]
+action = "clone"
+url = "https://github.com/user/personal-scripts.git"
+path = "{{ .User.home }}/scripts"
+private = true
+
+[[git]]
+name = "photo-organizer"
+profiles = [
+    "personal",
+]
+action = "clone"
+url = "https://github.com/user/photo-organizer.git"
+path = "{{ .User.home }}/tools/photo-organizer"
+private = false
+
+[[git]]
+name = "security-tools"
+profiles = [
+    "security",
+    "work",
+]
+action = "clone"
+url = "https://github.com/security/tools.git"
+path = "{{ .User.home }}/security/tools"
+private = true
+
+[[git]]
+name = "db-migrations"
+profiles = [
+    "database",
+    "work",
+    "dev",
+]
+action = "clone"
+url = "https://github.com/company/database-migrations.git"
+path = "{{ .User.home }}/database/migrations"
+private = true

--- a/examples/linux/Arch/toml/init.toml
+++ b/examples/linux/Arch/toml/init.toml
@@ -5,6 +5,7 @@ packageManagers = [
 
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
 order = [
     "repositories",

--- a/examples/linux/Arch/toml/init.toml
+++ b/examples/linux/Arch/toml/init.toml
@@ -1,22 +1,26 @@
+packageManagers = [
+    { name = "cargo", action = "install" },
+    { name = "brew", action = "install" },
+]
+
 [blueprints]
 format = "toml"
 location = "."
 order = [
-    "bootstrap",
     "repositories",
     "packages",
     "files",
+    "fonts",
     "services",
     "git",
     "scripts",
     "users",
-    "ssh_keys"
+    "ssh_keys",
+    "configuration",
 ]
 
-[[packageManagers]]
-name = "cargo"
-action = "install"
-
-[[packageManagers]]
-name = "brew"
-action = "install"
+[variables.userDefined]
+company = "MyCompany"
+department = "Engineering"
+editor_theme = "dracula"
+editor_plugins = "basic"

--- a/examples/linux/Arch/toml/scripts/scripts.toml
+++ b/examples/linux/Arch/toml/scripts/scripts.toml
@@ -1,173 +1,95 @@
-# Base scripts - always run
 [[scripts]]
 name = "system_info"
 action = "run"
-content = """
-#!/bin/bash
-echo "System Information:"
-echo "Hostname: $(hostname)"
-echo "User: $USER"
-echo "Distribution: $(lsb_release -d | cut -f2)"
-echo "Kernel: $(uname -r)"
-"""
+content = "#!/bin/bash\necho \"System Information:\"\necho \"Hostname: $(hostname)\"\necho \"User: $USER\"\necho \"Distribution: $(lsb_release -d | cut -f2)\"\necho \"Kernel: $(uname -r)\"\n"
 log = "{{ .User.home }}/.config/rwr/logs/system_info.log"
 
 [[scripts]]
 name = "update_system"
 action = "run"
 elevated = true
-content = """
-#!/bin/bash
-echo "Updating package database..."
-pacman -Sy --noconfirm
-echo "System updated successfully"
-"""
+content = "#!/bin/bash\necho \"Updating package database...\"\npacman -Sy --noconfirm\necho \"System updated successfully\"\n"
 log = "{{ .User.home }}/.config/rwr/logs/system_update.log"
 
-# Development environment setup
 [[scripts]]
 name = "setup_dev_environment"
-profiles = ["dev", "work"]
+profiles = [
+    "dev",
+    "work",
+]
 action = "run"
-content = """
-#!/bin/bash
-# Create development directories
-mkdir -p "{{ .User.home }}/Projects"
-mkdir -p "{{ .User.home }}/Projects/personal"
-mkdir -p "{{ .User.home }}/Projects/work"
-mkdir -p "{{ .User.home }}/.local/bin"
-
-# Set up development aliases
-echo 'alias ll="ls -alF"' >> "{{ .User.home }}/.bashrc"
-echo 'alias la="ls -A"' >> "{{ .User.home }}/.bashrc"
-echo 'alias l="ls -CF"' >> "{{ .User.home }}/.bashrc"
-
-echo "Development environment setup complete"
-"""
+content = "#!/bin/bash\n# Create development directories\nmkdir -p \"{{ .User.home }}/Projects\"\nmkdir -p \"{{ .User.home }}/Projects/personal\"\nmkdir -p \"{{ .User.home }}/Projects/work\"\nmkdir -p \"{{ .User.home }}/.local/bin\"\n\n# Set up development aliases\necho 'alias ll=\"ls -alF\"' >> \"{{ .User.home }}/.bashrc\"\necho 'alias la=\"ls -A\"' >> \"{{ .User.home }}/.bashrc\"\necho 'alias l=\"ls -CF\"' >> \"{{ .User.home }}/.bashrc\"\n\necho \"Development environment setup complete\"\n"
 log = "{{ .User.home }}/.config/rwr/logs/dev_setup.log"
 
-# Install development tools from source
 [[scripts]]
 name = "install_nvm"
-profiles = ["dev", "nodejs"]
+profiles = [
+    "dev",
+    "nodejs",
+]
 action = "run"
-content = """
-#!/bin/bash
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \\. "$NVM_DIR/nvm.sh"
-nvm install --lts
-nvm use --lts
-echo "NVM and latest LTS Node.js installed"
-"""
+content = "#!/bin/bash\ncurl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash\nexport NVM_DIR=\"$HOME/.nvm\"\n[ -s \"$NVM_DIR/nvm.sh\" ] && \\. \"$NVM_DIR/nvm.sh\"\nnvm install --lts\nnvm use --lts\necho \"NVM and latest LTS Node.js installed\"\n"
 log = "{{ .User.home }}/.config/rwr/logs/nvm_install.log"
 
-# Gaming optimizations
 [[scripts]]
 name = "gaming_optimizations"
-profiles = ["gaming"]
+profiles = [
+    "gaming",
+]
 action = "run"
 elevated = true
-content = """
-#!/bin/bash
-# Enable multilib repository
-sed -i '/^#\\[multilib\\]/,/^#Include = \\/etc\\/pacman.d\\/mirrorlist/ { s/^#//; }' /etc/pacman.conf
-
-# Update package database
-pacman -Sy --noconfirm
-
-# Set up gaming group
-groupadd -f gaming
-usermod -a -G gaming "{{ .User.username }}"
-
-echo "Gaming optimizations applied"
-"""
+content = "#!/bin/bash\n# Enable multilib repository\nsed -i '/^#\\[multilib\\]/,/^#Include = \\/etc\\/pacman.d\\/mirrorlist/ { s/^#//; }' /etc/pacman.conf\n\n# Update package database\npacman -Sy --noconfirm\n\n# Set up gaming group\ngroupadd -f gaming\nusermod -a -G gaming \"{{ .User.username }}\"\n\necho \"Gaming optimizations applied\"\n"
 log = "{{ .User.home }}/.config/rwr/logs/gaming_setup.log"
 
-# Security hardening
 [[scripts]]
 name = "security_setup"
-profiles = ["security", "work"]
+profiles = [
+    "security",
+    "work",
+]
 action = "run"
 elevated = true
-content = """
-#!/bin/bash
-# Configure firewall
-systemctl enable ufw
-ufw --force enable
-ufw default deny incoming
-ufw default allow outgoing
-ufw allow ssh
-
-# Set up fail2ban
-systemctl enable fail2ban
-systemctl start fail2ban
-
-echo "Basic security setup complete"
-"""
+content = "#!/bin/bash\n# Configure firewall\nsystemctl enable ufw\nufw --force enable\nufw default deny incoming\nufw default allow outgoing\nufw allow ssh\n\n# Set up fail2ban\nsystemctl enable fail2ban\nsystemctl start fail2ban\n\necho \"Basic security setup complete\"\n"
 log = "{{ .User.home }}/.config/rwr/logs/security_setup.log"
 
-# Database setup
 [[scripts]]
 name = "setup_postgresql_user"
-profiles = ["database", "dev"]
+profiles = [
+    "database",
+    "dev",
+]
 action = "run"
 elevated = true
-content = """
-#!/bin/bash
-# Create PostgreSQL user
-sudo -u postgres createuser -s "{{ .User.username }}"
-sudo -u postgres createdb "{{ .User.username }}"
-
-echo "PostgreSQL user setup complete"
-"""
+content = "#!/bin/bash\n# Create PostgreSQL user\nsudo -u postgres createuser -s \"{{ .User.username }}\"\nsudo -u postgres createdb \"{{ .User.username }}\"\n\necho \"PostgreSQL user setup complete\"\n"
 log = "{{ .User.home }}/.config/rwr/logs/postgresql_setup.log"
 
-# External script execution
 [[scripts]]
 name = "run_custom_setup"
-profiles = ["personal"]
+profiles = [
+    "personal",
+]
 action = "run"
 source = "{{ .User.home }}/Scripts/personal_setup.sh"
 args = "--user {{ .User.username }} --home {{ .User.home }}"
 log = "{{ .User.home }}/.config/rwr/logs/custom_setup.log"
 
-# Docker setup for development
 [[scripts]]
 name = "docker_user_setup"
-profiles = ["dev", "docker"]
+profiles = [
+    "dev",
+    "docker",
+]
 action = "run"
 elevated = true
-content = """
-#!/bin/bash
-# Add user to docker group
-usermod -a -G docker "{{ .User.username }}"
-
-# Enable and start Docker service
-systemctl enable docker
-systemctl start docker
-
-echo "Docker user setup complete. Please log out and back in for group changes to take effect."
-"""
+content = "#!/bin/bash\n# Add user to docker group\nusermod -a -G docker \"{{ .User.username }}\"\n\n# Enable and start Docker service\nsystemctl enable docker\nsystemctl start docker\n\necho \"Docker user setup complete. Please log out and back in for group changes to take effect.\"\n"
 log = "{{ .User.home }}/.config/rwr/logs/docker_setup.log"
 
-# Cleanup script
 [[scripts]]
 name = "system_cleanup"
-profiles = ["maintenance"]
+profiles = [
+    "maintenance",
+]
 action = "run"
 elevated = true
-content = """
-#!/bin/bash
-# Clean package cache
-pacman -Sc --noconfirm
-
-# Clean orphaned packages
-pacman -Rns $(pacman -Qtdq) --noconfirm 2>/dev/null || echo "No orphaned packages found"
-
-# Clear systemd journal logs older than 30 days
-journalctl --vacuum-time=30d
-
-echo "System cleanup complete"
-"""
+content = "#!/bin/bash\n# Clean package cache\npacman -Sc --noconfirm\n\n# Clean orphaned packages\npacman -Rns $(pacman -Qtdq) --noconfirm 2>/dev/null || echo \"No orphaned packages found\"\n\n# Clear systemd journal logs older than 30 days\njournalctl --vacuum-time=30d\n\necho \"System cleanup complete\"\n"
 log = "{{ .User.home }}/.config/rwr/logs/system_cleanup.log"

--- a/examples/linux/Arch/toml/services/services.toml
+++ b/examples/linux/Arch/toml/services/services.toml
@@ -1,9 +1,81 @@
 [[services]]
-name = "docker"
+name = "sshd"
 action = "enable"
 elevated = true
 
 [[services]]
 name = "docker"
+profiles = [
+    "work",
+]
+action = "enable"
+elevated = true
+
+[[services]]
+name = "docker"
+profiles = [
+    "work",
+]
 action = "start"
+elevated = true
+
+[[services]]
+name = "postgresql"
+profiles = [
+    "dev",
+]
+action = "enable"
+elevated = true
+
+[[services]]
+name = "redis"
+profiles = [
+    "dev",
+    "database",
+]
+action = "enable"
+elevated = true
+
+[[services]]
+name = "nginx"
+profiles = [
+    "work",
+    "dev",
+]
+action = "enable"
+elevated = true
+
+[[services]]
+name = "bluetooth"
+profiles = [
+    "personal",
+    "desktop",
+]
+action = "enable"
+elevated = true
+
+[[services]]
+name = "cups"
+profiles = [
+    "personal",
+    "office",
+]
+action = "enable"
+elevated = true
+
+[[services]]
+name = "fail2ban"
+profiles = [
+    "security",
+    "server",
+]
+action = "enable"
+elevated = true
+
+[[services]]
+name = "ufw"
+profiles = [
+    "security",
+]
+action = "enable"
 elevated = true

--- a/examples/linux/Arch/toml/users/users.toml
+++ b/examples/linux/Arch/toml/users/users.toml
@@ -1,8 +1,114 @@
 [[users]]
 name = "{{ .User.username }}"
 action = "modify"
-add_groups = ["docker"]
+add_groups = [
+    "wheel",
+    "users",
+]
+
+[[users]]
+name = "{{ .User.username }}"
+profiles = [
+    "dev",
+]
+action = "modify"
+add_groups = [
+    "docker",
+    "developers",
+    "git",
+]
+
+[[users]]
+name = "{{ .User.username }}"
+profiles = [
+    "work",
+]
+action = "modify"
+add_groups = [
+    "docker",
+    "sudo",
+    "developers",
+]
+
+[[users]]
+name = "{{ .User.username }}"
+profiles = [
+    "gaming",
+]
+action = "modify"
+add_groups = [
+    "games",
+    "audio",
+    "video",
+]
+
+[[users]]
+name = "developer"
+profiles = [
+    "dev",
+    "work",
+]
+action = "create"
+shell = "/bin/zsh"
+home = "/home/developer"
+groups = [
+    "developers",
+    "docker",
+]
+
+[[users]]
+name = "gamer"
+profiles = [
+    "gaming",
+]
+action = "create"
+shell = "/bin/bash"
+home = "/home/gamer"
+groups = [
+    "games",
+    "audio",
+    "video",
+]
+
+[[groups]]
+name = "users"
+action = "create"
 
 [[groups]]
 name = "developers"
+profiles = [
+    "dev",
+    "work",
+]
+action = "create"
+
+[[groups]]
+name = "docker"
+profiles = [
+    "dev",
+    "work",
+]
+action = "create"
+
+[[groups]]
+name = "games"
+profiles = [
+    "gaming",
+]
+action = "create"
+
+[[groups]]
+name = "security"
+profiles = [
+    "security",
+    "work",
+]
+action = "create"
+
+[[groups]]
+name = "database"
+profiles = [
+    "database",
+    "dev",
+]
 action = "create"

--- a/examples/linux/Arch/yaml/configuration/configuration.yaml
+++ b/examples/linux/Arch/yaml/configuration/configuration.yaml
@@ -1,0 +1,13 @@
+configurations:
+- name: interface-theme
+  action: set
+  tool: gsettings
+  schema: org.gnome.desktop.interface
+  settings:
+    gtk-theme: Adwaita-dark
+    color-scheme: prefer-dark
+- name: terminal-font
+  action: set
+  tool: dconf
+  key: /org/gnome/desktop/interface/monospace-font-name
+  value: FiraCode Nerd Font 11

--- a/examples/linux/Arch/yaml/fonts/fonts.yaml
+++ b/examples/linux/Arch/yaml/fonts/fonts.yaml
@@ -1,0 +1,15 @@
+fonts:
+- name: FiraCode
+  action: install
+  provider: nerd
+  location: user
+- name: JetBrainsMono
+  action: install
+  provider: nerd
+  location: user
+- names:
+  - Hack
+  - SourceCodePro
+  action: install
+  provider: nerd
+  location: system

--- a/examples/linux/Arch/yaml/init.yaml
+++ b/examples/linux/Arch/yaml/init.yaml
@@ -1,28 +1,25 @@
 blueprints:
   format: yaml
-  location: '.'
+  location: .
   order:
-    - bootstrap
-    - repositories
-    - packages
-    - files
-    - services
-    - git
-    - scripts
-    - users
-    - ssh_keys
+  - repositories
+  - packages
+  - files
+  - fonts
+  - services
+  - git
+  - scripts
+  - users
+  - ssh_keys
+  - configuration
 packageManagers:
-  - name: cargo
-    action: install
-  - name: brew
-    action: install
-
-# Values referenced by the profile-gated templates in files/files.yaml.
-# RWR registers no template functions, so there is no `default` filter — a value a
-# template needs has to exist here (or come from an RWR_* environment variable).
+- name: cargo
+  action: install
+- name: brew
+  action: install
 variables:
   userDefined:
-    company: "MyCompany"
-    department: "Engineering"
-    editor_theme: "dracula"
-    editor_plugins: "basic"
+    company: MyCompany
+    department: Engineering
+    editor_theme: dracula
+    editor_plugins: basic

--- a/examples/linux/Arch/yaml/init.yaml
+++ b/examples/linux/Arch/yaml/init.yaml
@@ -1,5 +1,6 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
   - repositories

--- a/examples/linux/Fedora/json/configuration/configuration.json
+++ b/examples/linux/Fedora/json/configuration/configuration.json
@@ -1,0 +1,21 @@
+{
+  "configurations": [
+    {
+      "name": "interface-theme",
+      "action": "set",
+      "tool": "gsettings",
+      "schema": "org.gnome.desktop.interface",
+      "settings": {
+        "gtk-theme": "Adwaita-dark",
+        "color-scheme": "prefer-dark"
+      }
+    },
+    {
+      "name": "terminal-font",
+      "action": "set",
+      "tool": "dconf",
+      "key": "/org/gnome/desktop/interface/monospace-font-name",
+      "value": "FiraCode Nerd Font 11"
+    }
+  ]
+}

--- a/examples/linux/Fedora/json/files/files.json
+++ b/examples/linux/Fedora/json/files/files.json
@@ -4,7 +4,7 @@
       "name": ".bashrc",
       "action": "create",
       "target": "{{ .User.home }}/",
-      "content": "# Custom .bashrc content\nalias ll='ls -alF'\nexport PATH=$PATH:$HOME/.local/bin"
+      "content": "# Custom .bashrc content\nalias ll='ls -alF'\nexport PATH=$PATH:$HOME/.local/bin\n"
     },
     {
       "name": ".gitignore",
@@ -14,10 +14,12 @@
     },
     {
       "name": ".vimrc",
-      "profiles": ["dev"],
+      "profiles": [
+        "dev"
+      ],
       "action": "create",
       "target": "{{ .User.home }}/",
-      "content": "set number\nset tabstop=4\nset shiftwidth=4\nset expandtab"
+      "content": "set number\nset tabstop=4\nset shiftwidth=4\nset expandtab\n"
     }
   ],
   "directories": [
@@ -29,7 +31,9 @@
     },
     {
       "name": ".config/code",
-      "profiles": ["dev"],
+      "profiles": [
+        "dev"
+      ],
       "action": "create",
       "target": "{{ .User.home }}/",
       "mode": 493

--- a/examples/linux/Fedora/json/fonts/fonts.json
+++ b/examples/linux/Fedora/json/fonts/fonts.json
@@ -1,0 +1,25 @@
+{
+  "fonts": [
+    {
+      "name": "FiraCode",
+      "action": "install",
+      "provider": "nerd",
+      "location": "user"
+    },
+    {
+      "name": "JetBrainsMono",
+      "action": "install",
+      "provider": "nerd",
+      "location": "user"
+    },
+    {
+      "names": [
+        "Hack",
+        "SourceCodePro"
+      ],
+      "action": "install",
+      "provider": "nerd",
+      "location": "system"
+    }
+  ]
+}

--- a/examples/linux/Fedora/json/init.json
+++ b/examples/linux/Fedora/json/init.json
@@ -3,15 +3,16 @@
     "format": "json",
     "location": ".",
     "order": [
-      "bootstrap",
       "repositories",
       "packages",
       "files",
+      "fonts",
       "services",
       "git",
       "scripts",
       "users",
-      "ssh_keys"
+      "ssh_keys",
+      "configuration"
     ]
   },
   "packageManagers": [

--- a/examples/linux/Fedora/json/init.json
+++ b/examples/linux/Fedora/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "repositories",

--- a/examples/linux/Fedora/json/repositories/repositories.json
+++ b/examples/linux/Fedora/json/repositories/repositories.json
@@ -8,7 +8,9 @@
     },
     {
       "name": "vscode",
-      "profiles": ["dev"],
+      "profiles": [
+        "dev"
+      ],
       "package_manager": "dnf",
       "action": "add",
       "url": "https://packages.microsoft.com/yumrepos/vscode",
@@ -16,14 +18,18 @@
     },
     {
       "name": "docker-ce",
-      "profiles": ["docker"],
+      "profiles": [
+        "docker"
+      ],
       "package_manager": "dnf",
       "action": "add",
       "url": "https://download.docker.com/linux/fedora/docker-ce.repo"
     },
     {
       "name": "steam",
-      "profiles": ["gaming"],
+      "profiles": [
+        "gaming"
+      ],
       "package_manager": "dnf",
       "action": "add",
       "url": "https://negativo17.org/repos/fedora-steam.repo"

--- a/examples/linux/Fedora/json/scripts/scripts.json
+++ b/examples/linux/Fedora/json/scripts/scripts.json
@@ -4,20 +4,24 @@
       "name": "update_system",
       "action": "run",
       "elevated": true,
-      "content": "#!/bin/bash\ndnf update -y\necho \"System updated successfully\""
+      "content": "#!/bin/bash\ndnf update -y\necho \"System updated successfully\"\n"
     },
     {
       "name": "setup_dev_environment",
-      "profiles": ["dev"],
+      "profiles": [
+        "dev"
+      ],
       "action": "run",
-      "content": "#!/bin/bash\nmkdir -p \"{{ .User.home }}/Projects\"\necho 'alias ll=\"ls -alF\"' >> \"{{ .User.home }}/.bashrc\"\necho \"Development environment setup complete\""
+      "content": "#!/bin/bash\nmkdir -p \"{{ .User.home }}/Projects\"\necho 'alias ll=\"ls -alF\"' >> \"{{ .User.home }}/.bashrc\"\necho \"Development environment setup complete\"\n"
     },
     {
       "name": "docker_user_setup",
-      "profiles": ["docker"],
+      "profiles": [
+        "docker"
+      ],
       "action": "run",
       "elevated": true,
-      "content": "#!/bin/bash\nusermod -a -G docker \"{{ .User.username }}\"\nsystemctl enable docker\nsystemctl start docker\necho \"Docker setup complete\""
+      "content": "#!/bin/bash\nusermod -a -G docker \"{{ .User.username }}\"\nsystemctl enable docker\nsystemctl start docker\necho \"Docker setup complete\"\n"
     }
   ]
 }

--- a/examples/linux/Fedora/json/users/users.json
+++ b/examples/linux/Fedora/json/users/users.json
@@ -1,12 +1,17 @@
 {
-  "ssh_keys": [
+  "users": [
     {
-      "name": "id_rsa",
-      "type": "ed25519",
-      "path": "{{ .User.home }}/.ssh/",
-      "comment": "{{ .User.username }}@github",
-      "no_passphrase": true,
-      "copy_to_github": false
+      "name": "{{ .User.username }}",
+      "action": "modify",
+      "add_groups": [
+        "docker"
+      ]
+    }
+  ],
+  "groups": [
+    {
+      "name": "developers",
+      "action": "create"
     }
   ]
 }

--- a/examples/linux/Fedora/toml/configuration/configuration.toml
+++ b/examples/linux/Fedora/toml/configuration/configuration.toml
@@ -1,0 +1,16 @@
+[[configurations]]
+name = "interface-theme"
+action = "set"
+tool = "gsettings"
+schema = "org.gnome.desktop.interface"
+
+[configurations.settings]
+gtk-theme = "Adwaita-dark"
+color-scheme = "prefer-dark"
+
+[[configurations]]
+name = "terminal-font"
+action = "set"
+tool = "dconf"
+key = "/org/gnome/desktop/interface/monospace-font-name"
+value = "FiraCode Nerd Font 11"

--- a/examples/linux/Fedora/toml/files/files.toml
+++ b/examples/linux/Fedora/toml/files/files.toml
@@ -1,12 +1,12 @@
+templates = [
+    { name = ".profile", action = "copy", source = "./src/", target = "{{ .User.home }}/" },
+]
+
 [[files]]
 name = ".bashrc"
 action = "create"
 target = "{{ .User.home }}/"
-content = """
-# Custom .bashrc content
-alias ll='ls -alF'
-export PATH=$PATH:$HOME/.local/bin
-"""
+content = "# Custom .bashrc content\nalias ll='ls -alF'\nexport PATH=$PATH:$HOME/.local/bin\n"
 
 [[files]]
 name = ".gitignore"
@@ -14,14 +14,26 @@ action = "copy"
 target = "{{ .User.home }}/"
 source = "./src/"
 
-[[directories]]
-name = ".config"
-action = "copy"
-source = "./src/"
+[[files]]
+name = ".vimrc"
+profiles = [
+    "dev",
+]
+action = "create"
 target = "{{ .User.home }}/"
+content = "set number\nset tabstop=4\nset shiftwidth=4\nset expandtab\n"
 
-[[templates]]
-name = ".profile"
-action = "copy"
-source = "./src/"
+[[directories]]
+name = "Projects"
+action = "create"
 target = "{{ .User.home }}/"
+mode = 493
+
+[[directories]]
+name = ".config/code"
+profiles = [
+    "dev",
+]
+action = "create"
+target = "{{ .User.home }}/"
+mode = 493

--- a/examples/linux/Fedora/toml/fonts/fonts.toml
+++ b/examples/linux/Fedora/toml/fonts/fonts.toml
@@ -1,0 +1,17 @@
+[[fonts]]
+name = "FiraCode"
+action = "install"
+provider = "nerd"
+location = "user"
+
+[[fonts]]
+name = "JetBrainsMono"
+action = "install"
+provider = "nerd"
+location = "user"
+
+[[fonts]]
+names = ["Hack", "SourceCodePro"]
+action = "install"
+provider = "nerd"
+location = "system"

--- a/examples/linux/Fedora/toml/init.toml
+++ b/examples/linux/Fedora/toml/init.toml
@@ -1,22 +1,20 @@
+packageManagers = [
+    { name = "cargo", action = "install" },
+    { name = "brew", action = "install" },
+]
+
 [blueprints]
 format = "toml"
 location = "."
 order = [
-    "bootstrap",
     "repositories",
     "packages",
     "files",
+    "fonts",
     "services",
     "git",
     "scripts",
     "users",
-    "ssh_keys"
+    "ssh_keys",
+    "configuration",
 ]
-
-[[packageManagers]]
-name = "cargo"
-action = "install"
-
-[[packageManagers]]
-name = "brew"
-action = "install"

--- a/examples/linux/Fedora/toml/init.toml
+++ b/examples/linux/Fedora/toml/init.toml
@@ -5,6 +5,7 @@ packageManagers = [
 
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
 order = [
     "repositories",

--- a/examples/linux/Fedora/toml/repositories/repositories.toml
+++ b/examples/linux/Fedora/toml/repositories/repositories.toml
@@ -1,12 +1,33 @@
 [[repositories]]
+name = "rpmfusion-free"
+package_manager = "dnf"
+action = "add"
+url = "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm"
+
+[[repositories]]
 name = "vscode"
+profiles = [
+    "dev",
+]
 package_manager = "dnf"
 action = "add"
 url = "https://packages.microsoft.com/yumrepos/vscode"
 key_url = "https://packages.microsoft.com/keys/microsoft.asc"
 
 [[repositories]]
-name = "docker"
+name = "docker-ce"
+profiles = [
+    "docker",
+]
 package_manager = "dnf"
 action = "add"
 url = "https://download.docker.com/linux/fedora/docker-ce.repo"
+
+[[repositories]]
+name = "steam"
+profiles = [
+    "gaming",
+]
+package_manager = "dnf"
+action = "add"
+url = "https://negativo17.org/repos/fedora-steam.repo"

--- a/examples/linux/Fedora/toml/scripts/scripts.toml
+++ b/examples/linux/Fedora/toml/scripts/scripts.toml
@@ -1,36 +1,22 @@
-# Base system script
 [[scripts]]
 name = "update_system"
 action = "run"
 elevated = true
-content = """
-#!/bin/bash
-dnf update -y
-echo "System updated successfully"
-"""
+content = "#!/bin/bash\ndnf update -y\necho \"System updated successfully\"\n"
 
-# Development setup
 [[scripts]]
 name = "setup_dev_environment"
-profiles = ["dev"]
+profiles = [
+    "dev",
+]
 action = "run"
-content = """
-#!/bin/bash
-mkdir -p "{{ .User.home }}/Projects"
-echo 'alias ll="ls -alF"' >> "{{ .User.home }}/.bashrc"
-echo "Development environment setup complete"
-"""
+content = "#!/bin/bash\nmkdir -p \"{{ .User.home }}/Projects\"\necho 'alias ll=\"ls -alF\"' >> \"{{ .User.home }}/.bashrc\"\necho \"Development environment setup complete\"\n"
 
-# Docker setup
 [[scripts]]
 name = "docker_user_setup"
-profiles = ["docker"]
+profiles = [
+    "docker",
+]
 action = "run"
 elevated = true
-content = """
-#!/bin/bash
-usermod -a -G docker "{{ .User.username }}"
-systemctl enable docker
-systemctl start docker
-echo "Docker setup complete"
-"""
+content = "#!/bin/bash\nusermod -a -G docker \"{{ .User.username }}\"\nsystemctl enable docker\nsystemctl start docker\necho \"Docker setup complete\"\n"

--- a/examples/linux/Fedora/toml/users/users.toml
+++ b/examples/linux/Fedora/toml/users/users.toml
@@ -1,8 +1,10 @@
+groups = [
+    { name = "developers", action = "create" },
+]
+
 [[users]]
 name = "{{ .User.username }}"
 action = "modify"
-add_groups = ["docker"]
-
-[[groups]]
-name = "developers"
-action = "create"
+add_groups = [
+    "docker",
+]

--- a/examples/linux/Fedora/yaml/configuration/configuration.yaml
+++ b/examples/linux/Fedora/yaml/configuration/configuration.yaml
@@ -1,0 +1,13 @@
+configurations:
+- name: interface-theme
+  action: set
+  tool: gsettings
+  schema: org.gnome.desktop.interface
+  settings:
+    gtk-theme: Adwaita-dark
+    color-scheme: prefer-dark
+- name: terminal-font
+  action: set
+  tool: dconf
+  key: /org/gnome/desktop/interface/monospace-font-name
+  value: FiraCode Nerd Font 11

--- a/examples/linux/Fedora/yaml/fonts/fonts.yaml
+++ b/examples/linux/Fedora/yaml/fonts/fonts.yaml
@@ -1,0 +1,15 @@
+fonts:
+- name: FiraCode
+  action: install
+  provider: nerd
+  location: user
+- name: JetBrainsMono
+  action: install
+  provider: nerd
+  location: user
+- names:
+  - Hack
+  - SourceCodePro
+  action: install
+  provider: nerd
+  location: system

--- a/examples/linux/Fedora/yaml/init.yaml
+++ b/examples/linux/Fedora/yaml/init.yaml
@@ -1,5 +1,6 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
   - repositories

--- a/examples/linux/Fedora/yaml/init.yaml
+++ b/examples/linux/Fedora/yaml/init.yaml
@@ -1,18 +1,19 @@
 blueprints:
   format: yaml
-  location: '.'
+  location: .
   order:
-    - bootstrap
-    - repositories
-    - packages
-    - files
-    - services
-    - git
-    - scripts
-    - users
-    - ssh_keys
+  - repositories
+  - packages
+  - files
+  - fonts
+  - services
+  - git
+  - scripts
+  - users
+  - ssh_keys
+  - configuration
 packageManagers:
-  - name: cargo
-    action: install
-  - name: brew
-    action: install
+- name: cargo
+  action: install
+- name: brew
+  action: install

--- a/examples/linux/Ubuntu/json/configuration/configuration.json
+++ b/examples/linux/Ubuntu/json/configuration/configuration.json
@@ -1,0 +1,21 @@
+{
+  "configurations": [
+    {
+      "name": "interface-theme",
+      "action": "set",
+      "tool": "gsettings",
+      "schema": "org.gnome.desktop.interface",
+      "settings": {
+        "gtk-theme": "Adwaita-dark",
+        "color-scheme": "prefer-dark"
+      }
+    },
+    {
+      "name": "terminal-font",
+      "action": "set",
+      "tool": "dconf",
+      "key": "/org/gnome/desktop/interface/monospace-font-name",
+      "value": "FiraCode Nerd Font 11"
+    }
+  ]
+}

--- a/examples/linux/Ubuntu/json/files/files.json
+++ b/examples/linux/Ubuntu/json/files/files.json
@@ -1,34 +1,25 @@
 {
   "files": [
     {
-      "src": "/etc/apt/apt.conf.d/99custom",
-      "dest": "/etc/apt/apt.conf.d/99custom",
-      "content": "APT::Get::Assume-Yes \"true\";\nAPT::Install-Suggests \"false\";\n",
-      "mode": 420,
-      "owner": "root",
-      "group": "root"
-    },
-    {
-      "src": "~/.bashrc",
-      "dest": "{{.User.home}}/.bashrc",
-      "content": "export EDITOR=vim\nexport PATH=$PATH:~/.local/bin\nalias ll='ls -la'\nalias grep='grep --color=auto'\n",
+      "name": ".profile",
+      "action": "copy",
+      "source": "./src/.profile",
+      "target": "{{ .User.home }}",
       "mode": 420
     },
     {
-      "src": "~/.gitconfig",
-      "dest": "{{.User.home}}/.gitconfig",
-      "content": "[user]\n    name = Developer\n    email = dev@example.com\n[core]\n    editor = vim\n",
-      "profiles": ["dev"],
+      "name": ".gitignore",
+      "action": "copy",
+      "source": "./src/.gitignore",
+      "target": "{{ .User.home }}",
       "mode": 420
     },
     {
-      "src": "/etc/nginx/sites-available/default",
-      "dest": "/etc/nginx/sites-available/default",
-      "content": "server {\n    listen 80 default_server;\n    root /var/www/html;\n    index index.html;\n}\n",
-      "profiles": ["server"],
-      "mode": 420,
-      "owner": "root",
-      "group": "root"
+      "name": "testFile.txt",
+      "action": "copy",
+      "source": "./src/.config",
+      "target": "{{ .User.home }}/.config",
+      "mode": 420
     }
   ]
 }

--- a/examples/linux/Ubuntu/json/fonts/fonts.json
+++ b/examples/linux/Ubuntu/json/fonts/fonts.json
@@ -1,0 +1,25 @@
+{
+  "fonts": [
+    {
+      "name": "FiraCode",
+      "action": "install",
+      "provider": "nerd",
+      "location": "user"
+    },
+    {
+      "name": "JetBrainsMono",
+      "action": "install",
+      "provider": "nerd",
+      "location": "user"
+    },
+    {
+      "names": [
+        "Hack",
+        "SourceCodePro"
+      ],
+      "action": "install",
+      "provider": "nerd",
+      "location": "system"
+    }
+  ]
+}

--- a/examples/linux/Ubuntu/json/init.json
+++ b/examples/linux/Ubuntu/json/init.json
@@ -3,15 +3,16 @@
     "format": "json",
     "location": ".",
     "order": [
-      "bootstrap",
       "repositories",
       "packages",
       "files",
+      "fonts",
       "services",
       "git",
       "scripts",
       "users",
-      "ssh_keys"
+      "ssh_keys",
+      "configuration"
     ]
   },
   "packageManagers": [

--- a/examples/linux/Ubuntu/json/init.json
+++ b/examples/linux/Ubuntu/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "repositories",

--- a/examples/linux/Ubuntu/json/repositories/repositories.json
+++ b/examples/linux/Ubuntu/json/repositories/repositories.json
@@ -1,38 +1,24 @@
 {
   "repositories": [
     {
-      "name": "universe",
-      "uri": "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) universe",
-      "key": ""
-    },
-    {
-      "name": "multiverse",
-      "uri": "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) multiverse",
-      "key": ""
-    },
-    {
       "name": "docker",
-      "uri": "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable",
-      "key": "https://download.docker.com/linux/ubuntu/gpg",
-      "profiles": ["dev"]
+      "action": "add",
+      "package_manager": "apt",
+      "url": "https://download.docker.com/linux/ubuntu",
+      "key_url": "https://download.docker.com/linux/ubuntu/gpg",
+      "channel": "stable",
+      "component": "stable",
+      "arch": "amd64"
     },
     {
-      "name": "nodejs",
-      "uri": "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x $(lsb_release -cs) main",
-      "key": "https://deb.nodesource.com/gpgkey/nodesource.gpg.key",
-      "profiles": ["dev"]
-    },
-    {
-      "name": "multimedia",
-      "uri": "deb http://www.deb-multimedia.org $(lsb_release -cs) main non-free",
-      "key": "https://www.deb-multimedia.org/pool/main/d/deb-multimedia-keyring/deb-multimedia-keyring_2016.8.1_all.deb",
-      "profiles": ["desktop"]
-    },
-    {
-      "name": "nginx",
-      "uri": "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/ubuntu $(lsb_release -cs) nginx",
-      "key": "https://nginx.org/keys/nginx_signing.key",
-      "profiles": ["server"]
+      "name": "hashicorp",
+      "action": "add",
+      "package_manager": "apt",
+      "url": "https://apt.releases.hashicorp.com",
+      "key_url": "https://apt.releases.hashicorp.com/gpg",
+      "channel": "stable",
+      "component": "main",
+      "arch": "amd64"
     }
   ]
 }

--- a/examples/linux/Ubuntu/json/services/services.json
+++ b/examples/linux/Ubuntu/json/services/services.json
@@ -1,45 +1,19 @@
 {
   "services": [
     {
-      "names": [
-        "ufw",
-        "ssh",
-        "cron"
-      ],
-      "action": "enable"
+      "name": "ssh",
+      "action": "enable",
+      "elevated": true
     },
     {
-      "names": [
-        "docker",
-        "nginx"
-      ],
-      "profiles": ["dev"],
-      "action": "enable"
+      "name": "docker",
+      "action": "enable",
+      "elevated": true
     },
     {
-      "names": [
-        "apache2",
-        "mysql",
-        "fail2ban"
-      ],
-      "profiles": ["server"],
-      "action": "enable"
-    },
-    {
-      "names": [
-        "bluetooth",
-        "cups"
-      ],
-      "profiles": ["desktop"],
-      "action": "enable"
-    },
-    {
-      "names": [
-        "snapd",
-        "ModemManager"
-      ],
-      "profiles": ["minimal"],
-      "action": "disable"
+      "name": "ufw",
+      "action": "start",
+      "elevated": true
     }
   ]
 }

--- a/examples/linux/Ubuntu/json/users/users.json
+++ b/examples/linux/Ubuntu/json/users/users.json
@@ -1,38 +1,27 @@
 {
+  "groups": [
+    {
+      "name": "developers",
+      "action": "create"
+    }
+  ],
   "users": [
     {
-      "username": "sysadmin",
+      "name": "builder",
+      "action": "create",
       "shell": "/bin/bash",
-      "groups": ["sudo", "adm"],
-      "create_home": true
+      "home": "/home/builder",
+      "groups": [
+        "developers"
+      ]
     },
     {
-      "username": "developer",
-      "shell": "/bin/bash",
-      "groups": ["sudo", "docker", "www-data"],
-      "create_home": true,
-      "profiles": ["dev"]
-    },
-    {
-      "username": "webserver",
-      "shell": "/bin/false",
-      "groups": ["www-data"],
-      "create_home": false,
-      "profiles": ["server"]
-    },
-    {
-      "username": "backup",
-      "shell": "/bin/bash",
-      "groups": ["backup"],
-      "create_home": true,
-      "profiles": ["server"]
-    },
-    {
-      "username": "guest",
-      "shell": "/bin/bash",
-      "groups": ["users", "audio", "video"],
-      "create_home": true,
-      "profiles": ["desktop"]
+      "name": "deploy",
+      "action": "create",
+      "shell": "/usr/sbin/nologin",
+      "groups": [
+        "developers"
+      ]
     }
   ]
 }

--- a/examples/linux/Ubuntu/toml/configuration/configuration.toml
+++ b/examples/linux/Ubuntu/toml/configuration/configuration.toml
@@ -1,0 +1,16 @@
+[[configurations]]
+name = "interface-theme"
+action = "set"
+tool = "gsettings"
+schema = "org.gnome.desktop.interface"
+
+[configurations.settings]
+gtk-theme = "Adwaita-dark"
+color-scheme = "prefer-dark"
+
+[[configurations]]
+name = "terminal-font"
+action = "set"
+tool = "dconf"
+key = "/org/gnome/desktop/interface/monospace-font-name"
+value = "FiraCode Nerd Font 11"

--- a/examples/linux/Ubuntu/toml/files/files.toml
+++ b/examples/linux/Ubuntu/toml/files/files.toml
@@ -1,48 +1,20 @@
-# Basic configuration files for all Ubuntu systems
 [[files]]
-src = "/etc/apt/apt.conf.d/99custom"
-dest = "/etc/apt/apt.conf.d/99custom"
-content = """APT::Get::Assume-Yes "true";
-APT::Install-Suggests "false";
-"""
-mode = 0o644
-owner = "root"
-group = "root"
+name = ".profile"
+action = "copy"
+source = "./src/.profile"
+target = "{{ .User.home }}"
+mode = 420
 
 [[files]]
-src = "~/.bashrc"
-dest = "{{.User.home}}/.bashrc"
-content = """export EDITOR=vim
-export PATH=$PATH:~/.local/bin
-alias ll='ls -la'
-alias grep='grep --color=auto'
-"""
-mode = 0o644
+name = ".gitignore"
+action = "copy"
+source = "./src/.gitignore"
+target = "{{ .User.home }}"
+mode = 420
 
-# Development configuration for dev profile
 [[files]]
-src = "~/.gitconfig"
-dest = "{{.User.home}}/.gitconfig"
-content = """[user]
-    name = Developer
-    email = dev@example.com
-[core]
-    editor = vim
-"""
-profiles = ["dev"]
-mode = 0o644
-
-# Server configuration for server profile
-[[files]]
-src = "/etc/nginx/sites-available/default"
-dest = "/etc/nginx/sites-available/default"
-content = """server {
-    listen 80 default_server;
-    root /var/www/html;
-    index index.html;
-}
-"""
-profiles = ["server"]
-mode = 0o644
-owner = "root"
-group = "root"
+name = "testFile.txt"
+action = "copy"
+source = "./src/.config"
+target = "{{ .User.home }}/.config"
+mode = 420

--- a/examples/linux/Ubuntu/toml/fonts/fonts.toml
+++ b/examples/linux/Ubuntu/toml/fonts/fonts.toml
@@ -1,0 +1,17 @@
+[[fonts]]
+name = "FiraCode"
+action = "install"
+provider = "nerd"
+location = "user"
+
+[[fonts]]
+name = "JetBrainsMono"
+action = "install"
+provider = "nerd"
+location = "user"
+
+[[fonts]]
+names = ["Hack", "SourceCodePro"]
+action = "install"
+provider = "nerd"
+location = "system"

--- a/examples/linux/Ubuntu/toml/init.toml
+++ b/examples/linux/Ubuntu/toml/init.toml
@@ -1,22 +1,20 @@
+packageManagers = [
+    { name = "cargo", action = "install" },
+    { name = "brew", action = "install" },
+]
+
 [blueprints]
 format = "toml"
 location = "."
 order = [
-    "bootstrap",
     "repositories",
     "packages",
     "files",
+    "fonts",
     "services",
     "git",
     "scripts",
     "users",
-    "ssh_keys"
+    "ssh_keys",
+    "configuration",
 ]
-
-[[packageManagers]]
-name = "cargo"
-action = "install"
-
-[[packageManagers]]
-name = "brew"
-action = "install"

--- a/examples/linux/Ubuntu/toml/init.toml
+++ b/examples/linux/Ubuntu/toml/init.toml
@@ -5,6 +5,7 @@ packageManagers = [
 
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
 order = [
     "repositories",

--- a/examples/linux/Ubuntu/toml/repositories/repositories.toml
+++ b/examples/linux/Ubuntu/toml/repositories/repositories.toml
@@ -1,37 +1,19 @@
-# Essential repositories for all Ubuntu systems
-[[repositories]]
-name = "universe"
-uri = "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) universe"
-key = ""
-
-[[repositories]]
-name = "multiverse"
-uri = "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) multiverse"
-key = ""
-
-# Development repositories for dev profile
 [[repositories]]
 name = "docker"
-uri = "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-key = "https://download.docker.com/linux/ubuntu/gpg"
-profiles = ["dev"]
+action = "add"
+package_manager = "apt"
+url = "https://download.docker.com/linux/ubuntu"
+key_url = "https://download.docker.com/linux/ubuntu/gpg"
+channel = "stable"
+component = "stable"
+arch = "amd64"
 
 [[repositories]]
-name = "nodejs"
-uri = "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x $(lsb_release -cs) main"
-key = "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
-profiles = ["dev"]
-
-# Media repositories for desktop profile
-[[repositories]]
-name = "multimedia"
-uri = "deb http://www.deb-multimedia.org $(lsb_release -cs) main non-free"
-key = "https://www.deb-multimedia.org/pool/main/d/deb-multimedia-keyring/deb-multimedia-keyring_2016.8.1_all.deb"
-profiles = ["desktop"]
-
-# Server repositories for server profile
-[[repositories]]
-name = "nginx"
-uri = "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/ubuntu $(lsb_release -cs) nginx"
-key = "https://nginx.org/keys/nginx_signing.key"
-profiles = ["server"]
+name = "hashicorp"
+action = "add"
+package_manager = "apt"
+url = "https://apt.releases.hashicorp.com"
+key_url = "https://apt.releases.hashicorp.com/gpg"
+channel = "stable"
+component = "main"
+arch = "amd64"

--- a/examples/linux/Ubuntu/toml/services/services.toml
+++ b/examples/linux/Ubuntu/toml/services/services.toml
@@ -1,45 +1,5 @@
-# Essential services for all Ubuntu systems
-[[services]]
-names = [
-    "ufw",
-    "ssh",
-    "cron"
+services = [
+    { name = "ssh", action = "enable", elevated = true },
+    { name = "docker", action = "enable", elevated = true },
+    { name = "ufw", action = "start", elevated = true },
 ]
-action = "enable"
-
-# Development services for dev profile
-[[services]]
-names = [
-    "docker",
-    "nginx"
-]
-profiles = ["dev"]
-action = "enable"
-
-# Server services for server profile
-[[services]]
-names = [
-    "apache2",
-    "mysql",
-    "fail2ban"
-]
-profiles = ["server"]
-action = "enable"
-
-# Desktop services for desktop profile
-[[services]]
-names = [
-    "bluetooth",
-    "cups"
-]
-profiles = ["desktop"]
-action = "enable"
-
-# Disable unnecessary services on minimal systems
-[[services]]
-names = [
-    "snapd",
-    "ModemManager"
-]
-profiles = ["minimal"]
-action = "disable"

--- a/examples/linux/Ubuntu/toml/users/users.toml
+++ b/examples/linux/Ubuntu/toml/users/users.toml
@@ -1,37 +1,20 @@
-# Basic user management for all Ubuntu systems
-[[users]]
-username = "sysadmin"
-shell = "/bin/bash"
-groups = ["sudo", "adm"]
-create_home = true
-
-# Development users for dev profile
-[[users]]
-username = "developer"
-shell = "/bin/bash"
-groups = ["sudo", "docker", "www-data"]
-create_home = true
-profiles = ["dev"]
-
-# Server users for server profile
-[[users]]
-username = "webserver"
-shell = "/bin/false"
-groups = ["www-data"]
-create_home = false
-profiles = ["server"]
+groups = [
+    { name = "developers", action = "create" },
+]
 
 [[users]]
-username = "backup"
+name = "builder"
+action = "create"
 shell = "/bin/bash"
-groups = ["backup"]
-create_home = true
-profiles = ["server"]
+home = "/home/builder"
+groups = [
+    "developers",
+]
 
-# Desktop users for desktop profile
 [[users]]
-username = "guest"
-shell = "/bin/bash"
-groups = ["users", "audio", "video"]
-create_home = true
-profiles = ["desktop"]
+name = "deploy"
+action = "create"
+shell = "/usr/sbin/nologin"
+groups = [
+    "developers",
+]

--- a/examples/linux/Ubuntu/yaml/configuration/configuration.yaml
+++ b/examples/linux/Ubuntu/yaml/configuration/configuration.yaml
@@ -1,0 +1,13 @@
+configurations:
+- name: interface-theme
+  action: set
+  tool: gsettings
+  schema: org.gnome.desktop.interface
+  settings:
+    gtk-theme: Adwaita-dark
+    color-scheme: prefer-dark
+- name: terminal-font
+  action: set
+  tool: dconf
+  key: /org/gnome/desktop/interface/monospace-font-name
+  value: FiraCode Nerd Font 11

--- a/examples/linux/Ubuntu/yaml/files/files.yaml
+++ b/examples/linux/Ubuntu/yaml/files/files.yaml
@@ -1,45 +1,16 @@
-# Basic configuration files for all Ubuntu systems
 files:
-  - src: /etc/apt/apt.conf.d/99custom
-    dest: /etc/apt/apt.conf.d/99custom
-    content: |
-      APT::Get::Assume-Yes "true";
-      APT::Install-Suggests "false";
-    mode: 0644
-    owner: root
-    group: root
-
-  - src: ~/.bashrc
-    dest: "{{.User.home}}/.bashrc"
-    content: |
-      export EDITOR=vim
-      export PATH=$PATH:~/.local/bin
-      alias ll='ls -la'
-      alias grep='grep --color=auto'
-    mode: 0644
-
-  # Development configuration for dev profile
-  - src: ~/.gitconfig
-    dest: "{{.User.home}}/.gitconfig"
-    content: |
-      [user]
-          name = Developer
-          email = dev@example.com
-      [core]
-          editor = vim
-    profiles: [dev]
-    mode: 0644
-
-  # Server configuration for server profile
-  - src: /etc/nginx/sites-available/default
-    dest: /etc/nginx/sites-available/default
-    content: |
-      server {
-          listen 80 default_server;
-          root /var/www/html;
-          index index.html;
-      }
-    profiles: [server]
-    mode: 0644
-    owner: root
-    group: root
+- name: .profile
+  action: copy
+  source: ./src/.profile
+  target: '{{ .User.home }}'
+  mode: 420
+- name: .gitignore
+  action: copy
+  source: ./src/.gitignore
+  target: '{{ .User.home }}'
+  mode: 420
+- name: testFile.txt
+  action: copy
+  source: ./src/.config
+  target: '{{ .User.home }}/.config'
+  mode: 420

--- a/examples/linux/Ubuntu/yaml/fonts/fonts.yaml
+++ b/examples/linux/Ubuntu/yaml/fonts/fonts.yaml
@@ -1,0 +1,15 @@
+fonts:
+- name: FiraCode
+  action: install
+  provider: nerd
+  location: user
+- name: JetBrainsMono
+  action: install
+  provider: nerd
+  location: user
+- names:
+  - Hack
+  - SourceCodePro
+  action: install
+  provider: nerd
+  location: system

--- a/examples/linux/Ubuntu/yaml/init.yaml
+++ b/examples/linux/Ubuntu/yaml/init.yaml
@@ -1,5 +1,6 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
   - repositories

--- a/examples/linux/Ubuntu/yaml/init.yaml
+++ b/examples/linux/Ubuntu/yaml/init.yaml
@@ -1,18 +1,19 @@
 blueprints:
   format: yaml
-  location: '.'
+  location: .
   order:
-    - bootstrap
-    - repositories
-    - packages
-    - files
-    - services
-    - git
-    - scripts
-    - users
-    - ssh_keys
+  - repositories
+  - packages
+  - files
+  - fonts
+  - services
+  - git
+  - scripts
+  - users
+  - ssh_keys
+  - configuration
 packageManagers:
-  - name: cargo
-    action: install
-  - name: brew
-    action: install
+- name: cargo
+  action: install
+- name: brew
+  action: install

--- a/examples/linux/Ubuntu/yaml/repositories/repositories.yaml
+++ b/examples/linux/Ubuntu/yaml/repositories/repositories.yaml
@@ -1,32 +1,17 @@
-# Essential repositories for all Ubuntu systems
 repositories:
-  - name: universe
-    uri: "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) universe"
-    key: ""
-
-  - name: multiverse
-    uri: "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) multiverse"
-    key: ""
-
-  # Development repositories for dev profile
-  - name: docker
-    uri: "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-    key: "https://download.docker.com/linux/ubuntu/gpg"
-    profiles: [dev]
-
-  - name: nodejs
-    uri: "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x $(lsb_release -cs) main"
-    key: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
-    profiles: [dev]
-
-  # Media repositories for desktop profile
-  - name: multimedia
-    uri: "deb http://www.deb-multimedia.org $(lsb_release -cs) main non-free"
-    key: "https://www.deb-multimedia.org/pool/main/d/deb-multimedia-keyring/deb-multimedia-keyring_2016.8.1_all.deb"
-    profiles: [desktop]
-
-  # Server repositories for server profile
-  - name: nginx
-    uri: "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/ubuntu $(lsb_release -cs) nginx"
-    key: "https://nginx.org/keys/nginx_signing.key"
-    profiles: [server]
+- name: docker
+  action: add
+  package_manager: apt
+  url: https://download.docker.com/linux/ubuntu
+  key_url: https://download.docker.com/linux/ubuntu/gpg
+  channel: stable
+  component: stable
+  arch: amd64
+- name: hashicorp
+  action: add
+  package_manager: apt
+  url: https://apt.releases.hashicorp.com
+  key_url: https://apt.releases.hashicorp.com/gpg
+  channel: stable
+  component: main
+  arch: amd64

--- a/examples/linux/Ubuntu/yaml/services/services.yaml
+++ b/examples/linux/Ubuntu/yaml/services/services.yaml
@@ -1,36 +1,10 @@
-# Essential services for all Ubuntu systems
 services:
-  - names:
-      - ufw
-      - ssh
-      - cron
-    action: enable
-
-  # Development services for dev profile
-  - names:
-      - docker
-      - nginx
-    profiles: [dev]
-    action: enable
-
-  # Server services for server profile
-  - names:
-      - apache2
-      - mysql
-      - fail2ban
-    profiles: [server]
-    action: enable
-
-  # Desktop services for desktop profile
-  - names:
-      - bluetooth
-      - cups
-    profiles: [desktop]
-    action: enable
-
-  # Disable unnecessary services on minimal systems
-  - names:
-      - snapd
-      - ModemManager
-    profiles: [minimal]
-    action: disable
+- name: ssh
+  action: enable
+  elevated: true
+- name: docker
+  action: enable
+  elevated: true
+- name: ufw
+  action: start
+  elevated: true

--- a/examples/linux/Ubuntu/yaml/users/users.yaml
+++ b/examples/linux/Ubuntu/yaml/users/users.yaml
@@ -1,33 +1,15 @@
-# Basic user management for all Ubuntu systems
+groups:
+- name: developers
+  action: create
 users:
-  - username: sysadmin
-    shell: /bin/bash
-    groups: [sudo, adm]
-    create_home: true
-
-  # Development users for dev profile
-  - username: developer
-    shell: /bin/bash
-    groups: [sudo, docker, www-data]
-    create_home: true
-    profiles: [dev]
-
-  # Server users for server profile
-  - username: webserver
-    shell: /bin/false
-    groups: [www-data]
-    create_home: false
-    profiles: [server]
-
-  - username: backup
-    shell: /bin/bash
-    groups: [backup]
-    create_home: true
-    profiles: [server]
-
-  # Desktop users for desktop profile
-  - username: guest
-    shell: /bin/bash
-    groups: [users, audio, video]
-    create_home: true
-    profiles: [desktop]
+- name: builder
+  action: create
+  shell: /bin/bash
+  home: /home/builder
+  groups:
+  - developers
+- name: deploy
+  action: create
+  shell: /usr/sbin/nologin
+  groups:
+  - developers

--- a/examples/macos/json/configuration/configuration.json
+++ b/examples/macos/json/configuration/configuration.json
@@ -1,0 +1,22 @@
+{
+  "configurations": [
+    {
+      "name": "dock-autohide",
+      "action": "set",
+      "tool": "macos_defaults",
+      "domain": "com.apple.dock",
+      "key": "autohide",
+      "kind": "bool",
+      "value": true
+    },
+    {
+      "name": "show-hidden-files",
+      "action": "set",
+      "tool": "macos_defaults",
+      "domain": "com.apple.finder",
+      "key": "AppleShowAllFiles",
+      "kind": "bool",
+      "value": true
+    }
+  ]
+}

--- a/examples/macos/json/fonts/fonts.json
+++ b/examples/macos/json/fonts/fonts.json
@@ -1,0 +1,25 @@
+{
+  "fonts": [
+    {
+      "name": "FiraCode",
+      "action": "install",
+      "provider": "nerd",
+      "location": "user"
+    },
+    {
+      "name": "JetBrainsMono",
+      "action": "install",
+      "provider": "nerd",
+      "location": "user"
+    },
+    {
+      "names": [
+        "Hack",
+        "SourceCodePro"
+      ],
+      "action": "install",
+      "provider": "nerd",
+      "location": "system"
+    }
+  ]
+}

--- a/examples/macos/json/init.json
+++ b/examples/macos/json/init.json
@@ -3,13 +3,16 @@
     "format": "json",
     "location": ".",
     "order": [
-      "bootstrap",
+      "repositories",
       "packages",
       "files",
+      "fonts",
       "services",
       "git",
       "scripts",
-      "ssh_keys"
+      "users",
+      "ssh_keys",
+      "configuration"
     ]
   },
   "packageManagers": [

--- a/examples/macos/json/init.json
+++ b/examples/macos/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "repositories",

--- a/examples/macos/json/repositories/repositories.json
+++ b/examples/macos/json/repositories/repositories.json
@@ -1,0 +1,9 @@
+{
+  "repositories": [
+    {
+      "name": "homebrew/cask-fonts",
+      "action": "add",
+      "package_manager": "brew"
+    }
+  ]
+}

--- a/examples/macos/json/scripts/scripts.json
+++ b/examples/macos/json/scripts/scripts.json
@@ -1,27 +1,25 @@
 {
   "scripts": [
     {
-      "name": "update-system",
-      "content": "#!/bin/bash\nbrew update && brew upgrade\nbrew cleanup\n"
+      "name": "update_homebrew",
+      "action": "run",
+      "content": "#!/bin/bash\nbrew update && brew upgrade\necho \"Homebrew updated successfully\"\n"
     },
     {
-      "name": "setup-developer-tools",
-      "content": "#!/bin/bash\nxcode-select --install\nsudo xcodebuild -license accept\n",
-      "profiles": ["dev"]
+      "name": "setup_dev_environment",
+      "profiles": [
+        "dev"
+      ],
+      "action": "run",
+      "content": "#!/bin/bash\nmkdir -p \"{{ .User.home }}/Projects\"\necho 'alias ll=\"ls -alF\"' >> \"{{ .User.home }}/.zshrc\"\necho \"Development environment setup complete\"\n"
     },
     {
-      "name": "configure-dock",
-      "content": "#!/bin/bash\ndefaults write com.apple.dock autohide -bool true\ndefaults write com.apple.dock tilesize -int 48\nkillall Dock\n",
-      "profiles": ["desktop"]
-    },
-    {
-      "name": "setup-homebrew-permissions",
-      "content": "#!/bin/bash\nsudo chown -R $(whoami) /usr/local/var/homebrew\nsudo chmod u+w /usr/local/var/homebrew\n"
-    },
-    {
-      "name": "configure-git",
-      "content": "#!/bin/bash\ngit config --global init.defaultBranch main\ngit config --global pull.rebase false\n",
-      "profiles": ["dev"]
+      "name": "docker_setup",
+      "profiles": [
+        "docker"
+      ],
+      "action": "run",
+      "content": "#!/bin/bash\nopen /Applications/Docker.app\necho \"Docker Desktop starting...\"\n"
     }
   ]
 }

--- a/examples/macos/json/users/users.json
+++ b/examples/macos/json/users/users.json
@@ -1,0 +1,19 @@
+{
+  "groups": [
+    {
+      "name": "developers",
+      "action": "create"
+    }
+  ],
+  "users": [
+    {
+      "name": "builder",
+      "action": "create",
+      "shell": "/bin/zsh",
+      "home": "/Users/builder",
+      "groups": [
+        "developers"
+      ]
+    }
+  ]
+}

--- a/examples/macos/toml/configuration/configuration.toml
+++ b/examples/macos/toml/configuration/configuration.toml
@@ -1,0 +1,17 @@
+[[configurations]]
+name = "dock-autohide"
+action = "set"
+tool = "macos_defaults"
+domain = "com.apple.dock"
+key = "autohide"
+kind = "bool"
+value = true
+
+[[configurations]]
+name = "show-hidden-files"
+action = "set"
+tool = "macos_defaults"
+domain = "com.apple.finder"
+key = "AppleShowAllFiles"
+kind = "bool"
+value = true

--- a/examples/macos/toml/fonts/fonts.toml
+++ b/examples/macos/toml/fonts/fonts.toml
@@ -1,0 +1,17 @@
+[[fonts]]
+name = "FiraCode"
+action = "install"
+provider = "nerd"
+location = "user"
+
+[[fonts]]
+name = "JetBrainsMono"
+action = "install"
+provider = "nerd"
+location = "user"
+
+[[fonts]]
+names = ["Hack", "SourceCodePro"]
+action = "install"
+provider = "nerd"
+location = "system"

--- a/examples/macos/toml/init.toml
+++ b/examples/macos/toml/init.toml
@@ -1,20 +1,20 @@
+packageManagers = [
+    { name = "cargo", action = "install" },
+    { name = "brew", action = "install" },
+]
+
 [blueprints]
 format = "toml"
 location = "."
 order = [
-    "bootstrap",
+    "repositories",
     "packages",
     "files",
+    "fonts",
     "services",
     "git",
     "scripts",
-    "ssh_keys"
+    "users",
+    "ssh_keys",
+    "configuration",
 ]
-
-[[packageManagers]]
-name = "cargo"
-action = "install"
-
-[[packageManagers]]
-name = "brew"
-action = "install"

--- a/examples/macos/toml/init.toml
+++ b/examples/macos/toml/init.toml
@@ -5,6 +5,7 @@ packageManagers = [
 
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
 order = [
     "repositories",

--- a/examples/macos/toml/repositories/repositories.toml
+++ b/examples/macos/toml/repositories/repositories.toml
@@ -1,0 +1,4 @@
+[[repositories]]
+name = "homebrew/cask-fonts"
+action = "add"
+package_manager = "brew"

--- a/examples/macos/toml/scripts/scripts.toml
+++ b/examples/macos/toml/scripts/scripts.toml
@@ -1,41 +1,20 @@
-# Essential system scripts for all macOS systems
 [[scripts]]
-name = "update-system"
-content = """#!/bin/bash
-brew update && brew upgrade
-brew cleanup
-"""
+name = "update_homebrew"
+action = "run"
+content = "#!/bin/bash\nbrew update && brew upgrade\necho \"Homebrew updated successfully\"\n"
 
 [[scripts]]
-name = "setup-homebrew-permissions"
-content = """#!/bin/bash
-sudo chown -R $(whoami) /usr/local/var/homebrew
-sudo chmod u+w /usr/local/var/homebrew
-"""
-
-# Development setup for dev profile
-[[scripts]]
-name = "setup-developer-tools"
-content = """#!/bin/bash
-xcode-select --install
-sudo xcodebuild -license accept
-"""
-profiles = ["dev"]
+name = "setup_dev_environment"
+profiles = [
+    "dev",
+]
+action = "run"
+content = "#!/bin/bash\nmkdir -p \"{{ .User.home }}/Projects\"\necho 'alias ll=\"ls -alF\"' >> \"{{ .User.home }}/.zshrc\"\necho \"Development environment setup complete\"\n"
 
 [[scripts]]
-name = "configure-git"
-content = """#!/bin/bash
-git config --global init.defaultBranch main
-git config --global pull.rebase false
-"""
-profiles = ["dev"]
-
-# Desktop customization for desktop profile
-[[scripts]]
-name = "configure-dock"
-content = """#!/bin/bash
-defaults write com.apple.dock autohide -bool true
-defaults write com.apple.dock tilesize -int 48
-killall Dock
-"""
-profiles = ["desktop"]
+name = "docker_setup"
+profiles = [
+    "docker",
+]
+action = "run"
+content = "#!/bin/bash\nopen /Applications/Docker.app\necho \"Docker Desktop starting...\"\n"

--- a/examples/macos/toml/users/users.toml
+++ b/examples/macos/toml/users/users.toml
@@ -1,0 +1,10 @@
+[[groups]]
+name = "developers"
+action = "create"
+
+[[users]]
+name = "builder"
+action = "create"
+shell = "/bin/zsh"
+home = "/Users/builder"
+groups = ["developers"]

--- a/examples/macos/yaml/configuration/configuration.yaml
+++ b/examples/macos/yaml/configuration/configuration.yaml
@@ -1,0 +1,15 @@
+configurations:
+- name: dock-autohide
+  action: set
+  tool: macos_defaults
+  domain: com.apple.dock
+  key: autohide
+  kind: bool
+  value: true
+- name: show-hidden-files
+  action: set
+  tool: macos_defaults
+  domain: com.apple.finder
+  key: AppleShowAllFiles
+  kind: bool
+  value: true

--- a/examples/macos/yaml/fonts/fonts.yaml
+++ b/examples/macos/yaml/fonts/fonts.yaml
@@ -1,0 +1,15 @@
+fonts:
+- name: FiraCode
+  action: install
+  provider: nerd
+  location: user
+- name: JetBrainsMono
+  action: install
+  provider: nerd
+  location: user
+- names:
+  - Hack
+  - SourceCodePro
+  action: install
+  provider: nerd
+  location: system

--- a/examples/macos/yaml/init.yaml
+++ b/examples/macos/yaml/init.yaml
@@ -1,16 +1,19 @@
 blueprints:
   format: yaml
-  location: '.'
+  location: .
   order:
-    - bootstrap
-    - packages
-    - files
-    - services
-    - git
-    - scripts
-    - ssh_keys
+  - repositories
+  - packages
+  - files
+  - fonts
+  - services
+  - git
+  - scripts
+  - users
+  - ssh_keys
+  - configuration
 packageManagers:
-  - name: cargo
-    action: install
-  - name: brew
-    action: install
+- name: cargo
+  action: install
+- name: brew
+  action: install

--- a/examples/macos/yaml/init.yaml
+++ b/examples/macos/yaml/init.yaml
@@ -1,5 +1,6 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
   - repositories

--- a/examples/macos/yaml/repositories/repositories.yaml
+++ b/examples/macos/yaml/repositories/repositories.yaml
@@ -1,0 +1,4 @@
+repositories:
+- name: homebrew/cask-fonts
+  action: add
+  package_manager: brew

--- a/examples/macos/yaml/users/users.yaml
+++ b/examples/macos/yaml/users/users.yaml
@@ -1,0 +1,10 @@
+groups:
+- name: developers
+  action: create
+users:
+- name: builder
+  action: create
+  shell: /bin/zsh
+  home: /Users/builder
+  groups:
+  - developers

--- a/examples/windows/json/configuration/configuration.json
+++ b/examples/windows/json/configuration/configuration.json
@@ -1,0 +1,14 @@
+{
+  "configurations": [
+    {
+      "name": "show-file-extensions",
+      "action": "set",
+      "tool": "windows_registry",
+      "elevated": true,
+      "path": "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced",
+      "key": "HideFileExt",
+      "type": "dword",
+      "value": 0
+    }
+  ]
+}

--- a/examples/windows/json/files/files.json
+++ b/examples/windows/json/files/files.json
@@ -1,36 +1,17 @@
 {
   "files": [
     {
-      "src": "C:\\Windows\\System32\\drivers\\etc\\hosts",
-      "dest": "C:\\Windows\\System32\\drivers\\etc\\hosts",
-      "content": "127.0.0.1       localhost\n::1             localhost\n",
+      "name": ".gitignore",
+      "action": "copy",
+      "source": "./src/.gitignore",
+      "target": "{{ .User.home }}",
       "mode": 420
     },
     {
-      "src": "C:\\ProgramData\\chocolatey\\config\\chocolatey.config",
-      "dest": "C:\\ProgramData\\chocolatey\\config\\chocolatey.config",
-      "content": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<chocolatey>\n  <config>\n    <add key=\"cacheLocation\" value=\"C:\\temp\\chocolatey\" />\n  </config>\n</chocolatey>\n",
-      "mode": 420
-    },
-    {
-      "src": "C:\\Users\\{{.User.username}}\\.gitconfig",
-      "dest": "C:\\Users\\{{.User.username}}\\.gitconfig",
-      "content": "[user]\n    name = Developer\n    email = dev@example.com\n[core]\n    autocrlf = true\n    editor = code\n",
-      "profiles": ["dev"],
-      "mode": 420
-    },
-    {
-      "src": "C:\\Users\\{{.User.username}}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1",
-      "dest": "C:\\Users\\{{.User.username}}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1",
-      "content": "Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned\nSet-Alias -Name ll -Value Get-ChildItem\n",
-      "profiles": ["work"],
-      "mode": 420
-    },
-    {
-      "src": "C:\\Users\\{{.User.username}}\\AppData\\Local\\Steam\\config\\config.vdf",
-      "dest": "C:\\Users\\{{.User.username}}\\AppData\\Local\\Steam\\config\\config.vdf",
-      "content": "\"InstallConfigStore\"\n{\n    \"Software\"\n    {\n        \"valve\"\n        {\n            \"Steam\"\n            {\n                \"AutoLaunchGameListOnStart\"    \"0\"\n            }\n        }\n    }\n}\n",
-      "profiles": ["gaming"],
+      "name": "testFile.txt",
+      "action": "copy",
+      "source": "./src/.config",
+      "target": "{{ .User.home }}/.config",
       "mode": 420
     }
   ]

--- a/examples/windows/json/fonts/fonts.json
+++ b/examples/windows/json/fonts/fonts.json
@@ -1,0 +1,25 @@
+{
+  "fonts": [
+    {
+      "name": "FiraCode",
+      "action": "install",
+      "provider": "nerd",
+      "location": "user"
+    },
+    {
+      "name": "JetBrainsMono",
+      "action": "install",
+      "provider": "nerd",
+      "location": "user"
+    },
+    {
+      "names": [
+        "Hack",
+        "SourceCodePro"
+      ],
+      "action": "install",
+      "provider": "nerd",
+      "location": "system"
+    }
+  ]
+}

--- a/examples/windows/json/init.json
+++ b/examples/windows/json/init.json
@@ -3,13 +3,16 @@
     "format": "json",
     "location": ".",
     "order": [
-      "bootstrap",
+      "repositories",
       "packages",
       "files",
+      "fonts",
       "services",
       "git",
       "scripts",
-      "ssh_keys"
+      "users",
+      "ssh_keys",
+      "configuration"
     ]
   },
   "packageManagers": [

--- a/examples/windows/json/init.json
+++ b/examples/windows/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "repositories",

--- a/examples/windows/json/repositories/repositories.json
+++ b/examples/windows/json/repositories/repositories.json
@@ -1,0 +1,9 @@
+{
+  "repositories": [
+    {
+      "name": "extras",
+      "action": "add",
+      "package_manager": "scoop"
+    }
+  ]
+}

--- a/examples/windows/json/services/services.json
+++ b/examples/windows/json/services/services.json
@@ -1,45 +1,14 @@
 {
   "services": [
     {
-      "names": [
-        "Themes",
-        "Windows Update",
-        "Windows Defender Antivirus Service"
-      ],
-      "action": "enable"
+      "name": "sshd",
+      "action": "enable",
+      "elevated": true
     },
     {
-      "names": [
-        "Docker Desktop Service",
-        "Windows Subsystem for Linux"
-      ],
-      "profiles": ["dev"],
-      "action": "enable"
-    },
-    {
-      "names": [
-        "Remote Desktop Services",
-        "Windows Remote Management"
-      ],
-      "profiles": ["work"],
-      "action": "enable"
-    },
-    {
-      "names": [
-        "Xbox Live Auth Manager",
-        "Xbox Live Game Save"
-      ],
-      "profiles": ["gaming"],
-      "action": "enable"
-    },
-    {
-      "names": [
-        "Windows Search",
-        "Print Spooler",
-        "Fax"
-      ],
-      "profiles": ["minimal"],
-      "action": "disable"
+      "name": "W32Time",
+      "action": "start",
+      "elevated": true
     }
   ]
 }

--- a/examples/windows/json/users/users.json
+++ b/examples/windows/json/users/users.json
@@ -1,39 +1,17 @@
 {
+  "groups": [
+    {
+      "name": "Developers",
+      "action": "create"
+    }
+  ],
   "users": [
     {
-      "username": "Administrator",
-      "groups": ["Administrators"],
-      "create_home": false
-    },
-    {
-      "username": "Guest",
-      "groups": ["Guests"],
-      "create_home": false,
-      "enabled": false
-    },
-    {
-      "username": "developer",
-      "groups": ["Administrators", "Remote Desktop Users"],
-      "create_home": true,
-      "profiles": ["dev"]
-    },
-    {
-      "username": "remote_worker",
-      "groups": ["Remote Desktop Users", "Users"],
-      "create_home": true,
-      "profiles": ["work"]
-    },
-    {
-      "username": "service_account",
-      "groups": ["Log on as a service"],
-      "create_home": false,
-      "profiles": ["work"]
-    },
-    {
-      "username": "gamer",
-      "groups": ["Users", "Performance Log Users"],
-      "create_home": true,
-      "profiles": ["gaming"]
+      "name": "builder",
+      "action": "create",
+      "groups": [
+        "Developers"
+      ]
     }
   ]
 }

--- a/examples/windows/toml/configuration/configuration.toml
+++ b/examples/windows/toml/configuration/configuration.toml
@@ -1,0 +1,9 @@
+[[configurations]]
+name = "show-file-extensions"
+action = "set"
+tool = "windows_registry"
+elevated = true
+path = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced"
+key = "HideFileExt"
+type = "dword"
+value = 0

--- a/examples/windows/toml/files/files.toml
+++ b/examples/windows/toml/files/files.toml
@@ -1,65 +1,13 @@
-# Basic configuration files for all Windows systems
 [[files]]
-src = "C:\\Windows\\System32\\drivers\\etc\\hosts"
-dest = "C:\\Windows\\System32\\drivers\\etc\\hosts"
-content = """127.0.0.1       localhost
-::1             localhost
-"""
-mode = 0o644
+name = ".gitignore"
+action = "copy"
+source = "./src/.gitignore"
+target = "{{ .User.home }}"
+mode = 420
 
 [[files]]
-src = "C:\\ProgramData\\chocolatey\\config\\chocolatey.config"
-dest = "C:\\ProgramData\\chocolatey\\config\\chocolatey.config"
-content = """<?xml version="1.0" encoding="utf-8"?>
-<chocolatey>
-  <config>
-    <add key="cacheLocation" value="C:\\temp\\chocolatey" />
-  </config>
-</chocolatey>
-"""
-mode = 0o644
-
-# Development configuration for dev profile
-[[files]]
-src = "C:\\Users\\{{.User.username}}\\.gitconfig"
-dest = "C:\\Users\\{{.User.username}}\\.gitconfig"
-content = """[user]
-    name = Developer
-    email = dev@example.com
-[core]
-    autocrlf = true
-    editor = code
-"""
-profiles = ["dev"]
-mode = 0o644
-
-# Work configuration for work profile
-[[files]]
-src = "C:\\Users\\{{.User.username}}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1"
-dest = "C:\\Users\\{{.User.username}}\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1"
-content = """Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
-Set-Alias -Name ll -Value Get-ChildItem
-"""
-profiles = ["work"]
-mode = 0o644
-
-# Gaming configuration for gaming profile
-[[files]]
-src = "C:\\Users\\{{.User.username}}\\AppData\\Local\\Steam\\config\\config.vdf"
-dest = "C:\\Users\\{{.User.username}}\\AppData\\Local\\Steam\\config\\config.vdf"
-content = """"InstallConfigStore"
-{
-    "Software"
-    {
-        "valve"
-        {
-            "Steam"
-            {
-                "AutoLaunchGameListOnStart"    "0"
-            }
-        }
-    }
-}
-"""
-profiles = ["gaming"]
-mode = 0o644
+name = "testFile.txt"
+action = "copy"
+source = "./src/.config"
+target = "{{ .User.home }}/.config"
+mode = 420

--- a/examples/windows/toml/fonts/fonts.toml
+++ b/examples/windows/toml/fonts/fonts.toml
@@ -1,0 +1,17 @@
+[[fonts]]
+name = "FiraCode"
+action = "install"
+provider = "nerd"
+location = "user"
+
+[[fonts]]
+name = "JetBrainsMono"
+action = "install"
+provider = "nerd"
+location = "user"
+
+[[fonts]]
+names = ["Hack", "SourceCodePro"]
+action = "install"
+provider = "nerd"
+location = "system"

--- a/examples/windows/toml/init.toml
+++ b/examples/windows/toml/init.toml
@@ -5,6 +5,7 @@ packageManagers = [
 
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
 order = [
     "repositories",

--- a/examples/windows/toml/init.toml
+++ b/examples/windows/toml/init.toml
@@ -1,22 +1,20 @@
+packageManagers = [
+    { name = "cargo", action = "install" },
+    { name = "chocolatey", action = "install" },
+]
+
 [blueprints]
 format = "toml"
 location = "."
 order = [
-    "bootstrap",
     "repositories",
     "packages",
     "files",
+    "fonts",
     "services",
     "git",
     "scripts",
     "users",
-    "ssh_keys"
+    "ssh_keys",
+    "configuration",
 ]
-
-[[packageManagers]]
-name = "cargo"
-action = "install"
-
-[[packageManagers]]
-name = "chocolatey"
-action = "install"

--- a/examples/windows/toml/repositories/repositories.toml
+++ b/examples/windows/toml/repositories/repositories.toml
@@ -1,0 +1,3 @@
+repositories = [
+    { name = "extras", action = "add", package_manager = "scoop" },
+]

--- a/examples/windows/toml/services/services.toml
+++ b/examples/windows/toml/services/services.toml
@@ -1,45 +1,4 @@
-# Essential services for all Windows systems
-[[services]]
-names = [
-    "Themes",
-    "Windows Update",
-    "Windows Defender Antivirus Service"
+services = [
+    { name = "sshd", action = "enable", elevated = true },
+    { name = "W32Time", action = "start", elevated = true },
 ]
-action = "enable"
-
-# Development services for dev profile
-[[services]]
-names = [
-    "Docker Desktop Service",
-    "Windows Subsystem for Linux"
-]
-profiles = ["dev"]
-action = "enable"
-
-# Work services for work profile
-[[services]]
-names = [
-    "Remote Desktop Services",
-    "Windows Remote Management"
-]
-profiles = ["work"]
-action = "enable"
-
-# Gaming services for gaming profile
-[[services]]
-names = [
-    "Xbox Live Auth Manager",
-    "Xbox Live Game Save"
-]
-profiles = ["gaming"]
-action = "enable"
-
-# Disable unnecessary services on minimal systems
-[[services]]
-names = [
-    "Windows Search",
-    "Print Spooler",
-    "Fax"
-]
-profiles = ["minimal"]
-action = "disable"

--- a/examples/windows/toml/users/users.toml
+++ b/examples/windows/toml/users/users.toml
@@ -1,38 +1,10 @@
-# Basic user management for all Windows systems
-[[users]]
-username = "Administrator"
-groups = ["Administrators"]
-create_home = false
+groups = [
+    { name = "Developers", action = "create" },
+]
 
 [[users]]
-username = "Guest"
-groups = ["Guests"]
-create_home = false
-enabled = false
-
-# Development users for dev profile
-[[users]]
-username = "developer"
-groups = ["Administrators", "Remote Desktop Users"]
-create_home = true
-profiles = ["dev"]
-
-# Work users for work profile
-[[users]]
-username = "remote_worker"
-groups = ["Remote Desktop Users", "Users"]
-create_home = true
-profiles = ["work"]
-
-[[users]]
-username = "service_account"
-groups = ["Log on as a service"]
-create_home = false
-profiles = ["work"]
-
-# Gaming users for gaming profile
-[[users]]
-username = "gamer"
-groups = ["Users", "Performance Log Users"]
-create_home = true
-profiles = ["gaming"]
+name = "builder"
+action = "create"
+groups = [
+    "Developers",
+]

--- a/examples/windows/yaml/configuration/configuration.yaml
+++ b/examples/windows/yaml/configuration/configuration.yaml
@@ -1,0 +1,9 @@
+configurations:
+- name: show-file-extensions
+  action: set
+  tool: windows_registry
+  elevated: true
+  path: SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+  key: HideFileExt
+  type: dword
+  value: 0

--- a/examples/windows/yaml/files/files.yaml
+++ b/examples/windows/yaml/files/files.yaml
@@ -1,61 +1,11 @@
-# Basic configuration files for all Windows systems
 files:
-  - src: C:\Windows\System32\drivers\etc\hosts
-    dest: C:\Windows\System32\drivers\etc\hosts
-    content: |
-      127.0.0.1       localhost
-      ::1             localhost
-    mode: 0644
-
-  - src: C:\ProgramData\chocolatey\config\chocolatey.config
-    dest: C:\ProgramData\chocolatey\config\chocolatey.config
-    content: |
-      <?xml version="1.0" encoding="utf-8"?>
-      <chocolatey>
-        <config>
-          <add key="cacheLocation" value="C:\temp\chocolatey" />
-        </config>
-      </chocolatey>
-    mode: 0644
-
-  # Development configuration for dev profile
-  - src: C:\Users\{{.User.username}}\.gitconfig
-    dest: C:\Users\{{.User.username}}\.gitconfig
-    content: |
-      [user]
-          name = Developer
-          email = dev@example.com
-      [core]
-          autocrlf = true
-          editor = code
-    profiles: [dev]
-    mode: 0644
-
-  # Work configuration for work profile
-  - src: C:\Users\{{.User.username}}\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
-    dest: C:\Users\{{.User.username}}\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
-    content: |
-      Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
-      Set-Alias -Name ll -Value Get-ChildItem
-    profiles: [work]
-    mode: 0644
-
-  # Gaming configuration for gaming profile
-  - src: C:\Users\{{.User.username}}\AppData\Local\Steam\config\config.vdf
-    dest: C:\Users\{{.User.username}}\AppData\Local\Steam\config\config.vdf
-    content: |
-      "InstallConfigStore"
-      {
-          "Software"
-          {
-              "valve"
-              {
-                  "Steam"
-                  {
-                      "AutoLaunchGameListOnStart"		"0"
-                  }
-              }
-          }
-      }
-    profiles: [gaming]
-    mode: 0644
+- name: .gitignore
+  action: copy
+  source: ./src/.gitignore
+  target: '{{ .User.home }}'
+  mode: 420
+- name: testFile.txt
+  action: copy
+  source: ./src/.config
+  target: '{{ .User.home }}/.config'
+  mode: 420

--- a/examples/windows/yaml/fonts/fonts.yaml
+++ b/examples/windows/yaml/fonts/fonts.yaml
@@ -1,0 +1,15 @@
+fonts:
+- name: FiraCode
+  action: install
+  provider: nerd
+  location: user
+- name: JetBrainsMono
+  action: install
+  provider: nerd
+  location: user
+- names:
+  - Hack
+  - SourceCodePro
+  action: install
+  provider: nerd
+  location: system

--- a/examples/windows/yaml/init.yaml
+++ b/examples/windows/yaml/init.yaml
@@ -1,16 +1,19 @@
 blueprints:
   format: yaml
-  location: '.'
+  location: .
   order:
-    - bootstrap
-    - packages
-    - files
-    - services
-    - git
-    - scripts
-    - ssh_keys
+  - repositories
+  - packages
+  - files
+  - fonts
+  - services
+  - git
+  - scripts
+  - users
+  - ssh_keys
+  - configuration
 packageManagers:
-  - name: cargo
-    action: install
-  - name: chocolatey
-    action: install
+- name: cargo
+  action: install
+- name: chocolatey
+  action: install

--- a/examples/windows/yaml/init.yaml
+++ b/examples/windows/yaml/init.yaml
@@ -1,5 +1,6 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
   - repositories

--- a/examples/windows/yaml/repositories/repositories.yaml
+++ b/examples/windows/yaml/repositories/repositories.yaml
@@ -1,0 +1,4 @@
+repositories:
+- name: extras
+  action: add
+  package_manager: scoop

--- a/examples/windows/yaml/services/services.yaml
+++ b/examples/windows/yaml/services/services.yaml
@@ -1,36 +1,7 @@
-# Essential services for all Windows systems
 services:
-  - names:
-      - Themes
-      - Windows Update
-      - Windows Defender Antivirus Service
-    action: enable
-
-  # Development services for dev profile
-  - names:
-      - Docker Desktop Service
-      - Windows Subsystem for Linux
-    profiles: [dev]
-    action: enable
-
-  # Work services for work profile
-  - names:
-      - Remote Desktop Services
-      - Windows Remote Management
-    profiles: [work]
-    action: enable
-
-  # Gaming services for gaming profile
-  - names:
-      - Xbox Live Auth Manager
-      - Xbox Live Game Save
-    profiles: [gaming]
-    action: enable
-
-  # Disable unnecessary services on minimal systems
-  - names:
-      - Windows Search
-      - Print Spooler
-      - Fax
-    profiles: [minimal]
-    action: disable
+- name: sshd
+  action: enable
+  elevated: true
+- name: W32Time
+  action: start
+  elevated: true

--- a/examples/windows/yaml/users/users.yaml
+++ b/examples/windows/yaml/users/users.yaml
@@ -1,33 +1,8 @@
-# Basic user management for all Windows systems
+groups:
+- name: Developers
+  action: create
 users:
-  - username: Administrator
-    groups: [Administrators]
-    create_home: false
-
-  - username: Guest
-    groups: [Guests]
-    create_home: false
-    enabled: false
-
-  # Development users for dev profile
-  - username: developer
-    groups: [Administrators, "Remote Desktop Users"]
-    create_home: true
-    profiles: [dev]
-
-  # Work users for work profile
-  - username: remote_worker
-    groups: ["Remote Desktop Users", Users]
-    create_home: true
-    profiles: [work]
-
-  - username: service_account
-    groups: ["Log on as a service"]
-    create_home: false
-    profiles: [work]
-
-  # Gaming users for gaming profile
-  - username: gamer
-    groups: [Users, "Performance Log Users"]
-    create_home: true
-    profiles: [gaming]
+- name: builder
+  action: create
+  groups:
+  - Developers

--- a/internal/helpers/schema.go
+++ b/internal/helpers/schema.go
@@ -1,0 +1,56 @@
+package helpers
+
+import (
+	"fmt"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// DecodeBlueprint reads a blueprint file as the schema version it is written in.
+//
+// The version is resolved most-specific-first — the file's own `schema_version`,
+// then the tree-wide version from the init file, then v1 — and that decides which
+// struct the bytes are decoded into. The result is converted to the canonical
+// type the processors consume, so nothing past this function needs to know more
+// than one version exists.
+//
+// treeVersion is initConfig.Init.SchemaVersion; pass 0 when unknown.
+func DecodeBlueprint(data []byte, format, blueprintType string, treeVersion int) (interface{}, int, error) {
+	// Read the declaration first, using the current schema. Every version so far
+	// carries schema_version in the same place, which is the one part of the
+	// format that cannot move.
+	declared, err := declaredSchemaVersion(data, format)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	version := types.ResolveSchemaVersion(declared, treeVersion, blueprintType)
+	if err := types.ValidateSchemaVersion(blueprintType, version); err != nil {
+		return nil, version, err
+	}
+
+	variant, err := types.NewSchemaVariant(blueprintType, version)
+	if err != nil {
+		return nil, version, err
+	}
+
+	if err := UnmarshalBlueprint(data, format, variant.Target()); err != nil {
+		return nil, version, fmt.Errorf("reading %s blueprint as schema v%d: %w",
+			blueprintType, version, err)
+	}
+
+	return variant.Canonical(), version, nil
+}
+
+// declaredSchemaVersion reads just the schema_version key, ignoring everything
+// else, so a file written in a version this build cannot read still reports which
+// version it wanted.
+func declaredSchemaVersion(data []byte, format string) (int, error) {
+	var probe types.SchemaVersion
+	if err := UnmarshalBlueprint(data, format, &probe); err != nil {
+		// The file is malformed; report that against the real schema rather than
+		// this probe, which produces a clearer message.
+		return 0, nil //nolint:nilerr // deliberate: surfaced by the real decode below
+	}
+	return probe.DeclaredVersion(), nil
+}

--- a/internal/helpers/schema_test.go
+++ b/internal/helpers/schema_test.go
@@ -1,0 +1,104 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+const v1Packages = `
+packages:
+  - name: git
+    action: install
+`
+
+// A blueprint that declares nothing is v1, in every format. This is the
+// compatibility guarantee: versioning cannot change how existing trees are read.
+func TestDecodeBlueprint_UndeclaredIsReadAsV1(t *testing.T) {
+	bodies := map[string]string{
+		"yaml": v1Packages,
+		"json": `{"packages":[{"name":"git","action":"install"}]}`,
+		"toml": "[[packages]]\nname = \"git\"\naction = \"install\"\n",
+	}
+
+	for format, body := range bodies {
+		t.Run(format, func(t *testing.T) {
+			out, version, err := DecodeBlueprint([]byte(body), format, types.BlueprintTypePackages, 0)
+			if err != nil {
+				t.Fatalf("DecodeBlueprint: %v", err)
+			}
+			if version != 1 {
+				t.Errorf("resolved version = %d, want 1", version)
+			}
+			pkgs, ok := out.(*types.PackagesData)
+			if !ok {
+				t.Fatalf("got %T, want *types.PackagesData", out)
+			}
+			if len(pkgs.Packages) != 1 || pkgs.Packages[0].Name != "git" {
+				t.Errorf("decoded content is wrong: %+v", pkgs.Packages)
+			}
+		})
+	}
+}
+
+// The tree-wide version from the init file applies when a file says nothing.
+func TestDecodeBlueprint_TreeVersionApplies(t *testing.T) {
+	_, version, err := DecodeBlueprint([]byte(v1Packages), "yaml", types.BlueprintTypePackages, 1)
+	if err != nil {
+		t.Fatalf("DecodeBlueprint: %v", err)
+	}
+	if version != 1 {
+		t.Errorf("resolved version = %d, want 1", version)
+	}
+}
+
+// A file declaring a version this build cannot read must fail loudly, naming the
+// version it wanted. Reading it as v1 would silently misinterpret its fields.
+func TestDecodeBlueprint_UnknownVersionIsRejected(t *testing.T) {
+	body := "schema_version: 99\npackages:\n  - name: git\n    action: install\n"
+
+	_, version, err := DecodeBlueprint([]byte(body), "yaml", types.BlueprintTypePackages, 0)
+	if err == nil {
+		t.Fatal("a blueprint declaring schema v99 must be rejected, not read as v1")
+	}
+	if version != 99 {
+		t.Errorf("reported version = %d, want the 99 the file asked for", version)
+	}
+	for _, want := range []string{"packages", "99", "upgrade rwr"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err, want)
+		}
+	}
+}
+
+// A file's declaration overrides the tree, which is what lets one resource type
+// move to a new version while the rest of the tree stays put.
+func TestDecodeBlueprint_FileOverridesTree(t *testing.T) {
+	body := "schema_version: 1\npackages:\n  - name: git\n    action: install\n"
+
+	// Tree says 99; the file says 1 and wins, so this decodes rather than failing.
+	_, version, err := DecodeBlueprint([]byte(body), "yaml", types.BlueprintTypePackages, 99)
+	if err != nil {
+		t.Fatalf("the file's own version should win over the tree: %v", err)
+	}
+	if version != 1 {
+		t.Errorf("resolved version = %d, want 1 from the file", version)
+	}
+}
+
+// Every registered blueprint type must round-trip its v1 decoder, so no type is
+// left without a schema when versioning is enforced.
+func TestSchemaRegistry_CoversEveryBlueprintType(t *testing.T) {
+	for _, blueprintType := range []string{
+		types.BlueprintTypePackages, types.BlueprintTypeRepositories,
+		types.BlueprintTypeFiles, types.BlueprintTypeServices,
+		types.BlueprintTypeGit, types.BlueprintTypeScripts,
+		types.BlueprintTypeSSHKeys, types.BlueprintTypeFonts,
+		types.BlueprintTypeUsers, types.BlueprintTypeConfiguration,
+	} {
+		if !types.HasSchemaVariant(blueprintType, 1) {
+			t.Errorf("%s has no v1 schema registered", blueprintType)
+		}
+	}
+}

--- a/internal/types/blueprints.go
+++ b/internal/types/blueprints.go
@@ -5,7 +5,12 @@
 package types
 
 type Init struct {
-	Format           string        `mapstructure:"format" yaml:"format" json:"format" toml:"format"`
+	Format string `mapstructure:"format" yaml:"format" json:"format" toml:"format"`
+	// SchemaVersion is the blueprint schema version this tree is written in. It
+	// applies to every blueprint type, and an individual blueprint file may
+	// override it by declaring its own. Zero means undeclared, which resolves to
+	// types.DefaultSchemaVersion.
+	SchemaVersion    int           `mapstructure:"schema_version,omitempty" yaml:"schema_version,omitempty" json:"schema_version,omitempty" toml:"schema_version,omitempty"`
 	Location         string        `mapstructure:"location,omitempty" yaml:"location,omitempty" json:"location,omitempty" toml:"location,omitempty"`
 	Order            []interface{} `mapstructure:"order,omitempty" yaml:"order,omitempty" json:"order,omitempty" toml:"order,omitempty"`
 	Git              *GitOptions   `mapstructure:"git,omitempty" yaml:"git,omitempty" json:"git,omitempty" toml:"git,omitempty"`

--- a/internal/types/configuration.go
+++ b/internal/types/configuration.go
@@ -19,5 +19,7 @@ type Configuration struct {
 }
 
 type ConfigData struct {
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion  `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
 	Configurations []Configuration `mapstructure:"configurations" yaml:"configurations" json:"configurations" toml:"configurations"`
 }

--- a/internal/types/file.go
+++ b/internal/types/file.go
@@ -33,9 +33,11 @@ type Directory struct {
 }
 
 type FileData struct {
-	Files       []File      `yaml:"files" json:"files" toml:"files"`
-	Templates   []File      `yaml:"templates" json:"templates" toml:"templates"`
-	Directories []Directory `yaml:"directories" json:"directories" toml:"directories"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Files         []File      `yaml:"files" json:"files" toml:"files"`
+	Templates     []File      `yaml:"templates" json:"templates" toml:"templates"`
+	Directories   []Directory `yaml:"directories" json:"directories" toml:"directories"`
 }
 
 // GetProfiles returns the profiles for this file.

--- a/internal/types/fonts.go
+++ b/internal/types/fonts.go
@@ -9,5 +9,7 @@ type Font struct {
 }
 
 type FontsData struct {
-	Fonts []Font `yaml:"fonts" json:"fonts" toml:"fonts"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Fonts         []Font `yaml:"fonts" json:"fonts" toml:"fonts"`
 }

--- a/internal/types/git.go
+++ b/internal/types/git.go
@@ -21,7 +21,9 @@ type Git struct {
 }
 
 type GitData struct {
-	Repos []Git `mapstructure:"git" yaml:"git,omitempty" json:"git,omitempty" toml:"git,omitempty"` // Slice of Git configurations
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Repos         []Git `mapstructure:"git" yaml:"git,omitempty" json:"git,omitempty" toml:"git,omitempty"` // Slice of Git configurations
 }
 
 // GetProfiles returns the profiles for this git operation.

--- a/internal/types/package.go
+++ b/internal/types/package.go
@@ -13,7 +13,9 @@ type Package struct {
 }
 
 type PackagesData struct {
-	Packages []Package `mapstructure:"packages,omitempty" yaml:"packages,omitempty" json:"packages,omitempty" toml:"packages,omitempty"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Packages      []Package `mapstructure:"packages,omitempty" yaml:"packages,omitempty" json:"packages,omitempty" toml:"packages,omitempty"`
 }
 
 // GetProfiles returns the profiles for this package.

--- a/internal/types/respository.go
+++ b/internal/types/respository.go
@@ -16,7 +16,9 @@ type Repository struct {
 }
 
 type RepositoriesData struct {
-	Repositories []Repository `mapstructure:"repositories" yaml:"repositories" json:"repositories" toml:"repositories"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Repositories  []Repository `mapstructure:"repositories" yaml:"repositories" json:"repositories" toml:"repositories"`
 }
 
 // GetProfiles returns the profiles for this repository.

--- a/internal/types/schema.go
+++ b/internal/types/schema.go
@@ -1,0 +1,175 @@
+package types
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DefaultSchemaVersion is the version assumed for a blueprint type that has only
+// ever had one. It is not the fallback for an undeclared blueprint — see
+// ResolveSchemaVersion, which falls back to the latest version instead.
+const DefaultSchemaVersion = 1
+
+// supportedSchemaVersions lists the versions each blueprint type can be written
+// in. Versions are per type on purpose: a breaking change to packages moves
+// packages to v2 and leaves everything else at v1, instead of dragging the whole
+// schema forward and arriving at v11 over changes that each touched one resource.
+//
+// To introduce a v2 for a type: add 2 here, teach that type's processor to branch
+// on the resolved version, and document the difference. Nothing else moves.
+var supportedSchemaVersions = map[string][]int{
+	BlueprintTypePackages:        {1},
+	BlueprintTypeRepositories:    {1},
+	BlueprintTypeFiles:           {1},
+	BlueprintTypeServices:        {1},
+	BlueprintTypeGit:             {1},
+	BlueprintTypeScripts:         {1},
+	BlueprintTypeSSHKeys:         {1},
+	BlueprintTypeFonts:           {1},
+	BlueprintTypeUsers:           {1},
+	BlueprintTypeConfiguration:   {1},
+	BlueprintTypePackageManagers: {1},
+	BlueprintTypeBootstrap:       {1},
+}
+
+// SchemaVersion is embedded in every blueprint data struct so an individual file
+// can declare the schema it is written in:
+//
+//	schema_version: 2
+//	packages:
+//	  - name: git
+//
+// A file's declaration overrides the tree-wide version from the init file, which
+// is what makes a single-resource breaking change possible: move one packages
+// blueprint to v2 and leave the rest of the tree alone.
+type SchemaVersion struct {
+	SchemaVersion int `mapstructure:"schema_version,omitempty" yaml:"schema_version,omitempty" json:"schema_version,omitempty" toml:"schema_version,omitempty"`
+}
+
+// DeclaredVersion returns the version this file declares, or 0 if it declares
+// none.
+func (s SchemaVersion) DeclaredVersion() int { return s.SchemaVersion }
+
+// ResolveSchemaVersion decides which schema version a blueprint file should be
+// read as.
+//
+// Precedence is most-specific-wins: the file's own declaration, then the
+// tree-wide version from the init file, then the latest version this build
+// supports for that type.
+//
+// Falling back to the latest means a blueprint written today gets today's schema
+// without boilerplate, and the version field is what you add when you want to be
+// pinned rather than something you must add to get started. The consequence is
+// that an undeclared blueprint follows the schema forward across upgrades, so a
+// tree that needs to stay on a particular version has to say so — which is what
+// the declaration is for.
+func ResolveSchemaVersion(fileDeclared, treeDeclared int, blueprintType string) int {
+	if fileDeclared > 0 {
+		return fileDeclared
+	}
+	if treeDeclared > 0 {
+		return treeDeclared
+	}
+	return LatestSchemaVersion(blueprintType)
+}
+
+// LatestSchemaVersion returns the newest version this build can read for a
+// blueprint type, or DefaultSchemaVersion for a type it does not know.
+func LatestSchemaVersion(blueprintType string) int {
+	latest := 0
+	for _, v := range supportedSchemaVersions[blueprintType] {
+		if v > latest {
+			latest = v
+		}
+	}
+	if latest == 0 {
+		return DefaultSchemaVersion
+	}
+	return latest
+}
+
+// ValidateSchemaVersion reports whether this build can read blueprintType at the
+// given version.
+//
+// It is deliberately strict. A blueprint asking for a schema this binary does not
+// know is one whose fields would be misread, and misreading a blueprint means
+// doing the wrong thing to somebody's machine rather than refusing.
+func ValidateSchemaVersion(blueprintType string, version int) error {
+	versions, known := supportedSchemaVersions[blueprintType]
+	if !known {
+		return fmt.Errorf("unknown blueprint type %q", blueprintType)
+	}
+	if version <= 0 {
+		return fmt.Errorf("%s: %d is not a valid schema version", blueprintType, version)
+	}
+	for _, v := range versions {
+		if v == version {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s: schema version %d is not supported by this build (supports %s) — "+
+		"upgrade rwr, or write this blueprint in a supported version",
+		blueprintType, version, versionList(blueprintType))
+}
+
+// ValidateTreeSchemaVersion reports whether a tree-wide version from an init file
+// is readable for every blueprint type. A tree-wide declaration applies to
+// everything, so it has to be supported everywhere.
+func ValidateTreeSchemaVersion(version int) error {
+	if version == 0 {
+		return nil // undeclared, resolves to the default
+	}
+	if version < 0 {
+		return fmt.Errorf("%d is not a valid schema version", version)
+	}
+
+	var unsupported []string
+	for _, blueprintType := range sortedKeys(supportedSchemaVersions) {
+		if !supportsVersion(blueprintType, version) {
+			unsupported = append(unsupported, fmt.Sprintf("%s (supports %s)",
+				blueprintType, versionList(blueprintType)))
+		}
+	}
+	if len(unsupported) == 0 {
+		return nil
+	}
+	return fmt.Errorf("schema version %d is not supported for %s — "+
+		"declare it per blueprint file instead, or upgrade rwr",
+		version, strings.Join(unsupported, ", "))
+}
+
+func supportsVersion(blueprintType string, version int) bool {
+	for _, v := range supportedSchemaVersions[blueprintType] {
+		if v == version {
+			return true
+		}
+	}
+	return false
+}
+
+// versionList renders the versions a blueprint type supports, for error messages.
+func versionList(blueprintType string) string {
+	versions := supportedSchemaVersions[blueprintType]
+	parts := make([]string, 0, len(versions))
+	for _, v := range versions {
+		parts = append(parts, fmt.Sprintf("%d", v))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// SupportedSchemaVersions returns the versions a blueprint type can be written in.
+func SupportedSchemaVersions(blueprintType string) []int {
+	out := append([]int(nil), supportedSchemaVersions[blueprintType]...)
+	sort.Ints(out)
+	return out
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/types/schema_registry.go
+++ b/internal/types/schema_registry.go
@@ -1,0 +1,133 @@
+package types
+
+import "fmt"
+
+// A blueprint's wire format and the struct the processors consume are two
+// different things, and versioning is what separates them.
+//
+// Each supported version of a blueprint type is its own struct describing exactly
+// what that version accepts on disk. Decoding picks the struct by resolved
+// version and then converts it to the canonical type the processors use. So a v2
+// of packages is a new struct plus a conversion — nothing downstream of the
+// decoder learns that more than one version exists, and no other blueprint type
+// is touched.
+//
+// Adding a version:
+//
+//  1. define the struct for the new wire format, e.g. packagesV2
+//  2. give it a Canonical() that maps it onto PackagesData
+//  3. register it under {BlueprintTypePackages: {2: ...}}
+//  4. add 2 to supportedSchemaVersions for that type
+//
+// Nothing else changes, which is the point: a breaking change to one resource
+// stays one resource wide instead of moving the whole schema to the next number.
+
+// SchemaVariant is one versioned wire format of a blueprint type.
+type SchemaVariant interface {
+	// Target returns the value to decode the file into.
+	Target() interface{}
+	// Canonical returns the decoded content as the type processors consume.
+	// For the current version this is the identity.
+	Canonical() interface{}
+	// DeclaredSchemaVersion reports the version the file declared, or 0.
+	DeclaredSchemaVersion() int
+}
+
+type variantFactory func() SchemaVariant
+
+// schemaRegistry maps a blueprint type and version to the struct that reads it.
+var schemaRegistry = map[string]map[int]variantFactory{
+	BlueprintTypePackages:      {1: func() SchemaVariant { return &packagesV1{} }},
+	BlueprintTypeRepositories:  {1: func() SchemaVariant { return &repositoriesV1{} }},
+	BlueprintTypeFiles:         {1: func() SchemaVariant { return &filesV1{} }},
+	BlueprintTypeServices:      {1: func() SchemaVariant { return &servicesV1{} }},
+	BlueprintTypeGit:           {1: func() SchemaVariant { return &gitV1{} }},
+	BlueprintTypeScripts:       {1: func() SchemaVariant { return &scriptsV1{} }},
+	BlueprintTypeSSHKeys:       {1: func() SchemaVariant { return &sshKeysV1{} }},
+	BlueprintTypeFonts:         {1: func() SchemaVariant { return &fontsV1{} }},
+	BlueprintTypeUsers:         {1: func() SchemaVariant { return &usersV1{} }},
+	BlueprintTypeConfiguration: {1: func() SchemaVariant { return &configurationV1{} }},
+}
+
+// NewSchemaVariant returns the struct that reads blueprintType at version.
+func NewSchemaVariant(blueprintType string, version int) (SchemaVariant, error) {
+	versions, known := schemaRegistry[blueprintType]
+	if !known {
+		return nil, fmt.Errorf("no schema registered for blueprint type %q", blueprintType)
+	}
+	factory, ok := versions[version]
+	if !ok {
+		return nil, ValidateSchemaVersion(blueprintType, version)
+	}
+	return factory(), nil
+}
+
+// HasSchemaVariant reports whether a decoder exists for this type and version.
+func HasSchemaVariant(blueprintType string, version int) bool {
+	_, ok := schemaRegistry[blueprintType][version]
+	return ok
+}
+
+// v1 variants. Each wraps the canonical struct, because v1 *is* the current
+// shape — the indirection only starts paying off at v2, where the wire struct
+// and the canonical struct diverge and Canonical() does real mapping work.
+
+type packagesV1 struct{ PackagesData }
+
+func (v *packagesV1) Target() interface{}        { return &v.PackagesData }
+func (v *packagesV1) Canonical() interface{}     { return &v.PackagesData }
+func (v *packagesV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type repositoriesV1 struct{ RepositoriesData }
+
+func (v *repositoriesV1) Target() interface{}        { return &v.RepositoriesData }
+func (v *repositoriesV1) Canonical() interface{}     { return &v.RepositoriesData }
+func (v *repositoriesV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type filesV1 struct{ FileData }
+
+func (v *filesV1) Target() interface{}        { return &v.FileData }
+func (v *filesV1) Canonical() interface{}     { return &v.FileData }
+func (v *filesV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type servicesV1 struct{ ServiceData }
+
+func (v *servicesV1) Target() interface{}        { return &v.ServiceData }
+func (v *servicesV1) Canonical() interface{}     { return &v.ServiceData }
+func (v *servicesV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type gitV1 struct{ GitData }
+
+func (v *gitV1) Target() interface{}        { return &v.GitData }
+func (v *gitV1) Canonical() interface{}     { return &v.GitData }
+func (v *gitV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type scriptsV1 struct{ ScriptData }
+
+func (v *scriptsV1) Target() interface{}        { return &v.ScriptData }
+func (v *scriptsV1) Canonical() interface{}     { return &v.ScriptData }
+func (v *scriptsV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type sshKeysV1 struct{ SSHKeyData }
+
+func (v *sshKeysV1) Target() interface{}        { return &v.SSHKeyData }
+func (v *sshKeysV1) Canonical() interface{}     { return &v.SSHKeyData }
+func (v *sshKeysV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type fontsV1 struct{ FontsData }
+
+func (v *fontsV1) Target() interface{}        { return &v.FontsData }
+func (v *fontsV1) Canonical() interface{}     { return &v.FontsData }
+func (v *fontsV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type usersV1 struct{ UsersData }
+
+func (v *usersV1) Target() interface{}        { return &v.UsersData }
+func (v *usersV1) Canonical() interface{}     { return &v.UsersData }
+func (v *usersV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type configurationV1 struct{ ConfigData }
+
+func (v *configurationV1) Target() interface{}        { return &v.ConfigData }
+func (v *configurationV1) Canonical() interface{}     { return &v.ConfigData }
+func (v *configurationV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }

--- a/internal/types/schema_test.go
+++ b/internal/types/schema_test.go
@@ -1,0 +1,197 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveSchemaVersion(t *testing.T) {
+	tests := []struct {
+		name         string
+		fileDeclared int
+		treeDeclared int
+		want         int
+	}{
+		{
+			name: "nothing declared falls back to the latest supported",
+			want: LatestSchemaVersion(BlueprintTypePackages),
+		},
+		{
+			name:         "tree version applies when the file says nothing",
+			treeDeclared: 2,
+			want:         2,
+		},
+		{
+			name:         "the file wins over the tree",
+			fileDeclared: 2,
+			treeDeclared: 1,
+			want:         2,
+		},
+		{
+			name:         "the file wins even when older than the tree",
+			fileDeclared: 1,
+			treeDeclared: 2,
+			want:         1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveSchemaVersion(tt.fileDeclared, tt.treeDeclared, BlueprintTypePackages)
+			if got != tt.want {
+				t.Errorf("ResolveSchemaVersion(%d, %d) = %d, want %d",
+					tt.fileDeclared, tt.treeDeclared, got, tt.want)
+			}
+		})
+	}
+}
+
+// An undeclared blueprint is read as the latest schema that type supports, so a
+// blueprint written today gets today's format without boilerplate.
+//
+// This asserts against LatestSchemaVersion rather than a literal, so it keeps
+// testing the intent once a type gains a v2 — a hardcoded 1 here would silently
+// keep passing while the behaviour it describes had changed.
+func TestResolveSchemaVersion_UndeclaredIsLatest(t *testing.T) {
+	for _, blueprintType := range []string{
+		BlueprintTypePackages, BlueprintTypeFiles, BlueprintTypeServices,
+	} {
+		want := LatestSchemaVersion(blueprintType)
+		if got := ResolveSchemaVersion(0, 0, blueprintType); got != want {
+			t.Errorf("%s: undeclared resolved to %d, want the latest %d",
+				blueprintType, got, want)
+		}
+	}
+}
+
+// A declaration always wins over the fallback, which is what pins a tree to a
+// version while newer ones exist.
+func TestResolveSchemaVersion_DeclarationPinsAgainstLatest(t *testing.T) {
+	if got := ResolveSchemaVersion(1, 0, BlueprintTypePackages); got != 1 {
+		t.Errorf("a file declaring v1 resolved to %d, want 1", got)
+	}
+	if got := ResolveSchemaVersion(0, 1, BlueprintTypePackages); got != 1 {
+		t.Errorf("a tree declaring v1 resolved to %d, want 1", got)
+	}
+}
+
+func TestLatestSchemaVersion(t *testing.T) {
+	for _, blueprintType := range []string{BlueprintTypePackages, BlueprintTypeFiles} {
+		latest := LatestSchemaVersion(blueprintType)
+		versions := SupportedSchemaVersions(blueprintType)
+		if latest != versions[len(versions)-1] {
+			t.Errorf("%s: latest = %d, but supported versions are %v",
+				blueprintType, latest, versions)
+		}
+	}
+	// An unknown type must not report 0, which would resolve to an invalid version.
+	if got := LatestSchemaVersion("nonsense"); got != DefaultSchemaVersion {
+		t.Errorf("unknown type reported latest %d, want %d", got, DefaultSchemaVersion)
+	}
+}
+
+func TestValidateSchemaVersion(t *testing.T) {
+	if err := ValidateSchemaVersion(BlueprintTypePackages, 1); err != nil {
+		t.Errorf("v1 packages should be supported: %v", err)
+	}
+
+	err := ValidateSchemaVersion(BlueprintTypePackages, 2)
+	if err == nil {
+		t.Fatal("v2 packages is not implemented yet and must be rejected")
+	}
+	// The message has to say what went wrong and what to do; a version this build
+	// cannot read means the blueprint would be misread, not merely unsupported.
+	for _, want := range []string{"packages", "2", "supports 1", "upgrade rwr"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err, want)
+		}
+	}
+
+	if err := ValidateSchemaVersion("nonsense", 1); err == nil {
+		t.Error("an unknown blueprint type should be rejected")
+	}
+	if err := ValidateSchemaVersion(BlueprintTypePackages, 0); err == nil {
+		t.Error("version 0 should be rejected as invalid")
+	}
+	if err := ValidateSchemaVersion(BlueprintTypePackages, -1); err == nil {
+		t.Error("a negative version should be rejected")
+	}
+}
+
+func TestValidateTreeSchemaVersion(t *testing.T) {
+	if err := ValidateTreeSchemaVersion(0); err != nil {
+		t.Errorf("an undeclared tree version is valid: %v", err)
+	}
+	if err := ValidateTreeSchemaVersion(1); err != nil {
+		t.Errorf("v1 is supported everywhere: %v", err)
+	}
+
+	err := ValidateTreeSchemaVersion(2)
+	if err == nil {
+		t.Fatal("a tree-wide v2 must be rejected while no type implements v2")
+	}
+	// A tree-wide version applies to every type, so when only some types have a
+	// v2 the fix is to declare it per file — the error should say so.
+	if !strings.Contains(err.Error(), "per blueprint file") {
+		t.Errorf("error should suggest declaring per file, got: %v", err)
+	}
+	if err := ValidateTreeSchemaVersion(-1); err == nil {
+		t.Error("a negative tree version should be rejected")
+	}
+}
+
+// The point of per-type versioning: moving one resource to v2 must not require
+// moving anything else. This asserts the registry is genuinely per type rather
+// than one shared list.
+func TestSupportedSchemaVersions_AreIndependentPerType(t *testing.T) {
+	for _, blueprintType := range []string{
+		BlueprintTypePackages, BlueprintTypeFiles, BlueprintTypeServices,
+		BlueprintTypeGit, BlueprintTypeScripts, BlueprintTypeSSHKeys,
+		BlueprintTypeFonts, BlueprintTypeUsers, BlueprintTypeConfiguration,
+		BlueprintTypeRepositories,
+	} {
+		versions := SupportedSchemaVersions(blueprintType)
+		if len(versions) == 0 {
+			t.Errorf("%s declares no supported schema versions", blueprintType)
+			continue
+		}
+		if versions[0] != 1 {
+			t.Errorf("%s should still support v1 for backwards compatibility, got %v",
+				blueprintType, versions)
+		}
+	}
+}
+
+// withExtraVersion temporarily teaches the registry that a type supports another
+// version, so the resolution rules can be exercised before any real v2 exists.
+func withExtraVersion(t *testing.T, blueprintType string, version int) {
+	t.Helper()
+	original := append([]int(nil), supportedSchemaVersions[blueprintType]...)
+	supportedSchemaVersions[blueprintType] = append(original, version)
+	t.Cleanup(func() { supportedSchemaVersions[blueprintType] = original })
+}
+
+// The real point of "undeclared means latest": when packages gains a v2, a
+// packages blueprint that declares nothing is read as v2 — while files, which did
+// not change, stays where it is. Today latest is 1 everywhere, so this simulates
+// the v2 to test the rule rather than the current numbers.
+func TestResolveSchemaVersion_UndeclaredFollowsANewVersion(t *testing.T) {
+	withExtraVersion(t, BlueprintTypePackages, 2)
+
+	if got := ResolveSchemaVersion(0, 0, BlueprintTypePackages); got != 2 {
+		t.Errorf("undeclared packages resolved to %d, want the new latest 2", got)
+	}
+	// A type that did not gain a version is unaffected — this is what keeps a
+	// breaking change contained to one resource.
+	if got := ResolveSchemaVersion(0, 0, BlueprintTypeFiles); got != 1 {
+		t.Errorf("undeclared files resolved to %d, want 1 — files did not change", got)
+	}
+	// Declaring a version still pins, which is how a tree stays on v1 after v2
+	// ships.
+	if got := ResolveSchemaVersion(1, 0, BlueprintTypePackages); got != 1 {
+		t.Errorf("packages pinned to v1 resolved to %d, want 1", got)
+	}
+	if got := ResolveSchemaVersion(0, 1, BlueprintTypePackages); got != 1 {
+		t.Errorf("packages under a v1 tree resolved to %d, want 1", got)
+	}
+}

--- a/internal/types/scripts.go
+++ b/internal/types/scripts.go
@@ -15,7 +15,9 @@ type Script struct {
 }
 
 type ScriptData struct {
-	Scripts []Script `mapstructure:"scripts,omitempty" yaml:"scripts,omitempty" json:"scripts,omitempty" toml:"scripts,omitempty"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Scripts       []Script `mapstructure:"scripts,omitempty" yaml:"scripts,omitempty" json:"scripts,omitempty" toml:"scripts,omitempty"`
 }
 
 // GetProfiles returns the profiles for this script.

--- a/internal/types/service.go
+++ b/internal/types/service.go
@@ -14,7 +14,9 @@ type Service struct {
 }
 
 type ServiceData struct {
-	Services []Service `mapstructure:"services" yaml:"services" json:"services" toml:"services"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Services      []Service `mapstructure:"services" yaml:"services" json:"services" toml:"services"`
 }
 
 // GetProfiles returns the profiles for this service.

--- a/internal/types/ssh_key.go
+++ b/internal/types/ssh_key.go
@@ -15,7 +15,9 @@ type SSHKey struct {
 }
 
 type SSHKeyData struct {
-	SSHKeys []SSHKey `mapstructure:"ssh_keys" yaml:"ssh_keys" json:"ssh_keys" toml:"ssh_keys"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	SSHKeys       []SSHKey `mapstructure:"ssh_keys" yaml:"ssh_keys" json:"ssh_keys" toml:"ssh_keys"`
 }
 
 // GetProfiles returns the profiles for this SSH key.

--- a/internal/types/users.go
+++ b/internal/types/users.go
@@ -35,8 +35,10 @@ type User struct {
 }
 
 type UsersData struct {
-	Groups []Group `mapstructure:"groups,omitempty" yaml:"groups,omitempty" json:"groups,omitempty" toml:"groups,omitempty"` // Groups data
-	Users  []User  `mapstructure:"users,omitempty" yaml:"users,omitempty" json:"users,omitempty" toml:"users,omitempty"`     // Users data
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Groups        []Group `mapstructure:"groups,omitempty" yaml:"groups,omitempty" json:"groups,omitempty" toml:"groups,omitempty"` // Groups data
+	Users         []User  `mapstructure:"users,omitempty" yaml:"users,omitempty" json:"users,omitempty" toml:"users,omitempty"`     // Users data
 }
 
 // GetProfiles returns the profiles for this group.

--- a/internal/validate/examples_schema_test.go
+++ b/internal/validate/examples_schema_test.go
@@ -1,0 +1,267 @@
+package validate
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/types"
+	"gopkg.in/yaml.v3"
+)
+
+// blueprintTargets maps a blueprint directory name to the type its files decode
+// into. This is the contract the examples are asserted against.
+func blueprintTarget(kind string) interface{} {
+	switch kind {
+	case types.BlueprintTypePackages:
+		return &types.PackagesData{}
+	case types.BlueprintTypeRepositories:
+		return &types.RepositoriesData{}
+	case types.BlueprintTypeFiles:
+		return &types.FileData{}
+	case types.BlueprintTypeServices:
+		return &types.ServiceData{}
+	case types.BlueprintTypeGit:
+		return &types.GitData{}
+	case types.BlueprintTypeScripts:
+		return &types.ScriptData{}
+	case types.BlueprintTypeSSHKeys:
+		return &types.SSHKeyData{}
+	case types.BlueprintTypeFonts:
+		return &types.FontsData{}
+	case types.BlueprintTypeUsers:
+		return &types.UsersData{}
+	case types.BlueprintTypeConfiguration:
+		return &types.ConfigData{}
+	default:
+		return nil
+	}
+}
+
+// Every example must decode into its blueprint struct with no unknown fields.
+//
+// This is the backwards-compatibility check: the decoders RWR uses in production
+// ignore unknown keys, so renaming or removing a struct field silently turns
+// every blueprint using it into a no-op rather than an error. Decoding strictly
+// here means such a change fails the build with the field named, instead of
+// shipping and quietly doing nothing on users' machines.
+//
+// It also catches the reverse — an example inventing a field that never existed,
+// which is how `src`/`dest`, `username` and script `mode` survived in the tree.
+func TestExamples_DecodeStrictlyIntoBlueprintStructs(t *testing.T) {
+	root := examplesDir(t)
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		ext := strings.TrimPrefix(filepath.Ext(path), ".")
+		switch ext {
+		case "yaml", "yml", "json", "toml":
+		default:
+			return nil
+		}
+
+		// The directory name is how RWR itself decides the blueprint type
+		// (getProcessorType in processors/blueprints.go).
+		kind := filepath.Base(filepath.Dir(path))
+		target := blueprintTarget(kind)
+		if target == nil {
+			return nil // init files, bootstrap, and the layout examples
+		}
+
+		raw, readErr := os.ReadFile(path) // #nosec G304 -- test walks the repo's own examples tree
+		if readErr != nil {
+			t.Errorf("%s: %v", path, readErr)
+			return nil
+		}
+		resolved, tmplErr := helpers.ResolveTemplate(raw, exampleVariables())
+		if tmplErr != nil {
+			return nil // reported by TestExamples_ParseInTheirDeclaredFormat
+		}
+
+		if unknown := strictDecode(resolved, ext, target); len(unknown) > 0 {
+			t.Errorf("%s: keys that no %T field accepts: %s\n"+
+				"    (production decoding ignores these silently, so the blueprint would be a no-op)",
+				path, target, strings.Join(unknown, ", "))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking examples: %v", err)
+	}
+}
+
+// strictDecode decodes data into target and returns any keys the target has no
+// field for. An empty result means the file matches the schema exactly.
+func strictDecode(data []byte, format string, target interface{}) []string {
+	switch format {
+	case "yaml", "yml":
+		dec := yaml.NewDecoder(bytes.NewReader(data))
+		dec.KnownFields(true)
+		if err := dec.Decode(target); err != nil {
+			return unknownFieldsFromError(err.Error())
+		}
+	case "json":
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(target); err != nil {
+			return unknownFieldsFromError(err.Error())
+		}
+	case "toml":
+		meta, err := toml.Decode(string(data), target)
+		if err != nil {
+			return unknownFieldsFromError(err.Error())
+		}
+		var unknown []string
+		for _, key := range meta.Undecoded() {
+			unknown = append(unknown, key.String())
+		}
+		return unknown
+	}
+	return nil
+}
+
+// unknownFieldsFromError reduces a decoder error to something readable. Decoders
+// phrase this differently, so the message is passed through when it does not
+// match a known shape.
+func unknownFieldsFromError(msg string) []string {
+	var out []string
+	for _, line := range strings.Split(msg, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+// The yaml, json and toml copies of a blueprint must express the same thing.
+//
+// They had drifted badly — the Arch files example was 194 lines of YAML against
+// 31 of JSON, and the macOS scripts example worked in YAML while the JSON and
+// TOML copies were missing the `action` every entry needs. Someone reading the
+// TOML tree was being shown something that would not run.
+func TestExamples_FormatsAgreeWithEachOther(t *testing.T) {
+	root := examplesDir(t)
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || filepath.Ext(path) != ".yaml" {
+			return err
+		}
+
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		// alternative_layouts/ demonstrates a layout the code does not implement
+		// (type detection by file content); it is being reworked separately, and
+		// its copies have drifted along with everything else there.
+		if strings.HasPrefix(rel, "alternative_layouts"+string(filepath.Separator)) {
+			return nil
+		}
+
+		parts := strings.Split(rel, string(filepath.Separator))
+		idx := -1
+		for i, p := range parts {
+			if p == "yaml" {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			return nil
+		}
+
+		counterpart := func(format string) string {
+			swapped := append([]string{}, parts...)
+			swapped[idx] = format
+			out := filepath.Join(root, filepath.Join(swapped...))
+			return strings.TrimSuffix(out, ".yaml") + "." + format
+		}
+
+		jsonPath, tomlPath := counterpart("json"), counterpart("toml")
+		if _, err := os.Stat(jsonPath); err != nil {
+			return nil
+		}
+		if _, err := os.Stat(tomlPath); err != nil {
+			return nil
+		}
+
+		var fromYAML, fromJSON, fromTOML map[string]interface{}
+		if !decodeInto(t, path, "yaml", &fromYAML) ||
+			!decodeInto(t, jsonPath, "json", &fromJSON) ||
+			!decodeInto(t, tomlPath, "toml", &fromTOML) {
+			return nil
+		}
+
+		// An init file names the format its tree is written in, so that one key is
+		// required to differ between the copies.
+		dropDeclaredFormat(fromYAML)
+		dropDeclaredFormat(fromJSON)
+		dropDeclaredFormat(fromTOML)
+
+		if !reflect.DeepEqual(fromYAML, fromJSON) {
+			t.Errorf("%s and its .json copy describe different things", rel)
+		}
+		if !reflect.DeepEqual(fromYAML, fromTOML) {
+			t.Errorf("%s and its .toml copy describe different things", rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking examples: %v", err)
+	}
+}
+
+func decodeInto(t *testing.T, path, format string, out *map[string]interface{}) bool {
+	t.Helper()
+	raw, err := os.ReadFile(path) // #nosec G304 -- test walks the repo's own examples tree
+	if err != nil {
+		t.Errorf("%s: %v", path, err)
+		return false
+	}
+	resolved, err := helpers.ResolveTemplate(raw, exampleVariables())
+	if err != nil {
+		return false // reported by the parse test
+	}
+	if err := helpers.UnmarshalBlueprint(resolved, format, out); err != nil {
+		return false // reported by the parse test
+	}
+
+	// Decoders disagree on Go representation for identical content — yaml yields
+	// []interface{} of maps where toml yields []map[string]interface{} — so
+	// canonicalise through JSON before comparing, or every file looks different.
+	canonical, err := json.Marshal(*out)
+	if err != nil {
+		t.Errorf("%s: %v", path, err)
+		return false
+	}
+	*out = nil
+	if err := json.Unmarshal(canonical, out); err != nil {
+		t.Errorf("%s: %v", path, err)
+		return false
+	}
+	return true
+}
+
+// dropDeclaredFormat removes blueprints.format, which legitimately differs
+// between the yaml, json and toml copies of an init file.
+func dropDeclaredFormat(m map[string]interface{}) {
+	blueprints, ok := m["blueprints"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	delete(blueprints, "format")
+}

--- a/internal/validate/examples_schema_test.go
+++ b/internal/validate/examples_schema_test.go
@@ -3,6 +3,8 @@ package validate
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -110,12 +112,20 @@ func strictDecode(data []byte, format string, target interface{}) []string {
 		dec := yaml.NewDecoder(bytes.NewReader(data))
 		dec.KnownFields(true)
 		if err := dec.Decode(target); err != nil {
+			// An empty document (a fully commented-out blueprint) decodes to EOF.
+			// That is a legitimate file, not an unknown field.
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
 			return unknownFieldsFromError(err.Error())
 		}
 	case "json":
 		dec := json.NewDecoder(bytes.NewReader(data))
 		dec.DisallowUnknownFields()
 		if err := dec.Decode(target); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
 			return unknownFieldsFromError(err.Error())
 		}
 	case "toml":


### PR DESCRIPTION
> Stacked on #152 — review that one first; this PR targets it as its base.

Covers points 1 and 3 of the request: an example per blueprint type on each
platform, and validation as a build check.

## Coverage

**`fonts` and `configuration` had no example anywhere**, despite both being
first-class types with their own processors and `rwr run` subcommands.
`repositories` was missing on macOS and Windows, `users` on macOS.

All five trees (Arch, Fedora, Ubuntu, macOS, Windows) now carry **all ten types**
in yaml, json and toml, wired into each init file's run order:

```
repositories packages files fonts services git scripts users ssh_keys configuration
```

The new examples use only what the code implements — fonts via the `nerd`
provider with `user`/`system` locations, and configuration limited to the four
tools that exist: `gsettings`/`dconf` on Linux, `macos_defaults` on macOS,
`windows_registry` on Windows.

## Correctness

Rewrote the Ubuntu and Windows `files`, `users`, `services` and `repositories`
examples. They used field names **no struct has**:

| Used | Actual |
|---|---|
| `src` / `dest` | `source` / `target` |
| `username`, `create_home`, `enabled` | `name` |
| `names` on services | one entry per service (`Service` has no plural form) |
| `uri` / `key` | `url` / `key_url` |

Unknown keys are dropped silently, so those examples decoded to **empty structs
and did nothing**. Most also had no `action`, which is a hard error. Renaming
fields wasn't enough — they're rewritten.

Also fixed `configuration` as the top-level key (`ConfigData`'s field is
`configurations`) — caught by the new strict-decode test while writing it, which
is a fair advert for the test.

## Consistency

The three copies had drifted into materially different content — Arch `files` was
194 lines of YAML against 31 of JSON, and macOS `scripts` worked in YAML while its
JSON and TOML copies were missing the `action` every entry needs. **All 57 triples
are regenerated from the YAML**, which was consistently the richer and working
variant.

## CI build check

A new `examples` job asserts on every PR:

- every example parses in the format its extension claims
- nothing references a template variable that doesn't exist — a missing key
  renders `<no value>` rather than erroring, so this is otherwise invisible
- every example **decodes strictly into its blueprint struct with no unknown keys**
- the yaml, json and toml copies describe the same thing
- `rwr validate` runs clean over all 21 example trees

**The strict-decode check is the backwards-compatibility guard you asked for.**
Production decoding ignores unknown keys, so renaming or removing a struct field
turns every blueprint using it into a silent no-op on users' machines. Now it
fails the build with the field named.

Two exclusions, both commented in place: `alternative_layouts/` demonstrates
content-based type detection the code doesn't implement (being reworked
separately), and an init file's declared `format` must differ between its own
copies.

## Verification

`go build`, `go test ./...`, `golangci-lint run`, `gosec ./...` all pass, and the
`rwr validate` loop was run locally over all 21 trees — clean, warnings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)