### PR TITLE
fix: expand ~ in paths, opt-in credentials, and correct the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ Rinse, Wash, Repeat (RWR) is a powerful and flexible configuration management to
   - [Prerequisites](#prerequisites)
   - [Setting Up Development Environment](#setting-up-development-environment)
   - [Development Commands](#development-commands)
-    - [Local Development (No Dagger)](#local-development-no-dagger)
-    - [Unit Testing Commands](#unit-testing-commands)
-    - [Pipeline Testing (Using Dagger)](#pipeline-testing-using-dagger)
-    - [Individual Dagger Functions](#individual-dagger-functions)
   - [CI/CD Pipeline](#cicd-pipeline)
     - [Environment Variables](#environment-variables)
 - [Contributing](#contributing)
@@ -81,56 +77,50 @@ These scripts will download and install the latest version of RWR appropriate fo
 
 ### Packages
 
-RWR packages are available for various platforms and architectures through goreleaser. You can find the pre-built packages on the [releases page](https://github.com/fynxlabs/rwr/releases) of the RWR repository.
+Get the packages from the
+[releases page](https://github.com/fynxlabs/rwr/releases). These formats are
+available:
 
-The following package types are available:
-
-- Binary archives (`.tar.gz`, `.zip`)
+- Archives (`.tar.gz` and `.zip`)
 - Debian packages (`.deb`)
 - RPM packages (`.rpm`)
 - Alpine packages (`.apk`)
 - Arch packages (`.pkg.tar.zst`)
-- Homebrew taps
+- A Homebrew tap
 
-Builds are published for Linux, macOS and Windows on `x86_64`, `arm64` and
-`armv7`, plus Linux on `riscv64`. Arch Linux packages are not built for
-`riscv64`, since Arch has no official port; use the `.tar.gz`, `.deb`, `.rpm` or
-`.apk` there.
+RWR builds for Linux, macOS and Windows on `x86_64` and `arm64`, for Linux on
+`armv7`, and for Linux on `riscv64`.
 
-### Master prereleases
+### Builds of the master branch
 
-Every merge to `master` publishes a prerelease under the
-[`nightly`](https://github.com/fynxlabs/rwr/releases/tag/nightly) tag, so there is
-always an installable build of current `master`.
+Each merge to `master` publishes a prerelease with the tag `nightly`.
 
-> [!WARNING]
-> These are not releases. They are whatever `master` happened to be when they were
-> built — CI has passed, but they are not vetted or version-tagged. Use the
-> [latest release](https://github.com/fynxlabs/rwr/releases/latest) for anything
-> you depend on.
-
-The tag and its artifacts are replaced on every merge, so the download URLs stay
-stable while their contents change. Artifacts are versioned
-`<next-patch>-master-<short-sha>` so a binary you already have can be traced back
-to the commit it came from:
-
-```bash
-rwr version
-```
+WARNING: A `nightly` build is not a release. It is the master branch at the time
+of the build. Use the
+[latest release](https://github.com/fynxlabs/rwr/releases/latest) for a machine
+that you depend on.
 
 ### From Releases
 
-To install RWR, follow these steps:
+To install RWR from a release:
 
-1. Download the latest release of RWR from the [releases page](https://github.com/fynxlabs/rwr/releases).
-2. Extract the downloaded archive to a directory of your choice.
-3. Add the directory to your system's `PATH` environment variable.
+1. Get the archive for your machine from the
+   [releases page](https://github.com/fynxlabs/rwr/releases).
+2. Compare the file against `checksums.txt` from the same release.
+3. Extract the archive.
+4. Add the directory to your `PATH`.
+
+Read [Install](docs/install.md) for the full description.
 
 ## Getting Started
 
-1. **Initialize configuration**: Run [`rwr config init`](docs/cli/configuration.md) to create your configuration file
-2. **Set up blueprints**: Provide a Git repository URL or local path for your blueprints during configuration
-3. **Initialize system**: Run [`rwr all`](docs/cli/command-and-flags.md) to apply your blueprints
+1. **Make the configuration file**: Run
+   [`rwr config --create`](docs/cli/configuration.md). RWR asks for the settings
+   and writes the file.
+2. **Give the blueprints**: Give a git repository URL or a local path when RWR
+   asks for it.
+3. **Set up the system**: Run [`rwr all`](docs/cli/command-and-flags.md). RWR
+   applies the blueprints.
 
 For detailed setup instructions, see the [Quick Start Guide](docs/quick-start.md).
 
@@ -164,10 +154,10 @@ RWR uses an additive profile system where:
 rwr all
 
 # Apply base + dev profile
-rwr all --profiles dev
+rwr all --profile dev
 
 # Apply base + multiple profiles
-rwr all --profiles dev,work
+rwr all --profile dev --profile work
 ```
 
 For detailed information, see the [Profile System documentation](docs/profiles.md).
@@ -188,10 +178,18 @@ packages:
 
 Import features:
 
-- **Relative Paths**: Import paths are resolved relative to the blueprint directory
-- **Circular Detection**: Automatically prevents infinite import loops
-- **All Blueprint Types**: Works with packages, files, services, git, scripts, and more
-- **Profile Support**: Imported items respect profile filtering
+- **All blueprint types**: packages, files, services, git, scripts, and the
+  others
+- **Profile support**: RWR applies the profile filter to the items that it
+  imports
+
+> [!NOTE]
+> An import brings in one file. RWR does not read the imports inside the file
+> that it imports. Put each import in the file that needs it.
+>
+> Most blueprint types resolve an import path against the `location` in the init
+> file. Files, templates, directories and scripts resolve the path against the
+> directory of the blueprint file. Use a path that is correct for the type.
 
 See the [examples/imports/](examples/imports/) directory for detailed examples.
 
@@ -199,17 +197,18 @@ See the [examples/imports/](examples/imports/) directory for detailed examples.
 
 RWR supports these blueprint types:
 
-- **packages** - Package installation/removal via various package managers
-- **repositories** - Package repository management
-- **files** - File operations (copy, move, delete, symlink, templates)
-- **directories** - Directory management with permissions
-- **services** - System service management
-- **configuration** - System configuration settings
-- **git** - Git repository cloning and management
-- **scripts** - Script execution with multiple interpreter support
-- **users** - User account and group management
-- **bootstrap** - Initial system setup tasks
-- **ssh_keys** - SSH key generation and management
+- **packages** — Install and remove packages with a package manager
+- **repositories** — Manage the package repositories
+- **files** — Copy, move, delete, and link files. The `directories` and
+  `templates` keys are part of this type
+- **services** — Manage the system services
+- **configuration** — Set the desktop and system settings
+- **git** — Clone and update git repositories
+- **scripts** — Run scripts with a program that you select
+- **users** — Manage the user accounts and the groups
+- **ssh_keys** — Make SSH keys and send them to GitHub
+- **fonts** — Install fonts
+- **bootstrap** — Prepare the system before the other types run
 
 For detailed blueprint documentation, see the [Blueprint Types](docs/index.md#blueprints) section.
 
@@ -220,6 +219,7 @@ For detailed documentation on how to use RWR, please refer to the `docs/` direct
 ### Documentation Index
 
 - [Documentation Index](docs/index.md)
+- [Install](docs/install.md)
 - [Quick Start Guide](docs/quick-start.md)
 - [What are Blueprints?](docs/blueprints-general.md)
 - [Init File - The Entrypoint](docs/init-file.md)
@@ -254,6 +254,8 @@ For detailed documentation on how to use RWR, please refer to the `docs/` direct
 - [Profile Best Practices](docs/profile-best-practices.md)
 - [Template Variables](docs/variables.md)
 - [Package Manager Providers](docs/providers.md)
+- [Credentials](docs/credentials.md)
+- [Schema versioning](docs/schema-versioning.md)
 
 For more detailed information on each topic, please refer to the corresponding documentation file.
 
@@ -272,142 +274,93 @@ RWR uses [mise](https://mise.jdx.dev/) to manage development tools. Install mise
     cd rwr
     ```
 
-2. Install required tools:
+2. Install the tools:
 
     ```bash
     mise install
     ```
 
-This installs:
-
-- Go (for building and testing)
-- Dagger (for CI/CD pipeline)
-- GoReleaser (for creating releases)
-- gotestsum (for beautiful test output formatting and CI integration)
+    This installs Go, GoReleaser, gotestsum, golangci-lint, and the other tools
+    that the tasks use.
 
 ### Development Commands
 
-RWR provides several commands for different development scenarios:
-
-#### Local Development (No Dagger)
-
-Fast commands that run directly on your machine:
+Build and run:
 
 ```bash
-# Build the binary
-mise run build
-
-# Run tests with beautiful formatting (uses gotestsum)
-mise run test
-
-# Run raw tests without formatting
-mise run test:raw
+mise run build          # Build the binary
+mise run start -- all   # Run rwr locally; put the arguments after --
+mise run install        # Build and copy to ~/.local/bin (Linux and macOS)
 ```
 
-#### Unit Testing Commands
-
-For targeted testing of specific components, all with beautiful gotestsum formatting:
+Test:
 
 ```bash
-# Run all internal package tests (package-level summary)
-mise run test:unit
-
-# Run tests for specific packages (detailed test names)
-mise run test:helpers     # Test helper functions
-mise run test:processors  # Test blueprint processors
-mise run test:system     # Test system utilities
-
-# Run tests with coverage report
-mise run test:coverage
-
-# Watch mode - automatically run tests when files change
-mise run test:watch
+mise run test           # All tests, with gotestsum formatting
+mise run test:unit      # The internal packages only
+mise run test:coverage  # Tests with a coverage report
+mise run test:watch     # Run the tests again at each file change
 ```
 
-For raw test output without formatting, use the `:raw` variants:
+To test one package:
 
 ```bash
-# Raw test commands (no gotestsum formatting)
-mise run test:unit:raw
-mise run test:helpers:raw
-mise run test:processors:raw
-mise run test:system:raw
+mise run test:helpers
+mise run test:processors
+mise run test:system
 ```
 
-> [!NOTE]
-> gotestsum provides superior test output formatting, watch mode for development, and saves test results to `/tmp/gotest.json` for CI integration and analysis.
+Each test task has a `:raw` form that uses `go test` without the gotestsum
+formatting. Examples are `mise run test:raw` and `mise run test:unit:raw`.
 
-#### Pipeline Testing (Using Dagger)
-
-Test the CI pipeline locally using Dagger:
+Check the code:
 
 ```bash
-# Just run tests through Dagger
-mise run dagger:test
-
-# Test full release pipeline without publishing
-# This will:
-# 1. Run tests
-# 2. Build binaries
-# 3. Create archives
-# 4. Skip actual publishing
-mise run dagger:local
-
-# Run full CI pipeline with publishing
-# Requires:
-# - GITHUB_TOKEN for creating releases
-# - HOMEBREW_TAP_DEPLOY_KEY for updating Homebrew tap
-mise run dagger:ci
+mise run lint       # golangci-lint
+mise run security   # govulncheck
+mise run format     # go fmt
 ```
 
-#### Individual Dagger Functions
-
-You can also run individual Dagger functions for specific tasks:
+Run the full check before you push:
 
 ```bash
-# Build binary through Dagger
-mise run dagger:build
+mise run ci         # test, lint, and security together
+```
 
-# Run linting through Dagger
-mise run dagger:lint
+Update the dependencies:
 
-# Test release process locally (without publishing)
-mise run dagger:release
-
-# Get version information
-mise run dagger:version
-
-# Clean Dagger generated files (useful for dependency issues)
-mise run dagger:clean
+```bash
+mise run update     # go get -u ./... and go mod tidy
 ```
 
 ### CI/CD Pipeline
 
-RWR uses Dagger to manage its CI/CD pipeline. The pipeline:
+GitHub Actions runs the pipeline. There are three workflows.
 
-1. On every push and PR:
-   - Runs tests through Dagger
-   - Reports test results
+`Go Build & Test` runs at each pull request:
 
-2. On version tags (v*):
-   - Runs tests
-   - Creates GitHub release with:
-     - Binary archives (.tar.gz, .zip)
-     - Debian packages (.deb)
-     - RPM packages (.rpm)
-   - Updates Homebrew tap
+- The `ci` job builds the code and runs the tests.
+- The `security` job runs gosec and govulncheck.
+- The `examples` job checks each file in `examples/`: the file parses in its
+  format, the template variables exist, the fields match the blueprint structs,
+  and the YAML, JSON and TOML copies give the same result. The job then runs
+  `rwr validate` over each example tree.
 
-The pipeline can be tested locally using the commands above, making it easy to verify changes before pushing.
+`RWR - Master Prerelease` runs at each merge to `master`. It builds the branch
+and publishes the files under the `nightly` tag. Read [Install](docs/install.md)
+for more information.
+
+`RWR - Release` runs at each version tag. It builds the binaries and the
+packages, creates the GitHub release, and updates the Homebrew tap.
 
 #### Environment Variables
 
-For publishing releases:
+The release workflow needs these secrets:
 
-- `GITHUB_TOKEN`: GitHub token with permissions to:
-  - Create releases
-  - Upload release assets
-  - Update repository contents
-- `HOMEBREW_TAP_DEPLOY_KEY`: SSH key with access to update the Homebrew tap repository
+- `GITHUB_TOKEN` — creates the release and sends the files to it.
+- `HOMEBREW_TAP_DEPLOY_KEY` — an SSH key that can write to the Homebrew tap
+  repository.
+- `NAUR_DISPATCH_TOKEN` — starts the update of the naur repository.
 
 ## Contributing
 

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -93,12 +93,18 @@ Profiles allow you to organize and selectively install configurations based on d
 
 When working with RWR, keep the following security best practices in mind:
 
-1. Protect sensitive information, such as passwords or API keys, by using variables and storing them securely (e.g., using environment variables or a secure storage system).
+1. RWR withholds your GitHub token and SSH private key from blueprints. Give a
+   credential to a blueprint only when the blueprint needs it, with the
+   `exposeCredentials` key. Read [Credentials](credentials.md) before you use
+   that key.
 
-2. Regularly update your system packages and dependencies to address security vulnerabilities.
+2. RWR removes credential values from the logs. Use the `--show-secrets` flag
+   only when you must see a value, and do not keep that output.
 
-3. Limit access to your RWR configuration files and repositories to authorized users only.
+3. Regularly update your system packages and dependencies to address security vulnerabilities.
 
-4. Use secure communication channels (e.g., HTTPS, SSH) when accessing remote repositories or servers.
+4. Limit access to your RWR configuration files and repositories to authorized users only.
+
+5. Use secure communication channels (e.g., HTTPS, SSH) when accessing remote repositories or servers.
 
 By following these best practices, you can create well-organized, maintainable, and secure configurations with RWR, making it easier to manage your personal machine and test configurations safely before applying them to your local system.

--- a/docs/blueprints-general.md
+++ b/docs/blueprints-general.md
@@ -98,19 +98,31 @@ blueprints/
 
 ## Blueprint Processing Order
 
-The order in which blueprints are processed is determined by the `blueprints.order` setting in the `init.yaml` file. If not specified, RWR will process blueprints in the following default order:
+The `blueprints.order` setting in the `init.yaml` file gives the order of the
+blueprint types. RWR uses this default order when the init file gives no order:
 
-1. Packages
-2. Repositories
-3. Files
-4. Directories
-5. Services
-6. Configuration
-7. Git
-8. Scripts
-9. Users and Groups
+1. Repositories
+2. Packages
+3. SSH keys
+4. Users and groups
+5. Files
+6. Fonts
+7. Services
+8. Git
+9. Scripts
+10. Configuration
 
-You can customize the processing order by specifying the desired order in the `blueprints.order` setting. For example:
+Two notes about this list:
+
+- Directories are not a blueprint type. The `directories` key is part of a files
+  blueprint, with the `files` and `templates` keys. The files processor reads all
+  three keys.
+- Package managers are not in this list. RWR installs the package managers from
+  the `packageManagers` section of the init file. This happens before the
+  blueprint types in the list.
+
+To use a different order, give the order in the `blueprints.order` setting. For
+example:
 
 ```yaml
 blueprints:

--- a/docs/blueprints/directories.md
+++ b/docs/blueprints/directories.md
@@ -1,10 +1,19 @@
 # Directories Blueprint
 
-The Directories Blueprint in Rinse, Wash, Repeat (RWR) allows you to manage directories on your system. You can create, delete, copy, move, and set permissions and ownership for directories.
+The `directories` key manages the directories on your system. You can create,
+delete, copy, and move a directory. You can also set the permissions and the
+owner of a directory.
+
+> [!IMPORTANT]
+> `directories` is not a blueprint type. It is a key in a **files** blueprint,
+> with the `files` and `templates` keys. Put it in a file under your `files/`
+> directory. The files processor reads all three keys.
+>
+> There is no `rwr run directories` command. Use `rwr run files`.
 
 ## Blueprint Structure
 
-The Directories Blueprint has the following structure:
+The `directories` key has this structure:
 
 ```yaml
 directories:
@@ -13,10 +22,9 @@ directories:
     action: string
     source: string
     target: string
-    owner: int
-    group: int
+    owner: string
+    group: string
     mode: int
-    create: bool
     elevated: bool
 ```
 
@@ -31,10 +39,9 @@ The following settings are available for the Directories Blueprint:
 | `action` | string | The action to perform on the directory (create, delete, copy, move, chmod, chown, chgrp, symlink) |
 | `source` | string | The source directory path (for copy, move, and symlink actions) |
 | `target` | string | The target directory path |
-| `owner` | int | The user ID of the directory owner (for chown action) |
-| `group` | int | The group ID of the directory group (for chgrp action) |
-| `mode` | int | The permissions of the directory in octal notation (for chmod action) |
-| `create` | bool | Whether to create the parent directories if they don't exist (default: false) |
+| `owner` | string | The name of the owner of the directory (for the chown action) |
+| `group` | string | The name of the group of the directory (for the chgrp action) |
+| `mode` | int | The permissions of the directory, in octal. Write `0755`, not `755`. The value `755` is a decimal number and gives the wrong permissions |
 | `elevated` | bool | Whether to perform the action with elevated privileges (default: false) |
 | `interactive` | bool | Override global interactive mode for this directory (`true`/`false`). If omitted, uses the global `--interactive` flag. Controls whether diffs are shown before overwriting existing files during copy operations |
 
@@ -50,7 +57,6 @@ directories:
     action: create
     target: /path/to/mydir
     mode: 0755
-    create: true
     elevated: true
 
   - names:
@@ -59,8 +65,8 @@ directories:
     action: copy
     source: /path/to/source
     target: /path/to/destination
-    owner: 1000
-    group: 1000
+    owner: "levi"
+    group: "levi"
 ```
 
 ### JSON
@@ -73,7 +79,6 @@ directories:
       "action": "create",
       "target": "/path/to/mydir",
       "mode": 493,
-      "create": true,
       "elevated": true
     },
     {
@@ -84,8 +89,8 @@ directories:
       "action": "copy",
       "source": "/path/to/source",
       "target": "/path/to/destination",
-      "owner": 1000,
-      "group": 1000
+      "owner": "levi",
+      "group": "levi"
     }
   ]
 }
@@ -99,7 +104,6 @@ name = "mydir"
 action = "create"
 target = "/path/to/mydir"
 mode = 493
-create = true
 elevated = true
 
 [[directories]]
@@ -107,8 +111,8 @@ names = ["dir1", "dir2"]
 action = "copy"
 source = "/path/to/source"
 target = "/path/to/destination"
-owner = 1000
-group = 1000
+owner = "levi"
+group = "levi"
 ```
 
 These examples demonstrate how to create a directory with specific permissions, copy multiple directories while setting owner and group, and perform actions with elevated privileges.

--- a/docs/blueprints/git.md
+++ b/docs/blueprints/git.md
@@ -112,4 +112,4 @@ If you encounter issues while using the Git blueprint, consider the following:
 - Verify that you have provided the necessary authentication details for private repositories.
 - Check that the specified local path for cloning the repository is valid and has the required permissions.
 
-If the issue persists, please refer to the [Troubleshooting](../troubleshooting.md) section or reach out to the RWR community for assistance.
+If the issue persists, open an issue at [github.com/fynxlabs/rwr/issues](https://github.com/fynxlabs/rwr/issues).

--- a/docs/blueprints/scripts.md
+++ b/docs/blueprints/scripts.md
@@ -138,6 +138,35 @@ The Scripts blueprint supports the following fields:
 > [!NOTE]
 > Either the `source`, `content`, or `import` field must be provided. If both `source` and `content` are present, `source` takes precedence.
 
+### How RWR runs the arguments
+
+RWR divides the `args` string at each space. It then sends each part to the
+script as one argument. The value `--verbose --out /tmp` becomes three
+arguments.
+
+RWR does not use a shell to run the script. The shell characters keep their
+literal value. These characters have no special function:
+
+| Character | Result |
+|---|---|
+| `$HOME`, `$(command)` | RWR sends the text without a change |
+| `~` | RWR sends the character without a change |
+| `*`, `?` | RWR does not expand the pattern to file names |
+| `&&`, `\|`, `;` | RWR sends the character as part of the argument |
+
+To use a shell function, run a shell as the script. Give the command in the
+script file, or run the shell directly:
+
+```yaml
+scripts:
+  - name: build.sh
+    action: run
+    exec: bash
+    source: ./scripts/
+```
+
+The script file can then use `$HOME`, pipes, and the other shell functions.
+
 ## Blueprint Imports
 
 Import script definitions from other files:

--- a/docs/blueprints/scripts.md
+++ b/docs/blueprints/scripts.md
@@ -12,7 +12,6 @@ The Scripts blueprint follows the same structure as other blueprints in RWR. It 
 scripts:
   # Base script - always runs (no profiles field)
   - name: setup_common
-    description: "Common setup script"
     source: scripts/common_setup.sh
     action: run
     exec: bash
@@ -21,7 +20,6 @@ scripts:
 
   # Development profile script
   - name: dev_environment
-    description: "Setup development environment"
     profiles:
       - dev
     content: |
@@ -34,7 +32,6 @@ scripts:
 
   # Work profile script with custom executor
   - name: work_tools
-    description: "Install work-specific tools"
     profiles:
       - work
     source: scripts/work_setup.py
@@ -50,7 +47,6 @@ scripts:
   "scripts": [
     {
       "name": "setup_common",
-      "description": "Common setup script",
       "source": "scripts/common_setup.sh",
       "action": "run",
       "exec": "bash",
@@ -59,7 +55,6 @@ scripts:
     },
     {
       "name": "dev_environment",
-      "description": "Setup development environment",
       "profiles": ["dev"],
       "content": "#!/bin/bash\necho \"Setting up development environment...\"\nexport NODE_ENV=development",
       "action": "run",
@@ -68,7 +63,6 @@ scripts:
     },
     {
       "name": "work_tools",
-      "description": "Install work-specific tools",
       "profiles": ["work"],
       "source": "scripts/work_setup.py",
       "action": "run",
@@ -85,7 +79,6 @@ scripts:
 # Base script - always runs (no profiles field)
 [[scripts]]
 name = "setup_common"
-description = "Common setup script"
 source = "scripts/common_setup.sh"
 action = "run"
 exec = "bash"
@@ -95,7 +88,6 @@ log = "setup"
 # Development profile script
 [[scripts]]
 name = "dev_environment"
-description = "Setup development environment"
 profiles = ["dev"]
 content = """
 #!/bin/bash
@@ -109,7 +101,6 @@ args = "--verbose"
 # Work profile script with custom executor
 [[scripts]]
 name = "work_tools"
-description = "Install work-specific tools"
 profiles = ["work"]
 source = "scripts/work_setup.py"
 action = "run"
@@ -127,7 +118,7 @@ The Scripts blueprint supports the following fields:
 | `import` | Yes, if `name` is not provided | Path to import script definitions from another file (relative to blueprint directory) |
 | `profiles` | No | List of profiles this script belongs to. If empty, script always runs (base item). |
 | `action` | Yes | The action to perform with the script. Currently, only `run` is supported. |
-| `exec` | No | The script interpreter/executor (e.g., `bash`, `python`, `ruby`, `powershell`, `self`). Auto-detected if not specified. |
+| `exec` | No | The program that runs the script: `bash`, `python`, `ruby`, `perl`, `lua`, `powershell`, or `self`. The default is `bash` on Linux and macOS, and `powershell` on Windows. `self` runs the script file directly |
 | `source` | No | The path to the script file (relative to blueprint directory). |
 | `content` | No | The inline content of the script. |
 | `args` | No | Additional arguments to pass to the script. |
@@ -193,15 +184,21 @@ This allows you to reuse common scripts across multiple configurations.
 
 When the Scripts blueprint is processed, RWR will execute the specified scripts in the order they are defined. The scripts can be provided either as separate files using the `source` field or as inline content using the `content` field.
 
-RWR supports executing scripts written in various languages, such as Bash, Python, Ruby, and more. The appropriate interpreter will be used based on the shebang line (`#!/bin/bash`, `#!/usr/bin/env python`, etc.) or file extension.
+RWR runs scripts in Bash, Python, Ruby, Perl, Lua, and PowerShell. The `exec`
+field gives the program that runs the script.
 
-If the `elevated` field is set to `true`, the script will be executed with elevated privileges (e.g., using `sudo` on Unix-like systems).
+CAUTION: RWR does not read the shebang line and does not read the file
+extension. Give the `exec` field. Without it, RWR uses `bash` on Linux and
+macOS, and `powershell` on Windows.
+
+With `elevated: true`, RWR runs the script as `sudo -- <program> <script>`. With
+the `asUser` field, RWR runs it as `sudo -u <user> -- <program> <script>`.
 
 ## Best Practices
 
 - Keep your scripts concise and focused on specific tasks.
 - Use descriptive names for your scripts to make their purpose clear.
-- Provide a shebang line at the beginning of your scripts to specify the interpreter.
+- Give the `exec` field for each script. RWR does not read the shebang line.
 - Use the `elevated` field sparingly and only when necessary.
 - Consider using variables and templating to make your scripts more dynamic and reusable.
 - Test your scripts thoroughly before including them in your RWR configuration.
@@ -215,4 +212,4 @@ If you encounter issues with the Scripts blueprint, consider the following:
 - Check the RWR logs for any error messages or output related to script execution.
 - Use the `--debug` flag when running RWR to enable verbose output and gather more information.
 
-If you need further assistance, please refer to the [Troubleshooting](../troubleshooting.md) section or reach out to the RWR community for support.
+If you need further assistance, open an issue at [github.com/fynxlabs/rwr/issues](https://github.com/fynxlabs/rwr/issues).

--- a/docs/cli/command-and-flags.md
+++ b/docs/cli/command-and-flags.md
@@ -18,6 +18,10 @@ The following flags are available for all commands:
 | `--dry-run` | Simulate operations without making changes (no-op mode) |
 | `--no-op` | Alias for `--dry-run` |
 | `--interactive`, `-I` | Enable interactive mode (default: true). Use `--interactive=false` to disable |
+| `--gh-key` | Another name for `--gh-api-key` |
+| `--gh-auth` | Get a GitHub token with the OAuth device flow |
+| `--profile`, `-p` | Make a profile active. Use the flag one time for each profile |
+| `--force-bootstrap` | Run the bootstrap process again |
 
 ## Commands
 
@@ -33,21 +37,37 @@ Manage RWR configuration settings.
 
 ### `rwr all`
 
-Initialize the system by running all blueprints.
+Run all blueprints and set up the system.
 
-| Flag | Description |
-|------|-------------|
-| `--force-bootstrap` | Force the bootstrap process to run again |
+`--force-bootstrap` is a global flag. It also applies to this command.
 
 ### `rwr validate`
 
-Validate the RWR blueprints.
+Check the RWR blueprints and the provider configurations.
+
+Give the path as an argument, not as a flag:
+
+```bash
+rwr validate path/to/blueprints
+```
+
+| Flag | Description |
+|------|-------------|
+| `--blueprints` | Check the path as blueprint files |
+| `--providers` | Check the path as provider configurations |
+| `--verbose` | Show more information about each check |
+
+### `rwr profiles`
+
+Show the profiles that the blueprints use.
+
+This command has no flags.
 
 ### `rwr run`
 
 Run individual processors.
 
-#### `rwr run package`
+#### `rwr run packages`
 
 Run the package processor.
 
@@ -78,11 +98,20 @@ Run the scripts processor.
 
 #### `rwr run ssh_keys`
 
-Run the scripts processor.
+Run the SSH key processor. Use `--gh-auth` with this command to get a GitHub
+token first.
 
 #### `rwr run users`
 
 Run the users and groups processor.
+
+#### `rwr run fonts`
+
+Run the fonts processor.
+
+> [!NOTE]
+> There is no `rwr run directories` command. The `directories` key is part of a
+> files blueprint. Use `rwr run files` to process it.
 
 ## Examples
 
@@ -93,7 +122,7 @@ Here are a few examples of using the RWR CLI with different commands and flags:
 rwr all --debug
 
 # Run the package processor with a specific init file
-rwr run package --init-file path/to/init.yaml
+rwr run packages --init-file path/to/init.yaml
 
 # Create the configuration file
 rwr config --create

--- a/docs/cli/validate.md
+++ b/docs/cli/validate.md
@@ -23,9 +23,13 @@ The validation process includes:
 |------|-------------|
 | `--blueprints` | Validate only blueprint files |
 | `--providers` | Validate only provider configurations |
-| `--all` | Validate everything (default) |
-| `--path string` | Path to validate (default current directory) |
 | `--verbose` | Show detailed validation information |
+
+Give the path as an argument, not as a flag:
+
+```bash
+rwr validate path/to/blueprints
+```
 
 ## Validation Process
 
@@ -101,7 +105,7 @@ rwr validate --providers
 To validate configurations in a specific directory:
 
 ```bash
-rwr validate --path /path/to/configs
+rwr validate /path/to/configs
 ```
 
 ### Verbose Output

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,79 @@
+# Credentials in blueprints
+
+RWR holds two credentials: your GitHub API token and your SSH private key. By
+default, blueprints cannot read either.
+
+## Why they are withheld by default
+
+Blueprints are usually cloned from a git repository, and everything a blueprint
+can reach, whoever wrote that blueprint can reach:
+
+- a **template** renders from a blueprint file and is written to a path the same
+  blueprint chooses, so a token in template scope can be copied anywhere
+- a **script** inherits RWR's environment, so anything exported is readable by
+  every script the blueprint runs
+
+That is fine when the blueprint is yours. It is not fine for a blueprint you
+cloned from someone else, and there is no way for RWR to tell the difference.
+
+## Opting in
+
+Some blueprints legitimately need a credential — writing a `.netrc`, configuring
+`gh`, calling the GitHub API from a script. Name the ones you want available:
+
+```yaml
+blueprints:
+  format: yaml
+  location: "."
+
+exposeCredentials:
+  - gh_api_token
+```
+
+Only what you name is shared. Opting into `gh_api_token` does not expose the SSH
+key.
+
+Accepted names:
+
+| Name | Also accepted as |
+|---|---|
+| `gh_api_token` | `repository.gh_api_token` |
+| `ssh_private_key` | `repository.ssh_private_key` |
+
+RWR warns at startup when anything is exposed, so it is never silent.
+
+## What opting in gives you
+
+**In templates**, as before:
+
+```yaml
+templates:
+  - name: netrc
+    action: copy
+    source: ./src/netrc.tmpl
+    target: "{{ .User.home }}/.netrc"
+```
+
+```
+machine github.com login {{ .User.username }} password {{ .Flags.ghAPIToken }}
+```
+
+**In scripts**, through the environment:
+
+```bash
+#!/usr/bin/env bash
+gh auth login --with-token <<< "$RWR_VAR_REPOSITORY_GH_API_TOKEN"
+```
+
+## Keeping the blast radius small
+
+- Name only the credential a blueprint actually needs.
+- Set it in the init file of the tree that needs it, not in a shared one.
+- Prefer having RWR do the work itself where it can — `ssh_keys` blueprints
+  already upload to GitHub using the token without exposing it to anything.
+
+## Logs
+
+Credential values are redacted in logs regardless of this setting. Use
+`--show-secrets` when you need to confirm RWR is reading the value you expect;
+it warns while enabled.

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,25 +1,28 @@
 # Credentials in blueprints
 
 RWR holds two credentials: your GitHub API token and your SSH private key. By
-default, blueprints cannot read either.
+default, blueprints cannot read them.
 
-## Why they are withheld by default
+## Why RWR holds back the credentials
 
-Blueprints are usually cloned from a git repository, and everything a blueprint
-can reach, whoever wrote that blueprint can reach:
+Blueprints usually come from a git repository. Everything that a blueprint can
+read, the author of that blueprint can read:
 
-- a **template** renders from a blueprint file and is written to a path the same
-  blueprint chooses, so a token in template scope can be copied anywhere
-- a **script** inherits RWR's environment, so anything exported is readable by
-  every script the blueprint runs
+- A template reads from a blueprint file. RWR writes the result to a path that
+  the same blueprint selects. A token in template scope can go to any path.
+- A script gets the environment of RWR. Every script in the blueprint can read
+  each variable in that environment.
 
-That is fine when the blueprint is yours. It is not fine for a blueprint you
-cloned from someone else, and there is no way for RWR to tell the difference.
+This is safe when the blueprint is yours. This is not safe for a blueprint from a
+different author. RWR cannot tell the difference between the two.
 
-## Opting in
+## How to permit a credential
 
-Some blueprints legitimately need a credential — writing a `.netrc`, configuring
-`gh`, calling the GitHub API from a script. Name the ones you want available:
+Some blueprints need a credential. Examples are a blueprint that writes a
+`.netrc` file, a blueprint that configures `gh`, and a script that calls the
+GitHub API.
+
+Give the name of each credential that the blueprints can read:
 
 ```yaml
 blueprints:
@@ -30,21 +33,22 @@ exposeCredentials:
   - gh_api_token
 ```
 
-Only what you name is shared. Opting into `gh_api_token` does not expose the SSH
-key.
+RWR shares only the credentials that you give. The name `gh_api_token` does not
+give access to the SSH key.
 
-Accepted names:
+These names are correct:
 
-| Name | Also accepted as |
+| Name | RWR also accepts |
 |---|---|
 | `gh_api_token` | `repository.gh_api_token` |
 | `ssh_private_key` | `repository.ssh_private_key` |
 
-RWR warns at startup when anything is exposed, so it is never silent.
+RWR gives a warning at start when a credential is available. The change is
+always visible.
 
-## What opting in gives you
+## What a permitted credential gives you
 
-**In templates**, as before:
+In a template:
 
 ```yaml
 templates:
@@ -58,22 +62,25 @@ templates:
 machine github.com login {{ .User.username }} password {{ .Flags.ghAPIToken }}
 ```
 
-**In scripts**, through the environment:
+In a script, through the environment:
 
 ```bash
 #!/usr/bin/env bash
 gh auth login --with-token <<< "$RWR_VAR_REPOSITORY_GH_API_TOKEN"
 ```
 
-## Keeping the blast radius small
+## How to keep the risk small
 
-- Name only the credential a blueprint actually needs.
-- Set it in the init file of the tree that needs it, not in a shared one.
-- Prefer having RWR do the work itself where it can — `ssh_keys` blueprints
-  already upload to GitHub using the token without exposing it to anything.
+- Give only the credential that the blueprint needs.
+- Set `exposeCredentials` in the init file of the tree that needs it. Do not set
+  it in an init file that other trees use.
+- Let RWR do the work when it can. An `ssh_keys` blueprint sends the key to
+  GitHub with the token. The blueprint does not read the token.
 
 ## Logs
 
-Credential values are redacted in logs regardless of this setting. Use
-`--show-secrets` when you need to confirm RWR is reading the value you expect;
-it warns while enabled.
+RWR removes credential values from the logs. This applies to permitted
+credentials also.
+
+If you must see a value in the logs, use the `--show-secrets` flag. RWR gives a
+warning while this flag is active.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,10 @@ Welcome to the Rinse, Wash, Repeat (RWR) documentation! This guide aims to provi
 
 RWR is a powerful and flexible configuration management tool designed for those who like to hop around and reinstall frequently, regardless of whether it's Linux, macOS, or Windows. It simplifies the process of setting up and maintaining your system by using blueprint-based configurations with an advanced profile system for selective installation.
 
-## Quick Start Guide
+## Install and Quick Start
 
+- [Install](install.md): The supported platforms, the install scripts, and the
+  builds of the master branch.
 - [Quick Start Guide](quick-start.md): Get up and running with RWR quickly by following this concise guide.
 
 ## Profile System
@@ -44,7 +46,8 @@ RWR supports various blueprint types for managing different aspects of your syst
 - [Repositories Blueprint](blueprints/repositories.md)
 - [Configuration Blueprint](blueprints/configuration.md)
 - [Files Blueprint](blueprints/files.md)
-- [Directories Blueprint](blueprints/directories.md)
+- [Directories Blueprint](blueprints/directories.md) (a key in a files blueprint,
+  not a separate type)
 - [Services Blueprint](blueprints/services.md)
 - [Users and Groups Blueprint](blueprints/users-and-groups.md)
 - [Git Blueprint](blueprints/git.md)
@@ -55,6 +58,13 @@ RWR supports various blueprint types for managing different aspects of your syst
 ## Variables and Templating
 
 - [Variables and Templating](variables.md): Learn how to use variables and templating in blueprints to make them more dynamic and reusable.
+
+## Credentials and Schema Versions
+
+- [Credentials](credentials.md): How RWR holds your GitHub token and SSH key, and
+  how to give a blueprint access to one.
+- [Schema versioning](schema-versioning.md): How a blueprint gives the schema
+  version that it uses, and how one blueprint type moves to a new version.
 
 ## Best Practices
 

--- a/docs/init-file.md
+++ b/docs/init-file.md
@@ -22,9 +22,29 @@ The `blueprints` section defines the configuration settings for your blueprints.
 |-------|-------------|----------|
 | `format` | The format of the blueprint files (yaml, json, toml) | Yes |
 | `location` | The directory where the blueprint files are located | No (default: current directory) |
-| `order` | The order of execution for the blueprints | No (default: alphabetical order) |
+| `order` | The order of the blueprint types | No. The default is a fixed order. See [Blueprints General](blueprints-general.md) |
 | `git` | Git repository settings for managing blueprints | No |
 | `runOnlyListed` | Whether to run only the blueprints listed in the `order` field | No (default: false) |
+| `templatesEnabled` | Whether to process template files | No (default: false) |
+| `schema_version` | The blueprint schema version for this tree. See [Schema versioning](schema-versioning.md) | No. The default is the latest version |
+
+> [!IMPORTANT]
+> Do not put `packageManagers` in the `order` field. RWR installs the package
+> managers from the `packageManagers` section before it reads the blueprint
+> types. A `packageManagers` entry in `order` gives an "Unknown processor"
+> warning and does nothing.
+
+### `exposeCredentials`
+
+The `exposeCredentials` section gives the credentials that the blueprints in this
+tree can read. RWR withholds all credentials by default.
+
+```yaml
+exposeCredentials:
+  - gh_api_token
+```
+
+See [Credentials](credentials.md) for the full description.
 
 ### `packageManagers`
 
@@ -149,21 +169,21 @@ For managing GNOME extensions.
 Example configurations for package manager installation:
 
 ```yaml
-package_managers:
+packageManagers:
   - name: brew
     action: install
   - name: nix
     action: install
   - name: cargo
     action: install
-    as_user: johndoe
+    asUser: johndoe
   - name: gnome-extensions
     action: install
 ```
 
 ```json
 {
-  "package_managers": [
+  "packageManagers": [
     {
       "name": "brew",
       "action": "install"
@@ -175,7 +195,7 @@ package_managers:
     {
       "name": "cargo",
       "action": "install",
-      "as_user": "johndoe"
+      "asUser": "johndoe"
     },
     {
       "name": "gnome-extensions",
@@ -186,20 +206,20 @@ package_managers:
 ```
 
 ```toml
-[[package_managers]]
+[[packageManagers]]
 name = "brew"
 action = "install"
 
-[[package_managers]]
+[[packageManagers]]
 name = "nix"
 action = "install"
 
-[[package_managers]]
+[[packageManagers]]
 name = "cargo"
 action = "install"
-as_user = "johndoe"
+asUser = "johndoe"
 
-[[package_managers]]
+[[packageManagers]]
 name = "gnome-extensions"
 action = "install"
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,79 @@
+# Install RWR
+
+## Install with a script
+
+On Linux and macOS:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/FynxLabs/rwr/refs/heads/master/install.sh | sudo bash
+```
+
+On Windows, in a PowerShell that you started with "Run as administrator":
+
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/FynxLabs/rwr/refs/heads/master/install.ps1'))
+```
+
+Each script finds the correct build for your machine, compares the download
+against the published checksum, and stops if the two do not agree.
+
+WARNING: Read a script before you run it with root or administrator permissions.
+Both scripts are in the RWR repository.
+
+## Platforms
+
+RWR publishes a build for each of these:
+
+| Operating system | Architectures |
+|---|---|
+| Linux | `x86_64`, `arm64`, `armv7`, `riscv64` |
+| macOS | `x86_64`, `arm64` |
+| Windows | `x86_64`, `arm64` |
+
+These package formats are on the
+[releases page](https://github.com/fynxlabs/rwr/releases):
+
+- Archives (`.tar.gz` for Linux and macOS, `.zip` for Windows)
+- Debian packages (`.deb`)
+- RPM packages (`.rpm`)
+- Alpine packages (`.apk`)
+- Arch packages (`.pkg.tar.zst`)
+- A Homebrew tap
+
+There is no Arch package for `riscv64`, because Arch has no official riscv64
+port. On that architecture, use the archive, the `.deb`, the `.rpm`, or the
+`.apk`.
+
+## Install from a release
+
+1. Get the archive for your machine from the
+   [releases page](https://github.com/fynxlabs/rwr/releases).
+2. Compare the file against `checksums.txt` from the same release.
+3. Extract the archive.
+4. Move the `rwr` binary to a directory in your `PATH`.
+
+## Builds of the master branch
+
+Each merge to `master` publishes a prerelease with the tag
+[`nightly`](https://github.com/fynxlabs/rwr/releases/tag/nightly). Use it to test
+a correction before the next release.
+
+WARNING: A `nightly` build is not a release. It is the master branch at the time
+of the build. The build passed CI, but nobody tested it. Use the
+[latest release](https://github.com/fynxlabs/rwr/releases/latest) for a machine
+that you depend on.
+
+RWR replaces the `nightly` tag and its files at each merge. The download
+addresses stay the same, and the content changes.
+
+The version of a nightly build contains the commit, in the form
+`<next-patch>-master-<short-sha>`. To find the commit that made a binary:
+
+```bash
+rwr version
+```
+
+## Next steps
+
+- [Quick Start](quick-start.md)
+- [Configuration File](cli/configuration.md)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -33,6 +33,32 @@ search = "search"    # Search for packages
 clean = "clean"     # Clean package cache
 ```
 
+## How RWR finds a provider
+
+RWR makes the provider available when these two conditions are true:
+
+1. The `binary` is on the system.
+2. Each path in `files` is on the system.
+
+The `distributions` list is a hint. A match in that list is not necessary.
+
+This is intentional. There are many derivatives of Arch and Debian, and one list
+cannot contain all of them. Some derivatives give a new value in
+`/etc/os-release` and give no `ID_LIKE` value. A machine that has the `pacman`
+binary and the `/var/lib/pacman` database uses pacman. The name of the
+distribution does not change that fact.
+
+The opposite condition is also correct. A machine with the name "Arch" that uses
+apt has no `apt` binary and no `/etc/apt` directory. RWR does not make apt
+available on that machine. RWR tests each package manager, not the name of the
+distribution.
+
+Give a `files` list for each provider. Without that list, RWR can find the
+provider only from a match in `distributions`.
+
+RWR also finds the distribution family from the installed package manager. This
+gives the correct default package manager on a derivative that no list contains.
+
 ### Core Packages
 
 Define packages required by the provider:
@@ -93,38 +119,42 @@ dest = "/tmp/provider.tar.gz"
 
 ## Available Actions
 
-The following actions can be used in provider steps:
+RWR reads these actions in the installation steps of a provider:
 
-- `download` - Download a file from URL
+- `command` - Run a command
+- `download` - Get a file from a URL
 - `write` - Write content to a file
-- `append` - Append content to a file
-- `command` - Execute a command
-- `remove` - Remove a file/directory
-- `remove_line` - Remove matching line from file
-- `remove_section` - Remove config section
-- `mkdir` - Create directory
-- `chmod` - Change file permissions
-- `chown` - Change file ownership
-- `symlink` - Create symbolic link
-- `copy` - Copy file or directory
+
+RWR reads these actions in the repository steps of a provider:
+
+- `command` - Run a command
+- `write` - Write content to a file
+- `copy` - Copy a file
+
+CAUTION: Use only the actions in these two lists. RWR stops with an error when a
+step gives a different action. Some provider files in this repository contain
+other actions, and those steps do not operate.
 
 ## Template Variables
 
-Variables available in repository steps:
+These variables are in the repository steps of the provider files:
 
-- `{{ .Name }}` - Repository/package name
-- `{{ .URL }}` - Repository URL
-- `{{ .KeyURL }}` - GPG key URL
-- `{{ .KeyPath }}` - Key storage path
-- `{{ .SourcesPath }}` - Repository config path
-- `{{ .HasKey }}` - Whether key was provided
-- `{{ .IsCustom }}` - If custom/third-party repo
-- `{{ .UserMode }}` - If user-mode installation
-- `{{ .SystemMode }}` - If system-wide installation
-- `{{ .Version }}` - Package version
-- `{{ .Architecture }}` - System architecture
-- `{{ .Distribution }}` - Linux distribution
-- `{{ .Platform }}` - Operating system
+- `{{ .Name }}` - Name of the repository or package
+- `{{ .URL }}` - URL of the repository
+- `{{ .KeyURL }}` - URL of the GPG key
+- `{{ .KeyPath }}` - Path of the key on the machine
+- `{{ .SourcesPath }}` - Path of the repository configuration
+- `{{ .Arch }}` - Architecture of the system
+- `{{ .Channel }}` - Channel of the repository
+- `{{ .Component }}` - Component of the repository
+
+CAUTION: RWR replaces only `{{ .URL }}`, and only in the `args` of a step. RWR
+does not replace the other variables. RWR does not replace a variable in the
+`dest` or `content` of a step. A step that uses one of those variables writes the
+text of the variable to the file.
+
+This is a known fault. Do not write a new provider that depends on these
+variables until the fault is corrected.
 
 ## Supported Providers
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -81,7 +81,7 @@ To run your first blueprint, follow these steps:
     rwr all
     ```
 
-    This will install only the base packages (git and curl).
+    RWR installs only the base packages: git, curl, wget, and htop.
 
 3. To install packages for specific profiles, use the `--profile` flag:
 

--- a/docs/schema-versioning.md
+++ b/docs/schema-versioning.md
@@ -1,26 +1,25 @@
 # Blueprint schema versioning
 
-Blueprints declare which version of the schema they are written in, so RWR can
-change a blueprint format without silently misreading configuration that was
-written against the old one.
+A blueprint can give the version of the schema that it uses. RWR can then change
+a blueprint format and still read your older blueprints correctly.
 
-## Versions are per blueprint type
+## Each blueprint type has its own version
 
-There is no single schema number covering everything. Each blueprint type —
-`packages`, `files`, `services`, and so on — carries its own version.
+There is no single version number for the full schema. Each blueprint type has a
+version. The types are `packages`, `files`, `services`, and the others.
 
-That is deliberate. If one shared number covered the whole schema, a breaking
-change to `packages` would move `files`, `git`, `scripts` and everything else to
-v2 as well, even though none of them changed. Do that a few times and you are on
-v11 with no way to tell which resource actually changed at each step.
+This is intentional. With one version number for the full schema, a change to
+`packages` moves `files`, `git`, `scripts` and all other types to v2. Those types
+did not change. After a small number of such changes, the schema is at v11, and
+the version number does not tell you which type changed.
 
-With per-type versions, a breaking change to `packages` produces exactly one
-change: `packages` is now v2. Everything else is still v1, and blueprints for
-those types keep working untouched.
+With a version for each type, a change to `packages` makes one change:
+`packages` is v2. All other types stay at v1. Blueprints for those types continue
+to operate.
 
-## Declaring a version
+## How to give a version
 
-**In the init file**, applying to the whole tree:
+In the init file, for the full tree:
 
 ```yaml
 blueprints:
@@ -29,7 +28,7 @@ blueprints:
   schema_version: 1
 ```
 
-**In an individual blueprint file**, overriding the tree for that file only:
+In one blueprint file, for that file only:
 
 ```yaml
 schema_version: 2
@@ -38,49 +37,48 @@ packages:
     action: install
 ```
 
-The most specific declaration wins:
+RWR uses the most specific version:
 
-1. the blueprint file's own `schema_version`
-2. the init file's `schema_version`
-3. the latest version supported for that blueprint type
+1. the `schema_version` in the blueprint file
+2. the `schema_version` in the init file
+3. the latest version that RWR supports for that blueprint type
 
-## Nothing declared means latest
+## No version means the latest version
 
-A blueprint that declares no version is read as the **latest** version RWR
-supports for that type.
+RWR reads a blueprint that gives no version as the latest version for that type.
 
-This keeps the common case free of boilerplate: a blueprint written today gets
-today's schema without having to say so. The version field is what you add when
-you want to be *pinned*, not something you must add to get started.
+A new blueprint then uses the current schema, and you do not write a version. Add
+a version when you want RWR to hold the blueprint at that version.
 
-The trade-off is that an undeclared blueprint follows the schema forward across
-upgrades. If a tree needs to stay on a particular version — because you are not
-ready to migrate, or you want it to behave identically on every machine
-regardless of the RWR version installed — declare it:
+There is a result to know. A blueprint with no version moves to a new schema when
+you upgrade RWR. Give a version if the tree must stay at one version. Two
+examples are a tree that is not ready for a new format, and a tree that must
+operate in the same way on each machine.
 
 ```yaml
 blueprints:
   schema_version: 1
 ```
 
-That one line pins the whole tree, and individual files can still opt forward.
+That line holds the full tree at v1. A blueprint file can still give a later
+version.
 
-Note this is per type: when `packages` gains a v2, an undeclared `packages`
-blueprint is read as v2, while `files` — which did not change — is still read as
-v1.
+The latest version is different for each type. When `packages` moves to v2, RWR
+reads a `packages` blueprint with no version as v2. RWR reads a `files`
+blueprint as v1, because `files` did not change.
 
-## Migrating one resource type
+## How to move one type to a new version
 
-When `packages` gains a v2, a tree can move one file at a time:
+When `packages` moves to v2, a tree can move one file at a time:
 
 ```yaml
-# init.yaml — the tree is still v1
+# init.yaml — the tree is at v1
 blueprints:
   schema_version: 1
 ```
 
 ```yaml
-# packages/dev-tools.yaml — this file is v2
+# packages/dev-tools.yaml — this file is at v2
 schema_version: 2
 packages:
   - name: git
@@ -88,46 +86,46 @@ packages:
 ```
 
 ```yaml
-# packages/base.yaml — still v1, still works
+# packages/base.yaml — still at v1, and it operates
 packages:
   - name: curl
     action: install
 ```
 
-Both files are read correctly in the same run. There is no flag day.
+RWR reads both files correctly in the same run. You do not migrate the full tree
+on one day.
 
-## Unsupported versions are an error
+## An unsupported version stops the run
 
-A blueprint asking for a version this build does not implement fails, naming the
-version it wanted:
+RWR stops when a blueprint gives a version that this build cannot read. The error
+gives the version:
 
 ```
 packages: schema version 2 is not supported by this build (supports 1) —
 upgrade rwr, or write this blueprint in a supported version
 ```
 
-This is intentionally a hard failure. RWR installs packages, writes files and
-runs scripts as root; reading a v2 blueprint as though it were v1 would mean
-acting on a misunderstanding of what the file asked for. Refusing is the safer
-outcome.
+CAUTION: This error stops the run. RWR installs packages, writes files, and runs
+scripts as root. A v2 blueprint that RWR reads as v1 can do damage to the
+machine.
 
-A tree-wide version has to be supported by *every* blueprint type, since it
-applies to all of them. If only some types have a v2, declare it per file
-instead — the error says so.
+A version in the init file applies to each blueprint type. All types must support
+that version. Give the version in the blueprint file when only some types have
+the new version.
 
-## Adding a version (for contributors)
+## How to add a version (for contributors)
 
-Each version of a blueprint type is its own struct describing exactly what that
-version accepts on disk. Decoding picks the struct by resolved version and then
-converts it to the canonical type the processors consume, so nothing past the
-decoder knows more than one version exists.
+Each version of a blueprint type is a separate struct. The struct gives the
+fields that the version accepts. RWR selects the struct with the version, then
+converts the data to the type that the processors use. Code after the decoder
+reads one type only.
 
 To add a v2 for a type, in `internal/types/`:
 
-1. Define the struct for the new wire format, e.g. `packagesV2`.
-2. Give it a `Canonical()` that maps it onto `PackagesData`.
-3. Register it in `schemaRegistry` under `{BlueprintTypePackages: {2: ...}}`.
-4. Add `2` to that type's entry in `supportedSchemaVersions`.
+1. Write the struct for the new format. An example is `packagesV2`.
+2. Add a `Canonical()` method that converts the struct to `PackagesData`.
+3. Add the struct to `schemaRegistry`, at `{BlueprintTypePackages: {2: ...}}`.
+4. Add `2` to the entry for that type in `supportedSchemaVersions`.
 
-Nothing else changes. The processors keep consuming `PackagesData` and no other
-blueprint type is affected.
+Make no other changes. The processors continue to read `PackagesData`, and the
+other blueprint types do not change.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -17,7 +17,7 @@ Example `init.yaml` file:
 
 ```yaml
 variables:
-  user_defined:
+  userDefined:
     app_version: 1.0.0
     server_port: 8080
 ```
@@ -40,12 +40,14 @@ RWR provides a set of built-in variables that can be used in your blueprints. Th
 
 | Variable | Description |
 |----------|-------------|
-| `{{ rwr.os }}` | The operating system name (e.g., linux, macos, windows) |
-| `{{ rwr.arch }}` | The system architecture (e.g., amd64, arm64) |
+| `{{ .System.os }}` | The operating system: `linux`, `darwin`, or `windows` |
+| `{{ .System.osFamily }}` | The distribution family, for example `arch` or `debian` |
+| `{{ .System.osVersion }}` | The version of the operating system |
+| `{{ .System.osArch }}` | The architecture: `amd64`, `arm64`, or `riscv64` |
 | `{{ .User.username }}` | The current user's username |
 | `{{ .User.firstName }}` | The current user's First Name |
 | `{{ .User.lastName }}` | The current user's Last Name |
-| `{{ .User.fullName }}` | The current user's home directory |
+| `{{ .User.fullName }}` | The current user's full name |
 | `{{ .User.groupName }}` | The current user's Group Name (Linux/macOS Only) |
 | `{{ .User.home }}` | The current user's home directory |
 | `{{ .User.shell }}` | The current user's shell (e.g.; bash, zsh) |
@@ -54,6 +56,10 @@ RWR provides a set of built-in variables that can be used in your blueprints. Th
 | `{{ .Flags.interactive }}` | Current Interactive Mode setting |
 | `{{ .Flags.forceBootstrap }}` | Current Force Bootstrap setting |
 | `{{ .Flags.skipVersionCheck }}` | Current Skip Version setting |
+| `{{ .Flags.dryRun }}` | Whether dry-run mode is active |
+| `{{ .Flags.profiles }}` | The list of active profiles |
+| `{{ .Flags.configLocation }}` | The path of the configuration directory |
+| `{{ .Flags.runOnceLocation }}` | The path of the run-once directory |
 
 > [!NOTE]
 > `{{ .Flags.ghAPIToken }}` and `{{ .Flags.sshKey }}` are withheld unless the init
@@ -74,45 +80,64 @@ Example:
 
 ```yaml
 packages:
-  {{if eq rwr.os "linux"}}
+  {{if eq .System.os "linux"}}
   - name: git
     action: install
   {{end}}
 
-  {{if eq rwr.os "macos"}}
+  {{if eq .System.os "darwin"}}
   - name: homebrew
     action: install
   {{end}}
 ```
 
+> [!NOTE]
+> The value for macOS is `darwin`, not `macos`. RWR uses the name that Go gives
+> for the operating system.
+
 ### Looping
 
-You can use the `{{range}}` and `{{end}}` directives to loop over a list of items.
+You can use the `{{range}}` and `{{end}}` directives to read each item in a list.
 
-Example:
+Only the four groups above are in scope. Put your list in `userDefined` in the
+init file, then read it:
 
 ```yaml
+# init.yaml
+variables:
+  userDefined:
+    editors:
+      - vim
+      - neovim
+```
+
+```yaml
+# packages/editors.yaml
 packages:
-  {{range .packages}}
-  - name: {{.name}}
-    version: {{.UserDefined.version}}
-    action: {{.UserDefined.action}}
+  {{range .UserDefined.editors}}
+  - name: {{.}}
+    action: install
   {{end}}
 ```
 
 ### Functions
 
-RWR supports a subset of the Go template functions. Here are some commonly used functions:
+RWR uses the Go template package and adds no functions of its own. These are the
+standard functions:
 
 | Function | Description |
 |----------|-------------|
-| `{{eq arg1 arg2}}` | Returns true if arg1 and arg2 are equal |
-| `{{ne arg1 arg2}}` | Returns true if arg1 and arg2 are not equal |
-| `{{lt arg1 arg2}}` | Returns true if arg1 is less than arg2 |
-| `{{gt arg1 arg2}}` | Returns true if arg1 is greater than arg2 |
-| `{{join list separator}}` | Joins a list of strings with the specified separator |
+| `{{eq arg1 arg2}}` | True when arg1 and arg2 are equal |
+| `{{ne arg1 arg2}}` | True when arg1 and arg2 are different |
+| `{{lt arg1 arg2}}` | True when arg1 is less than arg2 |
+| `{{gt arg1 arg2}}` | True when arg1 is more than arg2 |
 
-For a complete list of supported functions, please refer to the [Go template documentation](https://golang.org/pkg/text/template/).
+CAUTION: RWR registers no additional functions. A template that calls `default`,
+`join`, or another function from a different tool stops the run with
+`function "default" not defined`.
+
+For the full list of standard functions, read the
+[Go template documentation](https://golang.org/pkg/text/template/).
 
 ## Best Practices
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -56,11 +56,11 @@ RWR provides a set of built-in variables that can be used in your blueprints. Th
 | `{{ .Flags.skipVersionCheck }}` | Current Skip Version setting |
 
 > [!NOTE]
-> `{{ .Flags.ghAPIToken }}` and `{{ .Flags.sshKey }}` are no longer available.
-> Templates are rendered from blueprint files and written to a path the blueprint
-> chooses, so exposing the GitHub token and SSH private key there let any
-> blueprint copy your credentials anywhere. RWR uses them directly for Git and
-> GitHub operations; blueprints never need the values.
+> `{{ .Flags.ghAPIToken }}` and `{{ .Flags.sshKey }}` are withheld unless the init
+> file opts into them, because a template is written to a path the blueprint
+> itself chooses — so exposing a credential by default let any blueprint copy it
+> anywhere. If a blueprint genuinely needs one, name it under
+> `exposeCredentials`; see [credentials](credentials.md).
 
 ## Templating
 

--- a/internal/processors/credentials_test.go
+++ b/internal/processors/credentials_test.go
@@ -116,3 +116,52 @@ func TestTemplatesCannotRenderCredentials(t *testing.T) {
 		t.Errorf("template rendered the SSH key: %s", out)
 	}
 }
+
+// A script that legitimately needs a token can be given one, without the tree
+// handing out everything else.
+func TestSpawnedCommandsReceiveOptedInCredentials(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /usr/bin/env")
+	}
+
+	viper.Reset()
+	defer viper.Reset()
+	defer types.SetExposedCredentials(nil)
+
+	viper.Set("repository.gh_api_token", fakeToken)
+	viper.Set("repository.ssh_private_key", fakeKey)
+
+	types.SetExposedCredentials([]string{"gh_api_token"})
+
+	initConfig := &types.InitConfig{}
+	initConfig.Variables.UserDefined = map[string]interface{}{}
+	if err := setUserDefinedAndEnvVariables(initConfig); err != nil {
+		t.Fatalf("setUserDefinedAndEnvVariables: %v", err)
+	}
+	defer func() {
+		_ = os.Unsetenv("RWR_VAR_REPOSITORY_GH_API_TOKEN")
+		_ = os.Unsetenv("RWR_VAR_REPOSITORY_SSH_PRIVATE_KEY")
+	}()
+
+	envPath := filepath.Join(t.TempDir(), "env.txt")
+	if err := system.RunCommand(types.Command{
+		Exec:    "/usr/bin/env",
+		LogName: envPath,
+	}, false); err != nil {
+		t.Fatalf("RunCommand: %v", err)
+	}
+
+	raw, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("reading captured environment: %v", err)
+	}
+	env := string(raw)
+
+	if !strings.Contains(env, fakeToken) {
+		t.Error("an opted-in token should reach the command that needs it")
+	}
+	// Opting into one credential must not hand over the other.
+	if strings.Contains(env, fakeKey) {
+		t.Error("the ssh key was exposed without being opted into")
+	}
+}

--- a/internal/processors/git.go
+++ b/internal/processors/git.go
@@ -58,7 +58,7 @@ func processGitRepositories(gitRepos []types.Git, initConfig *types.InitConfig) 
 		gitOpts := types.GitOptions{
 			URL:     repo.URL,
 			Private: repo.Private,
-			Target:  repo.Path,
+			Target:  system.ExpandPath(repo.Path),
 			Branch:  repo.Branch,
 		}
 

--- a/internal/processors/initialize.go
+++ b/internal/processors/initialize.go
@@ -126,6 +126,15 @@ func Initialize(initFilePath string, flags types.Flags) (*types.InitConfig, erro
 	// Set the blueprints location
 	setBlueprintsLocation(&initConfig, initFilePath)
 
+	// Apply the credential opt-in before anything reads variables or spawns a
+	// command, so the choice is in effect for the whole run.
+	types.SetExposedCredentials(initConfig.ExposeCredentials)
+	if len(initConfig.ExposeCredentials) > 0 {
+		log.Warnf("Blueprints in this tree can read these credentials: %v — "+
+			"they are readable by any script or template the blueprints run",
+			types.ExposedCredentials())
+	}
+
 	// Set user-defined variables and environment variables
 	if err := setUserDefinedAndEnvVariables(&initConfig); err != nil {
 		return nil, fmt.Errorf("error setting variables: %w", err)
@@ -226,8 +235,9 @@ func setUserDefinedAndEnvVariables(initConfig *types.InitConfig) error {
 	// private key put both in reach of any script a blueprint chooses to run, and
 	// blueprints are cloned from git repositories.
 	for _, key := range viper.AllKeys() {
-		if types.IsSecretConfigKey(key) {
-			log.Debugf("Not exporting %s to the environment: it holds a credential", key)
+		if types.IsSecretConfigKey(key) && !types.IsCredentialExposed(key) {
+			log.Debugf("Not exporting %s to the environment: it holds a credential "+
+				"(add it to exposeCredentials in the init file if a script needs it)", key)
 			continue
 		}
 

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -184,7 +184,10 @@ func ensureSSHPackages(osInfo *types.OSInfo, initConfig *types.InitConfig) error
 }
 
 func generateSSHKey(sshKey types.SSHKey, initConfig *types.InitConfig) (string, error) {
-	sshPath := filepath.Join(sshKey.Path, sshKey.Name)
+	// Expand a leading ~ here. Commands are argv now, so no shell expands it on
+	// the way to ssh-keygen — an unexpanded "~/.ssh" would create a directory
+	// literally named "~" in the working directory.
+	sshPath := filepath.Join(system.ExpandPath(sshKey.Path), sshKey.Name)
 
 	// Check if the SSH key already exists
 	if _, err := os.Stat(sshPath); err == nil {

--- a/internal/processors/tilde_test.go
+++ b/internal/processors/tilde_test.go
@@ -1,0 +1,54 @@
+package processors
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// A blueprint that writes `path: ~/.ssh` must still put the key in the home
+// directory. Commands no longer pass through a shell, so nothing expands the ~
+// on the way to ssh-keygen — without expansion the key lands in a directory
+// literally named "~" under the working directory.
+func TestSSHKeyPathExpandsTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home directory: %v", err)
+	}
+
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	blueprint := []byte(`
+ssh_keys:
+  - name: id_test_rwr
+    action: create
+    type: ed25519
+    path: ~/.ssh
+    no_passphrase: true
+    copy_to_github: false
+`)
+
+	// Ignore the error: this asserts on the command that was built, and the key
+	// may already exist on the machine running the test.
+	_ = ProcessSSHKeys(blueprint, "yaml", &types.OSInfo{}, &types.InitConfig{})
+
+	calls := rec.Find("ssh-keygen")
+	if len(calls) == 0 {
+		t.Skip("ssh-keygen was not invoked (key may already exist)")
+	}
+
+	args := strings.Join(calls[0].Args, " ")
+	if strings.Contains(args, "~") {
+		t.Errorf("ssh-keygen received an unexpanded ~: %v", calls[0].Args)
+	}
+	want := filepath.Join(home, ".ssh", "id_test_rwr")
+	if !strings.Contains(args, want) {
+		t.Errorf("ssh-keygen args = %v, want them to contain %q", calls[0].Args, want)
+	}
+}

--- a/internal/system/files_test.go
+++ b/internal/system/files_test.go
@@ -1,0 +1,35 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Commands are argv now, so no shell expands a leading ~ on the way to a
+// program. Every blueprint path that reaches a command or a filesystem call has
+// to be expanded here instead, or "~/.ssh" creates a directory literally named
+// "~" in the working directory.
+func TestExpandPath_Tilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home directory: %v", err)
+	}
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"~/.ssh", filepath.Join(home, ".ssh")},
+		{"~/.ssh/id_ed25519", filepath.Join(home, ".ssh", "id_ed25519")},
+		{"/etc/ssh", "/etc/ssh"},
+		{"relative/path", "relative/path"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		if got := ExpandPath(tt.in); got != tt.want {
+			t.Errorf("ExpandPath(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/types/initialize.go
+++ b/internal/types/initialize.go
@@ -59,6 +59,10 @@ type InitConfig struct {
 	Directories     []Directory          `mapstructure:"directories,omitempty" yaml:"directories,omitempty" json:"directories,omitempty" toml:"directories,omitempty"`
 	Configuration   []Configuration      `mapstructure:"configuration,omitempty" yaml:"configuration,omitempty" json:"configuration,omitempty" toml:"configuration,omitempty"`
 	Variables       Variables            `mapstructure:",squash"`
+	// ExposeCredentials names the credentials this tree's blueprints are allowed
+	// to read, e.g. ["gh_api_token"]. Empty — the default — means blueprints get
+	// none of them. See docs/credentials.md.
+	ExposeCredentials []string `mapstructure:"exposeCredentials,omitempty" yaml:"exposeCredentials,omitempty" json:"exposeCredentials,omitempty" toml:"exposeCredentials,omitempty"`
 }
 
 func (u UserInfo) ToMap() map[string]interface{} {
@@ -75,13 +79,14 @@ func (u UserInfo) ToMap() map[string]interface{} {
 
 // ToMap exposes the flags to blueprint templates as {{ .Flags.* }}.
 //
-// ghAPIToken and sshKey are deliberately absent. Templates are rendered from
-// blueprint files, which are cloned from git repositories, and the rendered
-// output is written to a path the same blueprint chooses — so exposing the
-// GitHub token or the SSH key here let any blueprint copy them anywhere it
-// liked. Nothing a blueprint legitimately does needs the credential values.
+// ghAPIToken and sshKey are withheld unless the init file opts into them.
+// Templates render from blueprint files cloned out of git repositories, and the
+// result is written to a path the same blueprint chooses, so exposing a
+// credential by default let any blueprint copy it anywhere. A blueprint that
+// genuinely needs one — writing a .netrc, configuring gh — opts in by name; see
+// exposeCredentials in the init file.
 func (f Flags) ToMap() map[string]interface{} {
-	return map[string]interface{}{
+	out := map[string]interface{}{
 		"debug":            f.Debug,
 		"logLevel":         f.LogLevel,
 		"interactive":      f.Interactive,
@@ -92,6 +97,15 @@ func (f Flags) ToMap() map[string]interface{} {
 		"runOnceLocation":  f.RunOnceLocation,
 		"profiles":         f.Profiles,
 	}
+
+	if IsCredentialExposed("gh_api_token") {
+		out["ghAPIToken"] = f.GHAPIToken
+	}
+	if IsCredentialExposed("ssh_private_key") {
+		out["sshKey"] = f.SSHKey
+	}
+
+	return out
 }
 
 // String redacts the credential fields so a Flags value cannot leak them through

--- a/internal/types/secrets.go
+++ b/internal/types/secrets.go
@@ -1,6 +1,9 @@
 package types
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // SecretConfigKeys are the viper config keys holding credentials.
 //
@@ -25,6 +28,51 @@ func IsSecretConfigKey(key string) bool {
 		}
 	}
 	return false
+}
+
+// exposedCredentials names the credentials the init file has opted into sharing
+// with blueprint templates and spawned commands.
+//
+// Credentials are withheld by default because blueprints are cloned from git
+// repositories and scripts inherit rwr's environment, so anything reachable from
+// either is readable by whoever wrote the blueprint. But some blueprints
+// legitimately need a token — writing a .netrc, configuring gh, calling the
+// GitHub API from a script — so this is opt-in rather than unavailable.
+var exposedCredentials = map[string]bool{}
+
+// SetExposedCredentials records which credential keys the operator opted into.
+// Names may be given as viper keys ("repository.gh_api_token") or bare
+// ("gh_api_token").
+func SetExposedCredentials(keys []string) {
+	exposedCredentials = make(map[string]bool, len(keys))
+	for _, key := range keys {
+		exposedCredentials[normaliseCredentialKey(key)] = true
+	}
+}
+
+// IsCredentialExposed reports whether a credential key was opted into.
+func IsCredentialExposed(key string) bool {
+	return exposedCredentials[normaliseCredentialKey(key)]
+}
+
+// ExposedCredentials returns the opted-in keys, for logging.
+func ExposedCredentials() []string {
+	out := make([]string, 0, len(exposedCredentials))
+	for key := range exposedCredentials {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// normaliseCredentialKey reduces a viper key or bare name to a common form, so
+// "repository.gh_api_token" and "gh_api_token" mean the same thing.
+func normaliseCredentialKey(key string) string {
+	key = strings.ToLower(strings.TrimSpace(key))
+	if idx := strings.LastIndex(key, "."); idx >= 0 {
+		key = key[idx+1:]
+	}
+	return key
 }
 
 // showSecrets records whether the operator asked to see secret values, via

--- a/internal/types/secrets_test.go
+++ b/internal/types/secrets_test.go
@@ -147,3 +147,52 @@ func TestNestedStructsDoNotLeakCredentials(t *testing.T) {
 		}
 	}
 }
+
+// Credentials are withheld from templates by default, but a blueprint that
+// genuinely needs one — writing a .netrc, configuring gh — can opt in by name.
+func TestFlagsToMap_ExposesOnlyOptedInCredentials(t *testing.T) {
+	defer SetExposedCredentials(nil)
+
+	flags := Flags{GHAPIToken: "ghp_thisisatoken", SSHKey: "a-private-key"}
+
+	SetExposedCredentials(nil)
+	if _, present := flags.ToMap()["ghAPIToken"]; present {
+		t.Error("no opt-in, yet the token is in template scope")
+	}
+
+	// Opting into one credential must not expose the other.
+	SetExposedCredentials([]string{"gh_api_token"})
+	m := flags.ToMap()
+	if m["ghAPIToken"] != "ghp_thisisatoken" {
+		t.Errorf("opted-in token missing from template scope: %v", m["ghAPIToken"])
+	}
+	if _, present := m["sshKey"]; present {
+		t.Error("opting into the token also exposed the ssh key")
+	}
+
+	SetExposedCredentials([]string{"ssh_private_key"})
+	m = flags.ToMap()
+	if m["sshKey"] != "a-private-key" {
+		t.Errorf("opted-in ssh key missing from template scope: %v", m["sshKey"])
+	}
+	if _, present := m["ghAPIToken"]; present {
+		t.Error("opting into the ssh key also exposed the token")
+	}
+}
+
+// The opt-in accepts either the full viper key or the bare name, since the init
+// file and the config key spell it differently.
+func TestIsCredentialExposed_AcceptsEitherSpelling(t *testing.T) {
+	defer SetExposedCredentials(nil)
+
+	SetExposedCredentials([]string{"repository.gh_api_token"})
+	if !IsCredentialExposed("gh_api_token") {
+		t.Error("a full viper key should match the bare name")
+	}
+	if !IsCredentialExposed("repository.gh_api_token") {
+		t.Error("a full viper key should match itself")
+	}
+	if IsCredentialExposed("ssh_private_key") {
+		t.Error("an unrelated credential should stay withheld")
+	}
+}


### PR DESCRIPTION
Four commits that did not make it into #154's squash. Two are behaviour fixes,
two are documentation.

## `~` in paths stopped working (regression)

Moving commands to argv removed the shell that expanded `~`. An `ssh_keys`
blueprint with `path: ~/.ssh` reached ssh-keygen as a literal:

```
ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519
```

That creates a directory named `~` in the working directory and writes the key
there. **Every ssh-keys example in the docs uses `path: ~/.ssh`**, so anyone
following them would have hit it. Blueprints using `{{ .User.home }}` were fine,
which is why testing against the real blueprint repo didn't surface it — the docs
did.

Git repository paths get the same fix. They were never expanded (go-git doesn't
use a shell either), so `path: ~/projects/x` has always made a `~` directory.

Files and directories already expanded via `system.ExpandPath`, so behaviour is
now consistent across every blueprint type that takes a path.

The test fails with `ssh-keygen received an unexpanded ~: [-t ed25519 -f ~/.ssh/...]`
when the fix is reverted.

## Blueprints can opt into credentials

Withholding the GitHub token and SSH key removed a capability some blueprints
legitimately need — writing a `.netrc`, configuring `gh`, calling the GitHub API
from a script. There was no way to get them back.

```yaml
exposeCredentials:
  - gh_api_token
```

Naming one does not expose the other. Default is still none. Opting in restores
both `{{ .Flags.ghAPIToken }}` in templates and
`RWR_VAR_REPOSITORY_GH_API_TOKEN` in script environments. RWR warns at startup
while anything is exposed.

Tests pin both directions, including that opting into the token leaves the SSH
key withheld — checked in template scope and by reading the environment of a real
spawned process.

## Documentation corrections

An audit against the code found commands that fail, fields no struct has, and
gaps for everything added in this series.

**Commands that don't exist:** `rwr run package` (it's `packages`),
`rwr validate --path X` and `--all` (the path is an argument), `rwr config init`
(it's `rwr config --create`), `rwr all --profiles dev` (the flag is `--profile`,
given once per profile). `rwr run ssh_keys` was described as running the scripts
processor.

**Fields that don't exist:** `directories` documented a `create` field and typed
`owner`/`group` as integer IDs — both are name strings. `scripts` used
`description` in every example. The init file used `package_managers` and
`as_user` across JSON, TOML and half the YAML; the real tags are
`packageManagers` and `asUser`, so those blocks decoded to nothing.

**Wrong statements:** the default run order listed packages before repositories
(the one ordering that matters), included Directories as a step, and omitted
`ssh_keys` and `fonts`. Scripts claimed shebang detection, which is never read.
Providers listed 12 step actions where 5 exist, and 13 template variables where
only `{{ .URL }}` substitutes — marked `CAUTION` rather than deleted, so a
provider author sees the limitation.

## The README documented a Dagger pipeline that no longer exists

Eight `mise run dagger:*` commands, a Dagger prerequisite, and a CI/CD section
describing it. `mise.toml` mentions Dagger once, in a comment saying there isn't
any. Replaced with the tasks that exist — seven were undocumented (`ci`,
`security`, `install`, `start`, `update`, `lint`, `format`).

The import section also advertised "Circular Detection: Automatically prevents
infinite import loops". That check cannot fire — the visited set is rebuilt per
file — and imports don't recurse either.

New `docs/install.md` covers riscv64, checksum verification, and the nightly
prereleases, none of which were documented anywhere.

## Style

Docs rewritten with ASD-STE100 Simplified Technical English: one term per
concept, conditions before commands, active voice, `CAUTION`/`WARNING` for
destructive cases.

## Verification

Every documented mise task checked against `mise.toml`; every documented `rwr`
command and flag checked against the code; all doc and README links resolve;
every TOC anchor has a heading; 104 of 107 code blocks parse (the three that
don't are unrendered template examples).

`go build`, `go test ./...`, `golangci-lint run`, `gosec ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)