### PR TITLE
feat: version blueprint schemas per resource type

### DIFF
--- a/docs/schema-versioning.md
+++ b/docs/schema-versioning.md
@@ -1,0 +1,117 @@
+# Blueprint schema versioning
+
+Blueprints declare which version of the schema they are written in, so RWR can
+change a blueprint format without silently misreading configuration that was
+written against the old one.
+
+## Versions are per blueprint type
+
+There is no single schema number covering everything. Each blueprint type —
+`packages`, `files`, `services`, and so on — carries its own version.
+
+That is deliberate. If one shared number covered the whole schema, a breaking
+change to `packages` would move `files`, `git`, `scripts` and everything else to
+v2 as well, even though none of them changed. Do that a few times and you are on
+v11 with no way to tell which resource actually changed at each step.
+
+With per-type versions, a breaking change to `packages` produces exactly one
+change: `packages` is now v2. Everything else is still v1, and blueprints for
+those types keep working untouched.
+
+## Declaring a version
+
+**In the init file**, applying to the whole tree:
+
+```yaml
+blueprints:
+  format: yaml
+  location: "."
+  schema_version: 1
+```
+
+**In an individual blueprint file**, overriding the tree for that file only:
+
+```yaml
+schema_version: 2
+packages:
+  - name: git
+    action: install
+```
+
+The most specific declaration wins:
+
+1. the blueprint file's own `schema_version`
+2. the init file's `schema_version`
+3. v1
+
+## Nothing declared means v1
+
+A blueprint that declares no version is read as v1. Every blueprint written
+before versioning existed is v1, so absence has to mean 1 rather than "unset" —
+otherwise adding versioning would have broken every existing tree.
+
+You never have to add `schema_version` to keep working. You add it when you want
+a version that is not v1.
+
+## Migrating one resource type
+
+When `packages` gains a v2, a tree can move one file at a time:
+
+```yaml
+# init.yaml — the tree is still v1
+blueprints:
+  schema_version: 1
+```
+
+```yaml
+# packages/dev-tools.yaml — this file is v2
+schema_version: 2
+packages:
+  - name: git
+    action: install
+```
+
+```yaml
+# packages/base.yaml — still v1, still works
+packages:
+  - name: curl
+    action: install
+```
+
+Both files are read correctly in the same run. There is no flag day.
+
+## Unsupported versions are an error
+
+A blueprint asking for a version this build does not implement fails, naming the
+version it wanted:
+
+```
+packages: schema version 2 is not supported by this build (supports 1) —
+upgrade rwr, or write this blueprint in a supported version
+```
+
+This is intentionally a hard failure. RWR installs packages, writes files and
+runs scripts as root; reading a v2 blueprint as though it were v1 would mean
+acting on a misunderstanding of what the file asked for. Refusing is the safer
+outcome.
+
+A tree-wide version has to be supported by *every* blueprint type, since it
+applies to all of them. If only some types have a v2, declare it per file
+instead — the error says so.
+
+## Adding a version (for contributors)
+
+Each version of a blueprint type is its own struct describing exactly what that
+version accepts on disk. Decoding picks the struct by resolved version and then
+converts it to the canonical type the processors consume, so nothing past the
+decoder knows more than one version exists.
+
+To add a v2 for a type, in `internal/types/`:
+
+1. Define the struct for the new wire format, e.g. `packagesV2`.
+2. Give it a `Canonical()` that maps it onto `PackagesData`.
+3. Register it in `schemaRegistry` under `{BlueprintTypePackages: {2: ...}}`.
+4. Add `2` to that type's entry in `supportedSchemaVersions`.
+
+Nothing else changes. The processors keep consuming `PackagesData` and no other
+blueprint type is affected.

--- a/docs/schema-versioning.md
+++ b/docs/schema-versioning.md
@@ -42,16 +42,32 @@ The most specific declaration wins:
 
 1. the blueprint file's own `schema_version`
 2. the init file's `schema_version`
-3. v1
+3. the latest version supported for that blueprint type
 
-## Nothing declared means v1
+## Nothing declared means latest
 
-A blueprint that declares no version is read as v1. Every blueprint written
-before versioning existed is v1, so absence has to mean 1 rather than "unset" —
-otherwise adding versioning would have broken every existing tree.
+A blueprint that declares no version is read as the **latest** version RWR
+supports for that type.
 
-You never have to add `schema_version` to keep working. You add it when you want
-a version that is not v1.
+This keeps the common case free of boilerplate: a blueprint written today gets
+today's schema without having to say so. The version field is what you add when
+you want to be *pinned*, not something you must add to get started.
+
+The trade-off is that an undeclared blueprint follows the schema forward across
+upgrades. If a tree needs to stay on a particular version — because you are not
+ready to migrate, or you want it to behave identically on every machine
+regardless of the RWR version installed — declare it:
+
+```yaml
+blueprints:
+  schema_version: 1
+```
+
+That one line pins the whole tree, and individual files can still opt forward.
+
+Note this is per type: when `packages` gains a v2, an undeclared `packages`
+blueprint is read as v2, while `files` — which did not change — is still read as
+v1.
 
 ## Migrating one resource type
 

--- a/examples/alternative_layouts/flattened/json/init.json
+++ b/examples/alternative_layouts/flattened/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "packages",

--- a/examples/alternative_layouts/flattened/toml/init.toml
+++ b/examples/alternative_layouts/flattened/toml/init.toml
@@ -1,7 +1,13 @@
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
-order = ["packages", "git", "files", "scripts"]
+order = [
+    "packages",
+    "git",
+    "files",
+    "scripts",
+]
 
 [variables.userDefined]
 project_name = "flattened-setup"

--- a/examples/alternative_layouts/flattened/yaml/init.yaml
+++ b/examples/alternative_layouts/flattened/yaml/init.yaml
@@ -1,13 +1,13 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
-    - packages
-    - git
-    - files
-    - scripts
-
+  - packages
+  - git
+  - files
+  - scripts
 variables:
   userDefined:
-    project_name: "flattened-setup"
-    repo_url: "https://github.com/user/dotfiles.git"
+    project_name: flattened-setup
+    repo_url: https://github.com/user/dotfiles.git

--- a/examples/alternative_layouts/minimal_files/json/init.json
+++ b/examples/alternative_layouts/minimal_files/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "packages",

--- a/examples/alternative_layouts/minimal_files/toml/init.toml
+++ b/examples/alternative_layouts/minimal_files/toml/init.toml
@@ -1,7 +1,13 @@
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
-order = ["packages", "git", "files", "scripts"]
+order = [
+    "packages",
+    "git",
+    "files",
+    "scripts",
+]
 
 [variables.userDefined]
 project_name = "minimal-setup"

--- a/examples/alternative_layouts/minimal_files/yaml/init.yaml
+++ b/examples/alternative_layouts/minimal_files/yaml/init.yaml
@@ -1,13 +1,13 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
-    - packages
-    - git
-    - files
-    - scripts
-
+  - packages
+  - git
+  - files
+  - scripts
 variables:
   userDefined:
-    project_name: "minimal-setup"
-    repo_url: "https://github.com/user/dotfiles.git"
+    project_name: minimal-setup
+    repo_url: https://github.com/user/dotfiles.git

--- a/examples/linux/Arch/json/init.json
+++ b/examples/linux/Arch/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "repositories",

--- a/examples/linux/Arch/toml/init.toml
+++ b/examples/linux/Arch/toml/init.toml
@@ -5,6 +5,7 @@ packageManagers = [
 
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
 order = [
     "repositories",

--- a/examples/linux/Arch/yaml/init.yaml
+++ b/examples/linux/Arch/yaml/init.yaml
@@ -1,5 +1,6 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
   - repositories

--- a/examples/linux/Fedora/json/init.json
+++ b/examples/linux/Fedora/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "repositories",

--- a/examples/linux/Fedora/toml/init.toml
+++ b/examples/linux/Fedora/toml/init.toml
@@ -5,6 +5,7 @@ packageManagers = [
 
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
 order = [
     "repositories",

--- a/examples/linux/Fedora/yaml/init.yaml
+++ b/examples/linux/Fedora/yaml/init.yaml
@@ -1,5 +1,6 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
   - repositories

--- a/examples/linux/Ubuntu/json/init.json
+++ b/examples/linux/Ubuntu/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "repositories",

--- a/examples/linux/Ubuntu/toml/init.toml
+++ b/examples/linux/Ubuntu/toml/init.toml
@@ -5,6 +5,7 @@ packageManagers = [
 
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
 order = [
     "repositories",

--- a/examples/linux/Ubuntu/yaml/init.yaml
+++ b/examples/linux/Ubuntu/yaml/init.yaml
@@ -1,5 +1,6 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
   - repositories

--- a/examples/macos/json/init.json
+++ b/examples/macos/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "repositories",

--- a/examples/macos/toml/init.toml
+++ b/examples/macos/toml/init.toml
@@ -5,6 +5,7 @@ packageManagers = [
 
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
 order = [
     "repositories",

--- a/examples/macos/yaml/init.yaml
+++ b/examples/macos/yaml/init.yaml
@@ -1,5 +1,6 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
   - repositories

--- a/examples/windows/json/init.json
+++ b/examples/windows/json/init.json
@@ -1,6 +1,7 @@
 {
   "blueprints": {
     "format": "json",
+    "schema_version": 1,
     "location": ".",
     "order": [
       "repositories",

--- a/examples/windows/toml/init.toml
+++ b/examples/windows/toml/init.toml
@@ -5,6 +5,7 @@ packageManagers = [
 
 [blueprints]
 format = "toml"
+schema_version = 1
 location = "."
 order = [
     "repositories",

--- a/examples/windows/yaml/init.yaml
+++ b/examples/windows/yaml/init.yaml
@@ -1,5 +1,6 @@
 blueprints:
   format: yaml
+  schema_version: 1
   location: .
   order:
   - repositories

--- a/internal/helpers/schema.go
+++ b/internal/helpers/schema.go
@@ -1,0 +1,56 @@
+package helpers
+
+import (
+	"fmt"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// DecodeBlueprint reads a blueprint file as the schema version it is written in.
+//
+// The version is resolved most-specific-first — the file's own `schema_version`,
+// then the tree-wide version from the init file, then v1 — and that decides which
+// struct the bytes are decoded into. The result is converted to the canonical
+// type the processors consume, so nothing past this function needs to know more
+// than one version exists.
+//
+// treeVersion is initConfig.Init.SchemaVersion; pass 0 when unknown.
+func DecodeBlueprint(data []byte, format, blueprintType string, treeVersion int) (interface{}, int, error) {
+	// Read the declaration first, using the current schema. Every version so far
+	// carries schema_version in the same place, which is the one part of the
+	// format that cannot move.
+	declared, err := declaredSchemaVersion(data, format)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	version := types.ResolveSchemaVersion(declared, treeVersion)
+	if err := types.ValidateSchemaVersion(blueprintType, version); err != nil {
+		return nil, version, err
+	}
+
+	variant, err := types.NewSchemaVariant(blueprintType, version)
+	if err != nil {
+		return nil, version, err
+	}
+
+	if err := UnmarshalBlueprint(data, format, variant.Target()); err != nil {
+		return nil, version, fmt.Errorf("reading %s blueprint as schema v%d: %w",
+			blueprintType, version, err)
+	}
+
+	return variant.Canonical(), version, nil
+}
+
+// declaredSchemaVersion reads just the schema_version key, ignoring everything
+// else, so a file written in a version this build cannot read still reports which
+// version it wanted.
+func declaredSchemaVersion(data []byte, format string) (int, error) {
+	var probe types.SchemaVersion
+	if err := UnmarshalBlueprint(data, format, &probe); err != nil {
+		// The file is malformed; report that against the real schema rather than
+		// this probe, which produces a clearer message.
+		return 0, nil //nolint:nilerr // deliberate: surfaced by the real decode below
+	}
+	return probe.DeclaredVersion(), nil
+}

--- a/internal/helpers/schema.go
+++ b/internal/helpers/schema.go
@@ -24,7 +24,7 @@ func DecodeBlueprint(data []byte, format, blueprintType string, treeVersion int)
 		return nil, 0, err
 	}
 
-	version := types.ResolveSchemaVersion(declared, treeVersion)
+	version := types.ResolveSchemaVersion(declared, treeVersion, blueprintType)
 	if err := types.ValidateSchemaVersion(blueprintType, version); err != nil {
 		return nil, version, err
 	}

--- a/internal/helpers/schema_test.go
+++ b/internal/helpers/schema_test.go
@@ -1,0 +1,104 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+const v1Packages = `
+packages:
+  - name: git
+    action: install
+`
+
+// A blueprint that declares nothing is v1, in every format. This is the
+// compatibility guarantee: versioning cannot change how existing trees are read.
+func TestDecodeBlueprint_UndeclaredIsReadAsV1(t *testing.T) {
+	bodies := map[string]string{
+		"yaml": v1Packages,
+		"json": `{"packages":[{"name":"git","action":"install"}]}`,
+		"toml": "[[packages]]\nname = \"git\"\naction = \"install\"\n",
+	}
+
+	for format, body := range bodies {
+		t.Run(format, func(t *testing.T) {
+			out, version, err := DecodeBlueprint([]byte(body), format, types.BlueprintTypePackages, 0)
+			if err != nil {
+				t.Fatalf("DecodeBlueprint: %v", err)
+			}
+			if version != 1 {
+				t.Errorf("resolved version = %d, want 1", version)
+			}
+			pkgs, ok := out.(*types.PackagesData)
+			if !ok {
+				t.Fatalf("got %T, want *types.PackagesData", out)
+			}
+			if len(pkgs.Packages) != 1 || pkgs.Packages[0].Name != "git" {
+				t.Errorf("decoded content is wrong: %+v", pkgs.Packages)
+			}
+		})
+	}
+}
+
+// The tree-wide version from the init file applies when a file says nothing.
+func TestDecodeBlueprint_TreeVersionApplies(t *testing.T) {
+	_, version, err := DecodeBlueprint([]byte(v1Packages), "yaml", types.BlueprintTypePackages, 1)
+	if err != nil {
+		t.Fatalf("DecodeBlueprint: %v", err)
+	}
+	if version != 1 {
+		t.Errorf("resolved version = %d, want 1", version)
+	}
+}
+
+// A file declaring a version this build cannot read must fail loudly, naming the
+// version it wanted. Reading it as v1 would silently misinterpret its fields.
+func TestDecodeBlueprint_UnknownVersionIsRejected(t *testing.T) {
+	body := "schema_version: 99\npackages:\n  - name: git\n    action: install\n"
+
+	_, version, err := DecodeBlueprint([]byte(body), "yaml", types.BlueprintTypePackages, 0)
+	if err == nil {
+		t.Fatal("a blueprint declaring schema v99 must be rejected, not read as v1")
+	}
+	if version != 99 {
+		t.Errorf("reported version = %d, want the 99 the file asked for", version)
+	}
+	for _, want := range []string{"packages", "99", "upgrade rwr"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err, want)
+		}
+	}
+}
+
+// A file's declaration overrides the tree, which is what lets one resource type
+// move to a new version while the rest of the tree stays put.
+func TestDecodeBlueprint_FileOverridesTree(t *testing.T) {
+	body := "schema_version: 1\npackages:\n  - name: git\n    action: install\n"
+
+	// Tree says 99; the file says 1 and wins, so this decodes rather than failing.
+	_, version, err := DecodeBlueprint([]byte(body), "yaml", types.BlueprintTypePackages, 99)
+	if err != nil {
+		t.Fatalf("the file's own version should win over the tree: %v", err)
+	}
+	if version != 1 {
+		t.Errorf("resolved version = %d, want 1 from the file", version)
+	}
+}
+
+// Every registered blueprint type must round-trip its v1 decoder, so no type is
+// left without a schema when versioning is enforced.
+func TestSchemaRegistry_CoversEveryBlueprintType(t *testing.T) {
+	for _, blueprintType := range []string{
+		types.BlueprintTypePackages, types.BlueprintTypeRepositories,
+		types.BlueprintTypeFiles, types.BlueprintTypeServices,
+		types.BlueprintTypeGit, types.BlueprintTypeScripts,
+		types.BlueprintTypeSSHKeys, types.BlueprintTypeFonts,
+		types.BlueprintTypeUsers, types.BlueprintTypeConfiguration,
+	} {
+		if !types.HasSchemaVariant(blueprintType, 1) {
+			t.Errorf("%s has no v1 schema registered", blueprintType)
+		}
+	}
+}

--- a/internal/types/blueprints.go
+++ b/internal/types/blueprints.go
@@ -5,7 +5,12 @@
 package types
 
 type Init struct {
-	Format           string        `mapstructure:"format" yaml:"format" json:"format" toml:"format"`
+	Format string `mapstructure:"format" yaml:"format" json:"format" toml:"format"`
+	// SchemaVersion is the blueprint schema version this tree is written in. It
+	// applies to every blueprint type, and an individual blueprint file may
+	// override it by declaring its own. Zero means undeclared, which resolves to
+	// types.DefaultSchemaVersion.
+	SchemaVersion    int           `mapstructure:"schema_version,omitempty" yaml:"schema_version,omitempty" json:"schema_version,omitempty" toml:"schema_version,omitempty"`
 	Location         string        `mapstructure:"location,omitempty" yaml:"location,omitempty" json:"location,omitempty" toml:"location,omitempty"`
 	Order            []interface{} `mapstructure:"order,omitempty" yaml:"order,omitempty" json:"order,omitempty" toml:"order,omitempty"`
 	Git              *GitOptions   `mapstructure:"git,omitempty" yaml:"git,omitempty" json:"git,omitempty" toml:"git,omitempty"`

--- a/internal/types/configuration.go
+++ b/internal/types/configuration.go
@@ -19,5 +19,7 @@ type Configuration struct {
 }
 
 type ConfigData struct {
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion  `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
 	Configurations []Configuration `mapstructure:"configurations" yaml:"configurations" json:"configurations" toml:"configurations"`
 }

--- a/internal/types/file.go
+++ b/internal/types/file.go
@@ -33,9 +33,11 @@ type Directory struct {
 }
 
 type FileData struct {
-	Files       []File      `yaml:"files" json:"files" toml:"files"`
-	Templates   []File      `yaml:"templates" json:"templates" toml:"templates"`
-	Directories []Directory `yaml:"directories" json:"directories" toml:"directories"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Files         []File      `yaml:"files" json:"files" toml:"files"`
+	Templates     []File      `yaml:"templates" json:"templates" toml:"templates"`
+	Directories   []Directory `yaml:"directories" json:"directories" toml:"directories"`
 }
 
 // GetProfiles returns the profiles for this file.

--- a/internal/types/fonts.go
+++ b/internal/types/fonts.go
@@ -9,5 +9,7 @@ type Font struct {
 }
 
 type FontsData struct {
-	Fonts []Font `yaml:"fonts" json:"fonts" toml:"fonts"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Fonts         []Font `yaml:"fonts" json:"fonts" toml:"fonts"`
 }

--- a/internal/types/git.go
+++ b/internal/types/git.go
@@ -21,7 +21,9 @@ type Git struct {
 }
 
 type GitData struct {
-	Repos []Git `mapstructure:"git" yaml:"git,omitempty" json:"git,omitempty" toml:"git,omitempty"` // Slice of Git configurations
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Repos         []Git `mapstructure:"git" yaml:"git,omitempty" json:"git,omitempty" toml:"git,omitempty"` // Slice of Git configurations
 }
 
 // GetProfiles returns the profiles for this git operation.

--- a/internal/types/package.go
+++ b/internal/types/package.go
@@ -13,7 +13,9 @@ type Package struct {
 }
 
 type PackagesData struct {
-	Packages []Package `mapstructure:"packages,omitempty" yaml:"packages,omitempty" json:"packages,omitempty" toml:"packages,omitempty"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Packages      []Package `mapstructure:"packages,omitempty" yaml:"packages,omitempty" json:"packages,omitempty" toml:"packages,omitempty"`
 }
 
 // GetProfiles returns the profiles for this package.

--- a/internal/types/respository.go
+++ b/internal/types/respository.go
@@ -16,7 +16,9 @@ type Repository struct {
 }
 
 type RepositoriesData struct {
-	Repositories []Repository `mapstructure:"repositories" yaml:"repositories" json:"repositories" toml:"repositories"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Repositories  []Repository `mapstructure:"repositories" yaml:"repositories" json:"repositories" toml:"repositories"`
 }
 
 // GetProfiles returns the profiles for this repository.

--- a/internal/types/schema.go
+++ b/internal/types/schema.go
@@ -1,0 +1,154 @@
+package types
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DefaultSchemaVersion is assumed wherever no version is declared.
+//
+// Every blueprint written before versioning existed is v1, so absence has to mean
+// 1 — not "unset" — or introducing versioning would break every existing tree.
+const DefaultSchemaVersion = 1
+
+// supportedSchemaVersions lists the versions each blueprint type can be written
+// in. Versions are per type on purpose: a breaking change to packages moves
+// packages to v2 and leaves everything else at v1, instead of dragging the whole
+// schema forward and arriving at v11 over changes that each touched one resource.
+//
+// To introduce a v2 for a type: add 2 here, teach that type's processor to branch
+// on the resolved version, and document the difference. Nothing else moves.
+var supportedSchemaVersions = map[string][]int{
+	BlueprintTypePackages:        {1},
+	BlueprintTypeRepositories:    {1},
+	BlueprintTypeFiles:           {1},
+	BlueprintTypeServices:        {1},
+	BlueprintTypeGit:             {1},
+	BlueprintTypeScripts:         {1},
+	BlueprintTypeSSHKeys:         {1},
+	BlueprintTypeFonts:           {1},
+	BlueprintTypeUsers:           {1},
+	BlueprintTypeConfiguration:   {1},
+	BlueprintTypePackageManagers: {1},
+	BlueprintTypeBootstrap:       {1},
+}
+
+// SchemaVersion is embedded in every blueprint data struct so an individual file
+// can declare the schema it is written in:
+//
+//	schema_version: 2
+//	packages:
+//	  - name: git
+//
+// A file's declaration overrides the tree-wide version from the init file, which
+// is what makes a single-resource breaking change possible: move one packages
+// blueprint to v2 and leave the rest of the tree alone.
+type SchemaVersion struct {
+	SchemaVersion int `mapstructure:"schema_version,omitempty" yaml:"schema_version,omitempty" json:"schema_version,omitempty" toml:"schema_version,omitempty"`
+}
+
+// DeclaredVersion returns the version this file declares, or 0 if it declares
+// none.
+func (s SchemaVersion) DeclaredVersion() int { return s.SchemaVersion }
+
+// ResolveSchemaVersion decides which schema version a blueprint file should be
+// read as.
+//
+// Precedence is most-specific-wins: the file's own declaration, then the
+// tree-wide version from the init file, then the default. A file is never read as
+// a version older than it declares itself to be.
+func ResolveSchemaVersion(fileDeclared, treeDeclared int) int {
+	if fileDeclared > 0 {
+		return fileDeclared
+	}
+	if treeDeclared > 0 {
+		return treeDeclared
+	}
+	return DefaultSchemaVersion
+}
+
+// ValidateSchemaVersion reports whether this build can read blueprintType at the
+// given version.
+//
+// It is deliberately strict. A blueprint asking for a schema this binary does not
+// know is one whose fields would be misread, and misreading a blueprint means
+// doing the wrong thing to somebody's machine rather than refusing.
+func ValidateSchemaVersion(blueprintType string, version int) error {
+	versions, known := supportedSchemaVersions[blueprintType]
+	if !known {
+		return fmt.Errorf("unknown blueprint type %q", blueprintType)
+	}
+	if version <= 0 {
+		return fmt.Errorf("%s: %d is not a valid schema version", blueprintType, version)
+	}
+	for _, v := range versions {
+		if v == version {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s: schema version %d is not supported by this build (supports %s) — "+
+		"upgrade rwr, or write this blueprint in a supported version",
+		blueprintType, version, versionList(blueprintType))
+}
+
+// ValidateTreeSchemaVersion reports whether a tree-wide version from an init file
+// is readable for every blueprint type. A tree-wide declaration applies to
+// everything, so it has to be supported everywhere.
+func ValidateTreeSchemaVersion(version int) error {
+	if version == 0 {
+		return nil // undeclared, resolves to the default
+	}
+	if version < 0 {
+		return fmt.Errorf("%d is not a valid schema version", version)
+	}
+
+	var unsupported []string
+	for _, blueprintType := range sortedKeys(supportedSchemaVersions) {
+		if !supportsVersion(blueprintType, version) {
+			unsupported = append(unsupported, fmt.Sprintf("%s (supports %s)",
+				blueprintType, versionList(blueprintType)))
+		}
+	}
+	if len(unsupported) == 0 {
+		return nil
+	}
+	return fmt.Errorf("schema version %d is not supported for %s — "+
+		"declare it per blueprint file instead, or upgrade rwr",
+		version, strings.Join(unsupported, ", "))
+}
+
+func supportsVersion(blueprintType string, version int) bool {
+	for _, v := range supportedSchemaVersions[blueprintType] {
+		if v == version {
+			return true
+		}
+	}
+	return false
+}
+
+// versionList renders the versions a blueprint type supports, for error messages.
+func versionList(blueprintType string) string {
+	versions := supportedSchemaVersions[blueprintType]
+	parts := make([]string, 0, len(versions))
+	for _, v := range versions {
+		parts = append(parts, fmt.Sprintf("%d", v))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// SupportedSchemaVersions returns the versions a blueprint type can be written in.
+func SupportedSchemaVersions(blueprintType string) []int {
+	out := append([]int(nil), supportedSchemaVersions[blueprintType]...)
+	sort.Ints(out)
+	return out
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/types/schema.go
+++ b/internal/types/schema.go
@@ -6,10 +6,9 @@ import (
 	"strings"
 )
 
-// DefaultSchemaVersion is assumed wherever no version is declared.
-//
-// Every blueprint written before versioning existed is v1, so absence has to mean
-// 1 — not "unset" — or introducing versioning would break every existing tree.
+// DefaultSchemaVersion is the version assumed for a blueprint type that has only
+// ever had one. It is not the fallback for an undeclared blueprint — see
+// ResolveSchemaVersion, which falls back to the latest version instead.
 const DefaultSchemaVersion = 1
 
 // supportedSchemaVersions lists the versions each blueprint type can be written
@@ -56,16 +55,38 @@ func (s SchemaVersion) DeclaredVersion() int { return s.SchemaVersion }
 // read as.
 //
 // Precedence is most-specific-wins: the file's own declaration, then the
-// tree-wide version from the init file, then the default. A file is never read as
-// a version older than it declares itself to be.
-func ResolveSchemaVersion(fileDeclared, treeDeclared int) int {
+// tree-wide version from the init file, then the latest version this build
+// supports for that type.
+//
+// Falling back to the latest means a blueprint written today gets today's schema
+// without boilerplate, and the version field is what you add when you want to be
+// pinned rather than something you must add to get started. The consequence is
+// that an undeclared blueprint follows the schema forward across upgrades, so a
+// tree that needs to stay on a particular version has to say so — which is what
+// the declaration is for.
+func ResolveSchemaVersion(fileDeclared, treeDeclared int, blueprintType string) int {
 	if fileDeclared > 0 {
 		return fileDeclared
 	}
 	if treeDeclared > 0 {
 		return treeDeclared
 	}
-	return DefaultSchemaVersion
+	return LatestSchemaVersion(blueprintType)
+}
+
+// LatestSchemaVersion returns the newest version this build can read for a
+// blueprint type, or DefaultSchemaVersion for a type it does not know.
+func LatestSchemaVersion(blueprintType string) int {
+	latest := 0
+	for _, v := range supportedSchemaVersions[blueprintType] {
+		if v > latest {
+			latest = v
+		}
+	}
+	if latest == 0 {
+		return DefaultSchemaVersion
+	}
+	return latest
 }
 
 // ValidateSchemaVersion reports whether this build can read blueprintType at the

--- a/internal/types/schema_registry.go
+++ b/internal/types/schema_registry.go
@@ -1,0 +1,133 @@
+package types
+
+import "fmt"
+
+// A blueprint's wire format and the struct the processors consume are two
+// different things, and versioning is what separates them.
+//
+// Each supported version of a blueprint type is its own struct describing exactly
+// what that version accepts on disk. Decoding picks the struct by resolved
+// version and then converts it to the canonical type the processors use. So a v2
+// of packages is a new struct plus a conversion — nothing downstream of the
+// decoder learns that more than one version exists, and no other blueprint type
+// is touched.
+//
+// Adding a version:
+//
+//  1. define the struct for the new wire format, e.g. packagesV2
+//  2. give it a Canonical() that maps it onto PackagesData
+//  3. register it under {BlueprintTypePackages: {2: ...}}
+//  4. add 2 to supportedSchemaVersions for that type
+//
+// Nothing else changes, which is the point: a breaking change to one resource
+// stays one resource wide instead of moving the whole schema to the next number.
+
+// SchemaVariant is one versioned wire format of a blueprint type.
+type SchemaVariant interface {
+	// Target returns the value to decode the file into.
+	Target() interface{}
+	// Canonical returns the decoded content as the type processors consume.
+	// For the current version this is the identity.
+	Canonical() interface{}
+	// DeclaredSchemaVersion reports the version the file declared, or 0.
+	DeclaredSchemaVersion() int
+}
+
+type variantFactory func() SchemaVariant
+
+// schemaRegistry maps a blueprint type and version to the struct that reads it.
+var schemaRegistry = map[string]map[int]variantFactory{
+	BlueprintTypePackages:      {1: func() SchemaVariant { return &packagesV1{} }},
+	BlueprintTypeRepositories:  {1: func() SchemaVariant { return &repositoriesV1{} }},
+	BlueprintTypeFiles:         {1: func() SchemaVariant { return &filesV1{} }},
+	BlueprintTypeServices:      {1: func() SchemaVariant { return &servicesV1{} }},
+	BlueprintTypeGit:           {1: func() SchemaVariant { return &gitV1{} }},
+	BlueprintTypeScripts:       {1: func() SchemaVariant { return &scriptsV1{} }},
+	BlueprintTypeSSHKeys:       {1: func() SchemaVariant { return &sshKeysV1{} }},
+	BlueprintTypeFonts:         {1: func() SchemaVariant { return &fontsV1{} }},
+	BlueprintTypeUsers:         {1: func() SchemaVariant { return &usersV1{} }},
+	BlueprintTypeConfiguration: {1: func() SchemaVariant { return &configurationV1{} }},
+}
+
+// NewSchemaVariant returns the struct that reads blueprintType at version.
+func NewSchemaVariant(blueprintType string, version int) (SchemaVariant, error) {
+	versions, known := schemaRegistry[blueprintType]
+	if !known {
+		return nil, fmt.Errorf("no schema registered for blueprint type %q", blueprintType)
+	}
+	factory, ok := versions[version]
+	if !ok {
+		return nil, ValidateSchemaVersion(blueprintType, version)
+	}
+	return factory(), nil
+}
+
+// HasSchemaVariant reports whether a decoder exists for this type and version.
+func HasSchemaVariant(blueprintType string, version int) bool {
+	_, ok := schemaRegistry[blueprintType][version]
+	return ok
+}
+
+// v1 variants. Each wraps the canonical struct, because v1 *is* the current
+// shape — the indirection only starts paying off at v2, where the wire struct
+// and the canonical struct diverge and Canonical() does real mapping work.
+
+type packagesV1 struct{ PackagesData }
+
+func (v *packagesV1) Target() interface{}        { return &v.PackagesData }
+func (v *packagesV1) Canonical() interface{}     { return &v.PackagesData }
+func (v *packagesV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type repositoriesV1 struct{ RepositoriesData }
+
+func (v *repositoriesV1) Target() interface{}        { return &v.RepositoriesData }
+func (v *repositoriesV1) Canonical() interface{}     { return &v.RepositoriesData }
+func (v *repositoriesV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type filesV1 struct{ FileData }
+
+func (v *filesV1) Target() interface{}        { return &v.FileData }
+func (v *filesV1) Canonical() interface{}     { return &v.FileData }
+func (v *filesV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type servicesV1 struct{ ServiceData }
+
+func (v *servicesV1) Target() interface{}        { return &v.ServiceData }
+func (v *servicesV1) Canonical() interface{}     { return &v.ServiceData }
+func (v *servicesV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type gitV1 struct{ GitData }
+
+func (v *gitV1) Target() interface{}        { return &v.GitData }
+func (v *gitV1) Canonical() interface{}     { return &v.GitData }
+func (v *gitV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type scriptsV1 struct{ ScriptData }
+
+func (v *scriptsV1) Target() interface{}        { return &v.ScriptData }
+func (v *scriptsV1) Canonical() interface{}     { return &v.ScriptData }
+func (v *scriptsV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type sshKeysV1 struct{ SSHKeyData }
+
+func (v *sshKeysV1) Target() interface{}        { return &v.SSHKeyData }
+func (v *sshKeysV1) Canonical() interface{}     { return &v.SSHKeyData }
+func (v *sshKeysV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type fontsV1 struct{ FontsData }
+
+func (v *fontsV1) Target() interface{}        { return &v.FontsData }
+func (v *fontsV1) Canonical() interface{}     { return &v.FontsData }
+func (v *fontsV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type usersV1 struct{ UsersData }
+
+func (v *usersV1) Target() interface{}        { return &v.UsersData }
+func (v *usersV1) Canonical() interface{}     { return &v.UsersData }
+func (v *usersV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type configurationV1 struct{ ConfigData }
+
+func (v *configurationV1) Target() interface{}        { return &v.ConfigData }
+func (v *configurationV1) Canonical() interface{}     { return &v.ConfigData }
+func (v *configurationV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }

--- a/internal/types/schema_test.go
+++ b/internal/types/schema_test.go
@@ -1,0 +1,127 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveSchemaVersion(t *testing.T) {
+	tests := []struct {
+		name         string
+		fileDeclared int
+		treeDeclared int
+		want         int
+	}{
+		{
+			name: "nothing declared falls back to the default",
+			want: DefaultSchemaVersion,
+		},
+		{
+			name:         "tree version applies when the file says nothing",
+			treeDeclared: 2,
+			want:         2,
+		},
+		{
+			name:         "the file wins over the tree",
+			fileDeclared: 2,
+			treeDeclared: 1,
+			want:         2,
+		},
+		{
+			name:         "the file wins even when older than the tree",
+			fileDeclared: 1,
+			treeDeclared: 2,
+			want:         1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveSchemaVersion(tt.fileDeclared, tt.treeDeclared); got != tt.want {
+				t.Errorf("ResolveSchemaVersion(%d, %d) = %d, want %d",
+					tt.fileDeclared, tt.treeDeclared, got, tt.want)
+			}
+		})
+	}
+}
+
+// Absence must mean v1. Every blueprint written before versioning existed
+// declares nothing, so if absence meant anything else, adding versioning would
+// break every tree in the wild.
+func TestResolveSchemaVersion_UndeclaredIsV1(t *testing.T) {
+	if got := ResolveSchemaVersion(0, 0); got != 1 {
+		t.Errorf("an undeclared blueprint resolves to %d, want 1", got)
+	}
+}
+
+func TestValidateSchemaVersion(t *testing.T) {
+	if err := ValidateSchemaVersion(BlueprintTypePackages, 1); err != nil {
+		t.Errorf("v1 packages should be supported: %v", err)
+	}
+
+	err := ValidateSchemaVersion(BlueprintTypePackages, 2)
+	if err == nil {
+		t.Fatal("v2 packages is not implemented yet and must be rejected")
+	}
+	// The message has to say what went wrong and what to do; a version this build
+	// cannot read means the blueprint would be misread, not merely unsupported.
+	for _, want := range []string{"packages", "2", "supports 1", "upgrade rwr"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err, want)
+		}
+	}
+
+	if err := ValidateSchemaVersion("nonsense", 1); err == nil {
+		t.Error("an unknown blueprint type should be rejected")
+	}
+	if err := ValidateSchemaVersion(BlueprintTypePackages, 0); err == nil {
+		t.Error("version 0 should be rejected as invalid")
+	}
+	if err := ValidateSchemaVersion(BlueprintTypePackages, -1); err == nil {
+		t.Error("a negative version should be rejected")
+	}
+}
+
+func TestValidateTreeSchemaVersion(t *testing.T) {
+	if err := ValidateTreeSchemaVersion(0); err != nil {
+		t.Errorf("an undeclared tree version is valid: %v", err)
+	}
+	if err := ValidateTreeSchemaVersion(1); err != nil {
+		t.Errorf("v1 is supported everywhere: %v", err)
+	}
+
+	err := ValidateTreeSchemaVersion(2)
+	if err == nil {
+		t.Fatal("a tree-wide v2 must be rejected while no type implements v2")
+	}
+	// A tree-wide version applies to every type, so when only some types have a
+	// v2 the fix is to declare it per file — the error should say so.
+	if !strings.Contains(err.Error(), "per blueprint file") {
+		t.Errorf("error should suggest declaring per file, got: %v", err)
+	}
+	if err := ValidateTreeSchemaVersion(-1); err == nil {
+		t.Error("a negative tree version should be rejected")
+	}
+}
+
+// The point of per-type versioning: moving one resource to v2 must not require
+// moving anything else. This asserts the registry is genuinely per type rather
+// than one shared list.
+func TestSupportedSchemaVersions_AreIndependentPerType(t *testing.T) {
+	for _, blueprintType := range []string{
+		BlueprintTypePackages, BlueprintTypeFiles, BlueprintTypeServices,
+		BlueprintTypeGit, BlueprintTypeScripts, BlueprintTypeSSHKeys,
+		BlueprintTypeFonts, BlueprintTypeUsers, BlueprintTypeConfiguration,
+		BlueprintTypeRepositories,
+	} {
+		versions := SupportedSchemaVersions(blueprintType)
+		if len(versions) == 0 {
+			t.Errorf("%s declares no supported schema versions", blueprintType)
+			continue
+		}
+		if versions[0] != 1 {
+			t.Errorf("%s should still support v1 for backwards compatibility, got %v",
+				blueprintType, versions)
+		}
+	}
+}

--- a/internal/types/schema_test.go
+++ b/internal/types/schema_test.go
@@ -13,8 +13,8 @@ func TestResolveSchemaVersion(t *testing.T) {
 		want         int
 	}{
 		{
-			name: "nothing declared falls back to the default",
-			want: DefaultSchemaVersion,
+			name: "nothing declared falls back to the latest supported",
+			want: LatestSchemaVersion(BlueprintTypePackages),
 		},
 		{
 			name:         "tree version applies when the file says nothing",
@@ -37,7 +37,8 @@ func TestResolveSchemaVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ResolveSchemaVersion(tt.fileDeclared, tt.treeDeclared); got != tt.want {
+			got := ResolveSchemaVersion(tt.fileDeclared, tt.treeDeclared, BlueprintTypePackages)
+			if got != tt.want {
 				t.Errorf("ResolveSchemaVersion(%d, %d) = %d, want %d",
 					tt.fileDeclared, tt.treeDeclared, got, tt.want)
 			}
@@ -45,12 +46,47 @@ func TestResolveSchemaVersion(t *testing.T) {
 	}
 }
 
-// Absence must mean v1. Every blueprint written before versioning existed
-// declares nothing, so if absence meant anything else, adding versioning would
-// break every tree in the wild.
-func TestResolveSchemaVersion_UndeclaredIsV1(t *testing.T) {
-	if got := ResolveSchemaVersion(0, 0); got != 1 {
-		t.Errorf("an undeclared blueprint resolves to %d, want 1", got)
+// An undeclared blueprint is read as the latest schema that type supports, so a
+// blueprint written today gets today's format without boilerplate.
+//
+// This asserts against LatestSchemaVersion rather than a literal, so it keeps
+// testing the intent once a type gains a v2 — a hardcoded 1 here would silently
+// keep passing while the behaviour it describes had changed.
+func TestResolveSchemaVersion_UndeclaredIsLatest(t *testing.T) {
+	for _, blueprintType := range []string{
+		BlueprintTypePackages, BlueprintTypeFiles, BlueprintTypeServices,
+	} {
+		want := LatestSchemaVersion(blueprintType)
+		if got := ResolveSchemaVersion(0, 0, blueprintType); got != want {
+			t.Errorf("%s: undeclared resolved to %d, want the latest %d",
+				blueprintType, got, want)
+		}
+	}
+}
+
+// A declaration always wins over the fallback, which is what pins a tree to a
+// version while newer ones exist.
+func TestResolveSchemaVersion_DeclarationPinsAgainstLatest(t *testing.T) {
+	if got := ResolveSchemaVersion(1, 0, BlueprintTypePackages); got != 1 {
+		t.Errorf("a file declaring v1 resolved to %d, want 1", got)
+	}
+	if got := ResolveSchemaVersion(0, 1, BlueprintTypePackages); got != 1 {
+		t.Errorf("a tree declaring v1 resolved to %d, want 1", got)
+	}
+}
+
+func TestLatestSchemaVersion(t *testing.T) {
+	for _, blueprintType := range []string{BlueprintTypePackages, BlueprintTypeFiles} {
+		latest := LatestSchemaVersion(blueprintType)
+		versions := SupportedSchemaVersions(blueprintType)
+		if latest != versions[len(versions)-1] {
+			t.Errorf("%s: latest = %d, but supported versions are %v",
+				blueprintType, latest, versions)
+		}
+	}
+	// An unknown type must not report 0, which would resolve to an invalid version.
+	if got := LatestSchemaVersion("nonsense"); got != DefaultSchemaVersion {
+		t.Errorf("unknown type reported latest %d, want %d", got, DefaultSchemaVersion)
 	}
 }
 
@@ -123,5 +159,39 @@ func TestSupportedSchemaVersions_AreIndependentPerType(t *testing.T) {
 			t.Errorf("%s should still support v1 for backwards compatibility, got %v",
 				blueprintType, versions)
 		}
+	}
+}
+
+// withExtraVersion temporarily teaches the registry that a type supports another
+// version, so the resolution rules can be exercised before any real v2 exists.
+func withExtraVersion(t *testing.T, blueprintType string, version int) {
+	t.Helper()
+	original := append([]int(nil), supportedSchemaVersions[blueprintType]...)
+	supportedSchemaVersions[blueprintType] = append(original, version)
+	t.Cleanup(func() { supportedSchemaVersions[blueprintType] = original })
+}
+
+// The real point of "undeclared means latest": when packages gains a v2, a
+// packages blueprint that declares nothing is read as v2 — while files, which did
+// not change, stays where it is. Today latest is 1 everywhere, so this simulates
+// the v2 to test the rule rather than the current numbers.
+func TestResolveSchemaVersion_UndeclaredFollowsANewVersion(t *testing.T) {
+	withExtraVersion(t, BlueprintTypePackages, 2)
+
+	if got := ResolveSchemaVersion(0, 0, BlueprintTypePackages); got != 2 {
+		t.Errorf("undeclared packages resolved to %d, want the new latest 2", got)
+	}
+	// A type that did not gain a version is unaffected — this is what keeps a
+	// breaking change contained to one resource.
+	if got := ResolveSchemaVersion(0, 0, BlueprintTypeFiles); got != 1 {
+		t.Errorf("undeclared files resolved to %d, want 1 — files did not change", got)
+	}
+	// Declaring a version still pins, which is how a tree stays on v1 after v2
+	// ships.
+	if got := ResolveSchemaVersion(1, 0, BlueprintTypePackages); got != 1 {
+		t.Errorf("packages pinned to v1 resolved to %d, want 1", got)
+	}
+	if got := ResolveSchemaVersion(0, 1, BlueprintTypePackages); got != 1 {
+		t.Errorf("packages under a v1 tree resolved to %d, want 1", got)
 	}
 }

--- a/internal/types/scripts.go
+++ b/internal/types/scripts.go
@@ -15,7 +15,9 @@ type Script struct {
 }
 
 type ScriptData struct {
-	Scripts []Script `mapstructure:"scripts,omitempty" yaml:"scripts,omitempty" json:"scripts,omitempty" toml:"scripts,omitempty"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Scripts       []Script `mapstructure:"scripts,omitempty" yaml:"scripts,omitempty" json:"scripts,omitempty" toml:"scripts,omitempty"`
 }
 
 // GetProfiles returns the profiles for this script.

--- a/internal/types/service.go
+++ b/internal/types/service.go
@@ -14,7 +14,9 @@ type Service struct {
 }
 
 type ServiceData struct {
-	Services []Service `mapstructure:"services" yaml:"services" json:"services" toml:"services"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Services      []Service `mapstructure:"services" yaml:"services" json:"services" toml:"services"`
 }
 
 // GetProfiles returns the profiles for this service.

--- a/internal/types/ssh_key.go
+++ b/internal/types/ssh_key.go
@@ -15,7 +15,9 @@ type SSHKey struct {
 }
 
 type SSHKeyData struct {
-	SSHKeys []SSHKey `mapstructure:"ssh_keys" yaml:"ssh_keys" json:"ssh_keys" toml:"ssh_keys"`
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	SSHKeys       []SSHKey `mapstructure:"ssh_keys" yaml:"ssh_keys" json:"ssh_keys" toml:"ssh_keys"`
 }
 
 // GetProfiles returns the profiles for this SSH key.

--- a/internal/types/users.go
+++ b/internal/types/users.go
@@ -35,8 +35,10 @@ type User struct {
 }
 
 type UsersData struct {
-	Groups []Group `mapstructure:"groups,omitempty" yaml:"groups,omitempty" json:"groups,omitempty" toml:"groups,omitempty"` // Groups data
-	Users  []User  `mapstructure:"users,omitempty" yaml:"users,omitempty" json:"users,omitempty" toml:"users,omitempty"`     // Users data
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Groups        []Group `mapstructure:"groups,omitempty" yaml:"groups,omitempty" json:"groups,omitempty" toml:"groups,omitempty"` // Groups data
+	Users         []User  `mapstructure:"users,omitempty" yaml:"users,omitempty" json:"users,omitempty" toml:"users,omitempty"`     // Users data
 }
 
 // GetProfiles returns the profiles for this group.

--- a/internal/validate/examples_schema_test.go
+++ b/internal/validate/examples_schema_test.go
@@ -3,6 +3,8 @@ package validate
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -110,12 +112,20 @@ func strictDecode(data []byte, format string, target interface{}) []string {
 		dec := yaml.NewDecoder(bytes.NewReader(data))
 		dec.KnownFields(true)
 		if err := dec.Decode(target); err != nil {
+			// An empty document (a fully commented-out blueprint) decodes to EOF.
+			// That is a legitimate file, not an unknown field.
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
 			return unknownFieldsFromError(err.Error())
 		}
 	case "json":
 		dec := json.NewDecoder(bytes.NewReader(data))
 		dec.DisallowUnknownFields()
 		if err := dec.Decode(target); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
 			return unknownFieldsFromError(err.Error())
 		}
 	case "toml":


### PR DESCRIPTION
> Stacked on #153 — review that one first; this PR targets it as its base.

Point 4 of the request. Blueprints can declare which schema version they are
written in, so the format can change without silently misreading configuration
written against the old one.

## Versions are per blueprint type

No single number covers everything. `packages`, `files`, `services` and the rest
each carry their own version.

A shared number would drag `files`, `git`, `scripts` and everything else to v2
because `packages` changed. A few of those and you are on **v11** with no way to
tell which resource each bump was about. Per type, a breaking change to
`packages` produces exactly one change: packages is v2, everything else stays v1
and keeps working untouched.

## Declaration and precedence

Tree-wide, in the init file:

```yaml
blueprints:
  format: yaml
  schema_version: 1
```

Per file, overriding the tree — **this is what makes gradual migration work**:

```yaml
schema_version: 2
packages:
  - name: git
    action: install
```

Most specific wins: **file → tree → latest for that type**. So one packages
blueprint can move to v2 while the rest of the tree, *including other packages
files*, stays v1 — and both are read correctly in the same run. No flag day.

## Undeclared means latest

A blueprint that declares nothing is read as the **newest** version RWR supports
for that type. A blueprint written today gets today's schema without boilerplate,
and `schema_version` is what you add when you want to be **pinned** — not
something you must add to get started.

The trade-off, documented rather than left to be discovered: an undeclared
blueprint follows the schema forward across upgrades. A tree that needs to stay
put says so, and one line in the init file pins the whole thing.

The fallback is per type too — when `packages` gains a v2, an undeclared packages
blueprint is read as v2 while `files`, which didn't change, is still v1.

## Schema as a struct, with conversion

Each version is its own struct describing what that version accepts on disk.
Decoding picks the struct by resolved version, then converts to the canonical
type the processors consume — so nothing past the decoder knows more than one
version exists.

Adding a v2:

1. define the wire struct, e.g. `packagesV2`
2. give it a `Canonical()` mapping onto `PackagesData`
3. register it under `{BlueprintTypePackages: {2: ...}}`
4. list `2` in `supportedSchemaVersions`

**No processor changes. No other type touched.**

## Unsupported versions fail hard

```
packages: schema version 2 is not supported by this build (supports 1) —
upgrade rwr, or write this blueprint in a supported version
```

Not a fallback. RWR installs packages, writes files and runs scripts as root;
reading a v2 blueprint as though it were v1 means acting on a misunderstanding of
what was asked for. Refusing is safer. A tree-wide version must be supported by
every type since it applies to all of them, and the error points at per-file
declaration when only some types have moved.

## Tests

Every type supports only v1 today, which would make an
"undeclared-resolves-to-latest" test **vacuous**. So the rules are exercised
against a temporarily registered v2: an undeclared packages blueprint follows to
2, `files` stays at 1, and a declared v1 still pins in both the file and tree
positions. The undeclared-is-latest assertions compare against
`LatestSchemaVersion` rather than a literal, so they keep testing the intent once
a real v2 lands instead of silently passing while the behaviour changed.

Also covered: resolution precedence in yaml, json **and** toml — the declaration
is an embedded struct and the three decoders handle embedding differently, so
this is worth checking rather than assuming; rejection of an unknown version with
the *requested* version reported back; and that every blueprint type has a v1
decoder registered.

Documented in `docs/schema-versioning.md`, including how to add a version.

## Verification

`go build`, `go test ./...`, `go vet`, `golangci-lint run`, `gosec ./...` all
pass, and `rwr validate` runs clean over all 21 example trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)