### PR TITLE
fix: enforce schema versioning, validate the whole tree, read real profiles

### DIFF
--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -2,242 +2,56 @@ package cmd
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
-	"github.com/fynxlabs/rwr/internal/helpers"
-
 	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/processors"
 	"github.com/spf13/cobra"
 )
 
 var profilesCmd = &cobra.Command{
 	Use:   "profiles",
 	Short: "Discover and list available profiles in your configuration",
-	Long: `The profiles command analyzes your configuration files and lists all available profiles.
-This helps you understand what profiles are defined and can be activated using the --profile flag.
+	Long: `The profiles command reads your blueprints and lists every profile they declare.
+This tells you what you can pass to --profile.
 
-Profiles allow you to selectively install packages and configurations based on different contexts
-(work, personal, development, gaming, etc.). Items without profiles are considered "base" items
-and are always included.`,
-	Run: func(cmd *cobra.Command, args []string) {
+Profiles let you select what applies to a machine (work, personal, development,
+gaming, and so on). An entry that declares no profiles is a base item and always
+applies.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if initConfig == nil {
-			log.Error("Configuration not initialized. Please ensure you have a valid init file.")
-			return
+			return fmt.Errorf("configuration not initialized: check that you have a valid init file")
 		}
 
-		// Collect all profiles from all types
-		allProfiles := make(map[string]bool)
-
-		// Get profiles from packages
-		if initConfig.Packages != nil {
-			profiles := helpers.GetUniqueProfiles(initConfig.Packages)
-			for _, profile := range profiles {
-				allProfiles[profile] = true
-			}
+		summary, err := processors.CollectProfiles(initConfig)
+		if err != nil {
+			return fmt.Errorf("error reading profiles: %w", err)
 		}
 
-		// Get profiles from services
-		if initConfig.Services != nil {
-			profiles := helpers.GetUniqueProfiles(initConfig.Services)
-			for _, profile := range profiles {
-				allProfiles[profile] = true
-			}
+		log.Debugf("Inspected %d blueprint file(s) in %s", summary.Files, initConfig.Init.Location)
+
+		if len(summary.Names) == 0 {
+			fmt.Println("No profiles found in your blueprints.")
+			fmt.Printf("All %d item(s) are base items and always apply.\n", summary.BaseItems)
+			return nil
 		}
 
-		// Get profiles from files
-		if initConfig.Files != nil {
-			profiles := helpers.GetUniqueProfiles(initConfig.Files)
-			for _, profile := range profiles {
-				allProfiles[profile] = true
-			}
+		fmt.Printf("Available profiles (%d found):\n\n", len(summary.Names))
+		for _, profile := range summary.Names {
+			fmt.Printf("  • %s (%d items)\n", profile, summary.Counts[profile])
 		}
+		fmt.Printf("\n  base items (always applied): %d\n", summary.BaseItems)
 
-		// Get profiles from templates
-		if initConfig.Templates != nil {
-			profiles := helpers.GetUniqueProfiles(initConfig.Templates)
-			for _, profile := range profiles {
-				allProfiles[profile] = true
-			}
-		}
-
-		// Get profiles from directories
-		if initConfig.Directories != nil {
-			profiles := helpers.GetUniqueProfiles(initConfig.Directories)
-			for _, profile := range profiles {
-				allProfiles[profile] = true
-			}
-		}
-
-		// Get profiles from repositories
-		if initConfig.Repositories != nil {
-			profiles := helpers.GetUniqueProfiles(initConfig.Repositories)
-			for _, profile := range profiles {
-				allProfiles[profile] = true
-			}
-		}
-
-		// Convert map to sorted slice
-		var profilesList []string
-		for profile := range allProfiles {
-			profilesList = append(profilesList, profile)
-		}
-		sort.Strings(profilesList)
-
-		// Display results
-		if len(profilesList) == 0 {
-			fmt.Println("No profiles found in your configuration.")
-			fmt.Println("All items are base items and will always be included.")
-		} else {
-			fmt.Printf("Available profiles (%d found):\n\n", len(profilesList))
-			for _, profile := range profilesList {
-				fmt.Printf("  • %s\n", profile)
-			}
-			fmt.Println()
-			fmt.Println("Usage examples:")
-			fmt.Printf("  rwr run --profile %s\n", profilesList[0])
-			if len(profilesList) > 1 {
-				fmt.Printf("  rwr run --profile %s --profile %s\n", profilesList[0], profilesList[1])
-				fmt.Printf("  rwr run --profile %s\n", strings.Join(profilesList[:2], ","))
-			}
-			fmt.Println("  rwr run --profile all")
-		}
-
-		// Display profile statistics
 		fmt.Println()
-		fmt.Println("Profile Statistics:")
-		fmt.Printf("  Base items (no profiles): %d\n", countBaseItems())
-		for _, profile := range profilesList {
-			count := countProfileItems(profile)
-			fmt.Printf("  %s: %d items\n", profile, count)
+		fmt.Println("Usage examples:")
+		fmt.Printf("  rwr all --profile %s\n", summary.Names[0])
+		if len(summary.Names) > 1 {
+			fmt.Printf("  rwr all --profile %s --profile %s\n", summary.Names[0], summary.Names[1])
+			fmt.Printf("  rwr run packages --profile %s\n", strings.Join(summary.Names[:2], ","))
 		}
+		fmt.Println("  rwr all --profile all")
+		return nil
 	},
-}
-
-func countBaseItems() int {
-	count := 0
-
-	if initConfig.Packages != nil {
-		for _, pkg := range initConfig.Packages {
-			if len(pkg.GetProfiles()) == 0 {
-				count++
-			}
-		}
-	}
-
-	if initConfig.Services != nil {
-		for _, svc := range initConfig.Services {
-			if len(svc.GetProfiles()) == 0 {
-				count++
-			}
-		}
-	}
-
-	if initConfig.Files != nil {
-		for _, file := range initConfig.Files {
-			if len(file.GetProfiles()) == 0 {
-				count++
-			}
-		}
-	}
-
-	if initConfig.Templates != nil {
-		for _, tpl := range initConfig.Templates {
-			if len(tpl.GetProfiles()) == 0 {
-				count++
-			}
-		}
-	}
-
-	if initConfig.Directories != nil {
-		for _, dir := range initConfig.Directories {
-			if len(dir.GetProfiles()) == 0 {
-				count++
-			}
-		}
-	}
-
-	if initConfig.Repositories != nil {
-		for _, repo := range initConfig.Repositories {
-			if len(repo.GetProfiles()) == 0 {
-				count++
-			}
-		}
-	}
-
-	return count
-}
-
-func countProfileItems(targetProfile string) int {
-	count := 0
-
-	if initConfig.Packages != nil {
-		for _, pkg := range initConfig.Packages {
-			for _, profile := range pkg.GetProfiles() {
-				if profile == targetProfile {
-					count++
-					break
-				}
-			}
-		}
-	}
-
-	if initConfig.Services != nil {
-		for _, svc := range initConfig.Services {
-			for _, profile := range svc.GetProfiles() {
-				if profile == targetProfile {
-					count++
-					break
-				}
-			}
-		}
-	}
-
-	if initConfig.Files != nil {
-		for _, file := range initConfig.Files {
-			for _, profile := range file.GetProfiles() {
-				if profile == targetProfile {
-					count++
-					break
-				}
-			}
-		}
-	}
-
-	if initConfig.Templates != nil {
-		for _, tpl := range initConfig.Templates {
-			for _, profile := range tpl.GetProfiles() {
-				if profile == targetProfile {
-					count++
-					break
-				}
-			}
-		}
-	}
-
-	if initConfig.Directories != nil {
-		for _, dir := range initConfig.Directories {
-			for _, profile := range dir.GetProfiles() {
-				if profile == targetProfile {
-					count++
-					break
-				}
-			}
-		}
-	}
-
-	if initConfig.Repositories != nil {
-		for _, repo := range initConfig.Repositories {
-			for _, profile := range repo.GetProfiles() {
-				if profile == targetProfile {
-					count++
-					break
-				}
-			}
-		}
-	}
-
-	return count
 }
 
 func init() {

--- a/internal/helpers/blueprints.go
+++ b/internal/helpers/blueprints.go
@@ -8,6 +8,10 @@ package helpers
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/user"
+	"runtime"
+	"strings"
 
 	"charm.land/log/v2"
 	"github.com/BurntSushi/toml"
@@ -43,4 +47,49 @@ func UnmarshalBlueprint(data []byte, format string, v interface{}) error {
 	}
 	log.Debugf("Blueprint unmarshaled successfully")
 	return nil
+}
+
+// DefaultVariables builds the variable set every blueprint template renders
+// against: the running user, and an empty user-defined map.
+//
+// Both the run path and `rwr validate` need this. Validation used to render
+// against a zero-valued set, so any blueprint referencing {{ .User.home }} rendered
+// "<no value>" into the path it was about to be checked for.
+func DefaultVariables() (types.Variables, error) {
+	currentUser, err := user.Current()
+	if err != nil {
+		return types.Variables{}, fmt.Errorf("error retrieving current user information: %w", err)
+	}
+
+	names := strings.Fields(currentUser.Name)
+	firstName, lastName := "", ""
+	if len(names) > 0 {
+		firstName = names[0]
+	}
+	if len(names) > 1 {
+		lastName = names[len(names)-1]
+	}
+
+	groupName := ""
+	if runtime.GOOS != types.OSWindows {
+		group, err := user.LookupGroupId(currentUser.Gid)
+		if err != nil {
+			log.With("err", err).Warnf("Error retrieving primary group name for user %s", currentUser.Username)
+		} else {
+			groupName = group.Name
+		}
+	}
+
+	return types.Variables{
+		User: types.UserInfo{
+			Username:  currentUser.Username,
+			FirstName: firstName,
+			LastName:  lastName,
+			FullName:  currentUser.Name,
+			GroupName: groupName,
+			Home:      currentUser.HomeDir,
+			Shell:     os.Getenv("SHELL"),
+		},
+		UserDefined: make(map[string]interface{}),
+	}, nil
 }

--- a/internal/helpers/schema.go
+++ b/internal/helpers/schema.go
@@ -42,6 +42,41 @@ func DecodeBlueprint(data []byte, format, blueprintType string, treeVersion int)
 	return variant.Canonical(), version, nil
 }
 
+// DecodeBlueprintInto is DecodeBlueprint with the canonical result written into a
+// typed target, which is what the processors actually want.
+//
+// This is the function processors call. DecodeBlueprint returning interface{} is
+// why nothing called it: every processor decodes into a concrete struct, and
+// nobody was going to write a type assertion at each of twenty call sites. The
+// result was that the whole versioning path — resolution, validation, the variant
+// registry — sat behind a function with no callers, so a blueprint declaring an
+// unsupported schema_version was read as the current schema and applied to the
+// machine instead of being refused.
+func DecodeBlueprintInto[T any](data []byte, format, blueprintType string, treeVersion int, out *T) error {
+	canonical, _, err := DecodeBlueprint(data, format, blueprintType, treeVersion)
+	if err != nil {
+		return err
+	}
+
+	typed, ok := canonical.(*T)
+	if !ok {
+		return fmt.Errorf("internal: %s schema variant produced %T, expected %T",
+			blueprintType, canonical, out)
+	}
+
+	*out = *typed
+	return nil
+}
+
+// TreeSchemaVersion returns the tree-wide schema version an init file declares, or
+// 0 when there is no init config to ask.
+func TreeSchemaVersion(initConfig *types.InitConfig) int {
+	if initConfig == nil {
+		return 0
+	}
+	return initConfig.Init.SchemaVersion
+}
+
 // declaredSchemaVersion reads just the schema_version key, ignoring everything
 // else, so a file written in a version this build cannot read still reports which
 // version it wanted.

--- a/internal/processors/bootstrap.go
+++ b/internal/processors/bootstrap.go
@@ -47,7 +47,8 @@ func ProcessBootstrap(blueprintFile string, initConfig *types.InitConfig, osInfo
 
 	// Unmarshal the blueprint data
 	log.Debugf("Unmarshaling bootstrap data from %s", blueprintFile)
-	err = helpers.UnmarshalBlueprint(blueprintData, filepath.Ext(blueprintFile), &bootstrapData)
+	err = helpers.DecodeBlueprintInto(blueprintData, filepath.Ext(blueprintFile),
+		types.BlueprintTypeBootstrap, helpers.TreeSchemaVersion(initConfig), &bootstrapData)
 	if err != nil {
 		log.Errorf("Error unmarshaling bootstrap blueprint: %v", err)
 		return err

--- a/internal/processors/configuration.go
+++ b/internal/processors/configuration.go
@@ -18,7 +18,8 @@ import (
 func ProcessConfiguration(blueprintData []byte, blueprintDir string, format string, initConfig *types.InitConfig) error {
 	var configData types.ConfigData
 
-	err := helpers.UnmarshalBlueprint(blueprintData, format, &configData)
+	err := helpers.DecodeBlueprintInto(blueprintData, format, types.BlueprintTypeConfiguration,
+		helpers.TreeSchemaVersion(initConfig), &configData)
 	if err != nil {
 		return fmt.Errorf("error unmarshaling configuration blueprint: %w", err)
 	}

--- a/internal/processors/files.go
+++ b/internal/processors/files.go
@@ -44,21 +44,22 @@ func ProcessFiles(blueprintData []byte, blueprintDir string, format string, osIn
 // directories, and templates, then filters each by active profiles.
 func resolveAndFilterFileData(blueprintData []byte, blueprintDir string, format string, initConfig *types.InitConfig) ([]types.File, []types.Directory, []types.File, error) {
 	var fileData types.FileData
-	if err := helpers.UnmarshalBlueprint(blueprintData, format, &fileData); err != nil {
+	if err := helpers.DecodeBlueprintInto(blueprintData, format, types.BlueprintTypeFiles,
+		helpers.TreeSchemaVersion(initConfig), &fileData); err != nil {
 		return nil, nil, nil, fmt.Errorf("error unmarshaling file blueprint data: %w", err)
 	}
 
-	allFiles, err := processFileImports(fileData.Files, blueprintDir, format)
+	allFiles, err := processFileImports(fileData.Files, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error processing file imports: %w", err)
 	}
 
-	allDirs, err := processDirectoryImports(fileData.Directories, blueprintDir, format)
+	allDirs, err := processDirectoryImports(fileData.Directories, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error processing directory imports: %w", err)
 	}
 
-	allTemplates, err := processFileImports(fileData.Templates, blueprintDir, format)
+	allTemplates, err := processFileImports(fileData.Templates, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error processing template imports: %w", err)
 	}
@@ -646,7 +647,7 @@ func determineSourceAndTargetPaths(file types.File, blueprintDir string) (string
 	return sourcePath, targetPath, nil
 }
 
-func processFileImports(files []types.File, blueprintDir string, format string) ([]types.File, error) {
+func processFileImports(files []types.File, blueprintDir string, format string, treeVersion int) ([]types.File, error) {
 	allFiles := make([]types.File, 0)
 	visited := make(map[string]bool)
 
@@ -678,7 +679,7 @@ func processFileImports(files []types.File, blueprintDir string, format string) 
 			}
 
 			var importedFileData types.FileData
-			if err := helpers.UnmarshalBlueprint(importData, fileFormat, &importedFileData); err != nil {
+			if err := helpers.DecodeBlueprintInto(importData, fileFormat, types.BlueprintTypeFiles, treeVersion, &importedFileData); err != nil {
 				return nil, fmt.Errorf("error unmarshaling import file %s: %w", importPath, err)
 			}
 
@@ -692,7 +693,7 @@ func processFileImports(files []types.File, blueprintDir string, format string) 
 	return allFiles, nil
 }
 
-func processDirectoryImports(directories []types.Directory, blueprintDir string, format string) ([]types.Directory, error) {
+func processDirectoryImports(directories []types.Directory, blueprintDir string, format string, treeVersion int) ([]types.Directory, error) {
 	allDirectories := make([]types.Directory, 0)
 	visited := make(map[string]bool)
 
@@ -724,7 +725,7 @@ func processDirectoryImports(directories []types.Directory, blueprintDir string,
 			}
 
 			var importedFileData types.FileData
-			if err := helpers.UnmarshalBlueprint(importData, fileFormat, &importedFileData); err != nil {
+			if err := helpers.DecodeBlueprintInto(importData, fileFormat, types.BlueprintTypeFiles, treeVersion, &importedFileData); err != nil {
 				return nil, fmt.Errorf("error unmarshaling import file %s: %w", importPath, err)
 			}
 

--- a/internal/processors/fonts.go
+++ b/internal/processors/fonts.go
@@ -52,7 +52,8 @@ func ProcessFonts(blueprintData []byte, blueprintDir string, format string, osIn
 
 	log.Debug("Processing fonts from blueprint")
 
-	err = helpers.UnmarshalBlueprint(blueprintData, format, &fontsData)
+	err = helpers.DecodeBlueprintInto(blueprintData, format, types.BlueprintTypeFonts,
+		helpers.TreeSchemaVersion(initConfig), &fontsData)
 	if err != nil {
 		return fmt.Errorf("error unmarshaling fonts blueprint data: %w", err)
 	}

--- a/internal/processors/git.go
+++ b/internal/processors/git.go
@@ -20,14 +20,15 @@ func ProcessGitRepositories(blueprintData []byte, format string, initConfig *typ
 	log.Debugf("Processing Git repositories from blueprint")
 
 	// Unmarshal the blueprint data
-	err = helpers.UnmarshalBlueprint(blueprintData, format, &gitData)
+	err = helpers.DecodeBlueprintInto(blueprintData, format, types.BlueprintTypeGit,
+		helpers.TreeSchemaVersion(initConfig), &gitData)
 	if err != nil {
 		return fmt.Errorf("error unmarshaling Git repository blueprint: %w", err)
 	}
 
 	// Process imports and merge imported git repos
 	blueprintDir := initConfig.Init.Location
-	allRepos, err := processGitImports(gitData.Repos, blueprintDir, format)
+	allRepos, err := processGitImports(gitData.Repos, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return fmt.Errorf("error processing git imports: %w", err)
 	}
@@ -126,7 +127,7 @@ func processGitRepositories(gitRepos []types.Git, initConfig *types.InitConfig) 
 // 	return nil
 // }
 
-func processGitImports(repos []types.Git, blueprintDir string, format string) ([]types.Git, error) {
+func processGitImports(repos []types.Git, blueprintDir string, format string, treeVersion int) ([]types.Git, error) {
 	allRepos := make([]types.Git, 0)
 	visited := make(map[string]bool)
 
@@ -158,7 +159,7 @@ func processGitImports(repos []types.Git, blueprintDir string, format string) ([
 			}
 
 			var importedGitData types.GitData
-			if err := helpers.UnmarshalBlueprint(importData, fileFormat, &importedGitData); err != nil {
+			if err := helpers.DecodeBlueprintInto(importData, fileFormat, types.BlueprintTypeGit, treeVersion, &importedGitData); err != nil {
 				return nil, fmt.Errorf("error unmarshaling import file %s: %w", importPath, err)
 			}
 

--- a/internal/processors/initialize.go
+++ b/internal/processors/initialize.go
@@ -3,9 +3,7 @@ package processors
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"charm.land/log/v2"
@@ -119,6 +117,13 @@ func Initialize(initFilePath string, flags types.Flags) (*types.InitConfig, erro
 		return nil, fmt.Errorf("error unmarshaling %s: %w", processedInitFile, err)
 	}
 
+	// A tree-wide schema version applies to every blueprint type, so it has to be
+	// readable everywhere. Checked here rather than per file: an unreadable tree
+	// version is wrong before a single blueprint is opened.
+	if err := types.ValidateTreeSchemaVersion(initConfig.Init.SchemaVersion); err != nil {
+		return nil, fmt.Errorf("error in %s: %w", initFilePath, err)
+	}
+
 	// Set additional config values
 	initConfig.Variables = variables
 	initConfig.Variables.Flags = flags
@@ -145,43 +150,10 @@ func Initialize(initFilePath string, flags types.Flags) (*types.InitConfig, erro
 	return &initConfig, nil
 }
 
+// setDefaultVariables is helpers.DefaultVariables, shared with `rwr validate` so
+// both render blueprints against the same variables.
 func setDefaultVariables() (types.Variables, error) {
-	currentUser, err := user.Current()
-	if err != nil {
-		return types.Variables{}, fmt.Errorf("error retrieving current user information: %w", err)
-	}
-
-	names := strings.Fields(currentUser.Name)
-	firstName, lastName := "", ""
-	if len(names) > 0 {
-		firstName = names[0]
-	}
-	if len(names) > 1 {
-		lastName = names[len(names)-1]
-	}
-
-	groupName := ""
-	if runtime.GOOS != "windows" {
-		group, err := user.LookupGroupId(currentUser.Gid)
-		if err != nil {
-			log.With("err", err).Warnf("Error retrieving primary group name for user %s", currentUser.Username)
-		} else {
-			groupName = group.Name
-		}
-	}
-
-	return types.Variables{
-		User: types.UserInfo{
-			Username:  currentUser.Username,
-			FirstName: firstName,
-			LastName:  lastName,
-			FullName:  currentUser.Name,
-			GroupName: groupName,
-			Home:      currentUser.HomeDir,
-			Shell:     os.Getenv("SHELL"),
-		},
-		UserDefined: make(map[string]interface{}),
-	}, nil
+	return helpers.DefaultVariables()
 }
 
 func convertTomlToYaml(data []byte) ([]byte, string, error) {

--- a/internal/processors/packages.go
+++ b/internal/processors/packages.go
@@ -28,7 +28,8 @@ func ProcessPackages(data []byte, packages *types.PackagesData, format string, o
 	// If data is provided, unmarshal it
 	if data != nil {
 		var pkgData types.PackagesData
-		if err := helpers.UnmarshalBlueprint(data, format, &pkgData); err != nil {
+		if err := helpers.DecodeBlueprintInto(data, format, types.BlueprintTypePackages,
+			helpers.TreeSchemaVersion(initConfig), &pkgData); err != nil {
 			return fmt.Errorf("error unmarshaling package blueprint: %w", err)
 		}
 		packages = &pkgData
@@ -77,7 +78,8 @@ func ProcessPackages(data []byte, packages *types.PackagesData, format string, o
 
 			// Unmarshal the imported package data
 			var importedPkgData types.PackagesData
-			if err := helpers.UnmarshalBlueprint(importData, fileFormat, &importedPkgData); err != nil {
+			if err := helpers.DecodeBlueprintInto(importData, fileFormat, types.BlueprintTypePackages,
+				helpers.TreeSchemaVersion(initConfig), &importedPkgData); err != nil {
 				return fmt.Errorf("error unmarshaling import file %s: %w", importPath, err)
 			}
 

--- a/internal/processors/profiles.go
+++ b/internal/processors/profiles.go
@@ -1,0 +1,204 @@
+package processors
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// ProfileSummary is what a tree's blueprints declare about profiles.
+type ProfileSummary struct {
+	// Names are the profile names found, sorted.
+	Names []string
+	// Counts is the number of entries carrying each profile.
+	Counts map[string]int
+	// BaseItems is the number of entries carrying no profile, which always apply.
+	BaseItems int
+	// Files is the number of blueprint files inspected.
+	Files int
+}
+
+// CollectProfiles walks the blueprint tree and reports the profiles it declares.
+//
+// This reads the blueprints. `rwr profiles` used to read only the arrays written
+// inline in the init file, and profiles are declared on blueprint entries — so the
+// command that exists to tell an operator what `--profile` accepts answered "No
+// profiles found" for every tree that uses profiles.
+func CollectProfiles(initConfig *types.InitConfig) (*ProfileSummary, error) {
+	summary := &ProfileSummary{Counts: map[string]int{}}
+
+	// The init file may carry entries of its own; keep counting those.
+	collectFrom(summary, initConfig.Packages)
+	collectFrom(summary, initConfig.Services)
+	collectFrom(summary, initConfig.Files)
+	collectFrom(summary, initConfig.Templates)
+	collectFrom(summary, initConfig.Directories)
+	collectFrom(summary, initConfig.Repositories)
+
+	location := initConfig.Init.Location
+	if location == "" {
+		return finish(summary), nil
+	}
+
+	format := initConfig.Init.Format
+	if format == "" {
+		format = types.FormatYAML
+	}
+	wantExt := "." + format
+
+	err := filepath.WalkDir(location, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if path != location && strings.HasPrefix(entry.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != wantExt {
+			return nil
+		}
+		base := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
+		if base == "init" {
+			return nil
+		}
+
+		blueprintType := blueprintTypeForPath(location, path)
+		if blueprintType == "" {
+			return nil
+		}
+
+		data, err := os.ReadFile(path) // #nosec G304 G122 -- read-only walk of the operator's own blueprint tree; containment added in PR8
+		if err != nil {
+			log.Warnf("Could not read %s: %v", path, err)
+			return nil
+		}
+
+		resolved, err := helpers.ResolveTemplate(data, initConfig.Variables)
+		if err != nil {
+			log.Warnf("Could not resolve variables in %s: %v", path, err)
+			return nil
+		}
+
+		if err := collectFromFile(summary, resolved, format, blueprintType); err != nil {
+			log.Warnf("Could not read profiles from %s: %v", path, err)
+			return nil
+		}
+		summary.Files++
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error walking blueprint tree %s: %w", location, err)
+	}
+
+	return finish(summary), nil
+}
+
+// blueprintTypeForPath names the blueprint type from the directory a file sits in,
+// the same way the run order does.
+func blueprintTypeForPath(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return ""
+	}
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		switch part {
+		case types.BlueprintTypePackages, types.BlueprintTypeRepositories, types.BlueprintTypeFiles,
+			types.BlueprintTypeServices, types.BlueprintTypeUsers, types.BlueprintTypeGit,
+			types.BlueprintTypeScripts, types.BlueprintTypeSSHKeys, types.BlueprintTypeFonts,
+			types.BlueprintTypeConfiguration:
+			return part
+		}
+	}
+	return ""
+}
+
+// collectFromFile decodes one blueprint and records the profiles its entries carry.
+func collectFromFile(summary *ProfileSummary, data []byte, format, blueprintType string) error {
+	switch blueprintType {
+	case types.BlueprintTypePackages:
+		var d types.PackagesData
+		if err := helpers.DecodeBlueprintInto(data, format, blueprintType, 0, &d); err != nil {
+			return err
+		}
+		collectFrom(summary, d.Packages)
+	case types.BlueprintTypeRepositories:
+		var d types.RepositoriesData
+		if err := helpers.DecodeBlueprintInto(data, format, blueprintType, 0, &d); err != nil {
+			return err
+		}
+		collectFrom(summary, d.Repositories)
+	case types.BlueprintTypeFiles:
+		var d types.FileData
+		if err := helpers.DecodeBlueprintInto(data, format, blueprintType, 0, &d); err != nil {
+			return err
+		}
+		collectFrom(summary, d.Files)
+		collectFrom(summary, d.Templates)
+		collectFrom(summary, d.Directories)
+	case types.BlueprintTypeServices:
+		var d types.ServiceData
+		if err := helpers.DecodeBlueprintInto(data, format, blueprintType, 0, &d); err != nil {
+			return err
+		}
+		collectFrom(summary, d.Services)
+	case types.BlueprintTypeGit:
+		var d types.GitData
+		if err := helpers.DecodeBlueprintInto(data, format, blueprintType, 0, &d); err != nil {
+			return err
+		}
+		collectFrom(summary, d.Repos)
+	case types.BlueprintTypeScripts:
+		var d types.ScriptData
+		if err := helpers.DecodeBlueprintInto(data, format, blueprintType, 0, &d); err != nil {
+			return err
+		}
+		collectFrom(summary, d.Scripts)
+	case types.BlueprintTypeSSHKeys:
+		var d types.SSHKeyData
+		if err := helpers.DecodeBlueprintInto(data, format, blueprintType, 0, &d); err != nil {
+			return err
+		}
+		collectFrom(summary, d.SSHKeys)
+	case types.BlueprintTypeUsers:
+		var d types.UsersData
+		if err := helpers.DecodeBlueprintInto(data, format, blueprintType, 0, &d); err != nil {
+			return err
+		}
+		collectFrom(summary, d.Users)
+		collectFrom(summary, d.Groups)
+	}
+	return nil
+}
+
+// collectFrom records one slice of profile-carrying entries.
+func collectFrom[T interface{ GetProfiles() []string }](summary *ProfileSummary, items []T) {
+	for _, item := range items {
+		profiles := item.GetProfiles()
+		if len(profiles) == 0 {
+			summary.BaseItems++
+			continue
+		}
+		for _, profile := range profiles {
+			if profile == "" {
+				continue
+			}
+			summary.Counts[profile]++
+		}
+	}
+}
+
+func finish(summary *ProfileSummary) *ProfileSummary {
+	for name := range summary.Counts {
+		summary.Names = append(summary.Names, name)
+	}
+	sort.Strings(summary.Names)
+	return summary
+}

--- a/internal/processors/profiles_discovery_test.go
+++ b/internal/processors/profiles_discovery_test.go
@@ -1,0 +1,138 @@
+package processors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// `rwr profiles` used to read only the arrays written inline in the init file.
+// Profiles are declared on blueprint entries, so the command that exists to tell
+// an operator what --profile accepts reported "No profiles found" for every tree
+// that actually uses profiles. These tests build a tree the normal way.
+
+func writeBlueprintTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, content := range files {
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func treeConfig(root string) *types.InitConfig {
+	init := &types.InitConfig{}
+	init.Init.Location = root
+	init.Init.Format = types.FormatYAML
+	init.Variables.UserDefined = map[string]interface{}{}
+	return init
+}
+
+func TestCollectProfiles_ReadsTheBlueprintTree(t *testing.T) {
+	root := writeBlueprintTree(t, map[string]string{
+		"packages/work.yaml": "packages:\n" +
+			"  - name: slack\n    action: install\n    profiles: [work]\n" +
+			"  - name: git\n    action: install\n",
+		"packages/home.yaml": "packages:\n" +
+			"  - name: steam\n    action: install\n    profiles: [personal, gaming]\n",
+		"services/base.yaml": "services:\n" +
+			"  - name: sshd\n    action: enable\n    profiles: [work]\n",
+	})
+
+	summary, err := CollectProfiles(treeConfig(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]int{"work": 2, "personal": 1, "gaming": 1}
+	if len(summary.Names) != len(want) {
+		t.Fatalf("found profiles %v, want %v", summary.Names, want)
+	}
+	for name, count := range want {
+		if summary.Counts[name] != count {
+			t.Errorf("profile %q counted %d items, want %d", name, summary.Counts[name], count)
+		}
+	}
+	if summary.BaseItems != 1 {
+		t.Errorf("base items = %d, want 1", summary.BaseItems)
+	}
+}
+
+func TestCollectProfiles_CoversEveryBlueprintType(t *testing.T) {
+	root := writeBlueprintTree(t, map[string]string{
+		"packages/p.yaml":     "packages:\n  - name: git\n    action: install\n    profiles: [a]\n",
+		"repositories/r.yaml": "repositories:\n  - name: r\n    package_manager: apt\n    action: add\n    profiles: [b]\n",
+		"files/f.yaml":        "files:\n  - source: ./x\n    target: /tmp/x\n    action: copy\n    profiles: [c]\n",
+		"services/s.yaml":     "services:\n  - name: sshd\n    action: enable\n    profiles: [d]\n",
+		"git/g.yaml":          "git:\n  - name: d\n    action: clone\n    url: https://example.invalid/d.git\n    path: /tmp/d\n    profiles: [e]\n",
+		"scripts/sc.yaml":     "scripts:\n  - name: s.sh\n    action: run\n    source: ./bin\n    profiles: [f]\n",
+		"users/u.yaml":        "users:\n  - name: tester\n    action: create\n    profiles: [g]\n",
+	})
+
+	summary, err := CollectProfiles(treeConfig(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"a", "b", "c", "d", "e", "f", "g"} {
+		if summary.Counts[want] == 0 {
+			t.Errorf("profile %q from its blueprint type was not found; got %v", want, summary.Names)
+		}
+	}
+}
+
+// The names come back sorted so the output is stable between runs.
+func TestCollectProfiles_NamesAreSorted(t *testing.T) {
+	root := writeBlueprintTree(t, map[string]string{
+		"packages/p.yaml": "packages:\n" +
+			"  - name: a\n    action: install\n    profiles: [zeta, alpha, mid]\n",
+	})
+
+	summary, err := CollectProfiles(treeConfig(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"alpha", "mid", "zeta"}
+	for i, name := range want {
+		if summary.Names[i] != name {
+			t.Fatalf("names = %v, want %v", summary.Names, want)
+		}
+	}
+}
+
+// A blueprint referencing a variable has to render before it can be read.
+func TestCollectProfiles_RendersTemplates(t *testing.T) {
+	root := writeBlueprintTree(t, map[string]string{
+		"files/f.yaml": "files:\n  - source: ./x\n    target: \"{{ .User.home }}/x\"\n" +
+			"    action: copy\n    profiles: [dots]\n",
+	})
+
+	init := treeConfig(root)
+	init.Variables.User = types.UserInfo{Home: "/home/tester"}
+
+	summary, err := CollectProfiles(init)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Counts["dots"] != 1 {
+		t.Fatalf("templated blueprint contributed no profile; got %v", summary.Names)
+	}
+}
+
+func TestCollectProfiles_EmptyTreeReportsNothing(t *testing.T) {
+	summary, err := CollectProfiles(treeConfig(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summary.Names) != 0 || summary.BaseItems != 0 {
+		t.Fatalf("empty tree reported %v / %d base items", summary.Names, summary.BaseItems)
+	}
+}

--- a/internal/processors/respository.go
+++ b/internal/processors/respository.go
@@ -21,14 +21,15 @@ func ProcessRepositories(blueprintData []byte, format string, osInfo *types.OSIn
 	log.Debugf("Processing repositories from blueprint")
 
 	// Unmarshal the blueprint data
-	err = helpers.UnmarshalBlueprint(blueprintData, format, &repositoriesBlueprint)
+	err = helpers.DecodeBlueprintInto(blueprintData, format, types.BlueprintTypeRepositories,
+		helpers.TreeSchemaVersion(initConfig), &repositoriesBlueprint)
 	if err != nil {
 		return fmt.Errorf("error unmarshaling repository blueprint: %w", err)
 	}
 
 	// Process imports and merge imported repositories
 	blueprintDir := initConfig.Init.Location
-	allRepositories, err := processRepositoryImports(repositoriesBlueprint.Repositories, blueprintDir, format)
+	allRepositories, err := processRepositoryImports(repositoriesBlueprint.Repositories, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return fmt.Errorf("error processing repository imports: %w", err)
 	}
@@ -153,7 +154,7 @@ func processRepositories(repositories []types.Repository, osInfo *types.OSInfo, 
 	return nil
 }
 
-func processRepositoryImports(repositories []types.Repository, blueprintDir string, format string) ([]types.Repository, error) {
+func processRepositoryImports(repositories []types.Repository, blueprintDir string, format string, treeVersion int) ([]types.Repository, error) {
 	allRepositories := make([]types.Repository, 0)
 	visited := make(map[string]bool)
 
@@ -185,7 +186,7 @@ func processRepositoryImports(repositories []types.Repository, blueprintDir stri
 			}
 
 			var importedRepoData types.RepositoriesData
-			if err := helpers.UnmarshalBlueprint(importData, fileFormat, &importedRepoData); err != nil {
+			if err := helpers.DecodeBlueprintInto(importData, fileFormat, types.BlueprintTypeRepositories, treeVersion, &importedRepoData); err != nil {
 				return nil, fmt.Errorf("error unmarshaling import file %s: %w", importPath, err)
 			}
 

--- a/internal/processors/schema_version_test.go
+++ b/internal/processors/schema_version_test.go
@@ -1,0 +1,227 @@
+package processors
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// Schema versioning is only worth anything if the processors enforce it. It was
+// written, tested at the helper level, and then wired to nothing: every processor
+// called UnmarshalBlueprint directly, so a blueprint declaring a schema this build
+// cannot read was decoded as the current schema and applied to the machine.
+//
+// These tests call the real processors with real blueprint bytes and a recording
+// executor. Each one fails if the enforcement is removed again.
+
+func newTestOSInfo() *types.OSInfo {
+	osInfo := &types.OSInfo{}
+	osInfo.PackageManager.Default = types.PackageManagerInfo{Name: "pacman", Bin: "/usr/bin/pacman"}
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{
+		"pacman": osInfo.PackageManager.Default,
+	}
+	return osInfo
+}
+
+// unsupportedVersionCases covers every blueprint type a processor decodes. Each
+// blueprint is otherwise valid, so the only reason to refuse it is the version.
+var unsupportedVersionCases = []struct {
+	name      string
+	blueprint string
+	run       func(data []byte, osInfo *types.OSInfo, init *types.InitConfig) error
+}{
+	{
+		name:      "packages",
+		blueprint: "schema_version: 99\npackages:\n  - name: git\n    action: install\n    package_manager: pacman\n",
+		run: func(data []byte, osInfo *types.OSInfo, init *types.InitConfig) error {
+			return ProcessPackages(data, nil, "yaml", osInfo, init)
+		},
+	},
+	{
+		name:      "services",
+		blueprint: "schema_version: 99\nservices:\n  - name: sshd\n    action: enable\n",
+		run: func(data []byte, osInfo *types.OSInfo, init *types.InitConfig) error {
+			return ProcessServices(data, "yaml", osInfo, init)
+		},
+	},
+	{
+		name:      "git",
+		blueprint: "schema_version: 99\nrepositories:\n  - name: dots\n    url: https://example.invalid/d.git\n    path: /tmp/rwr-test-dots\n",
+		run: func(data []byte, osInfo *types.OSInfo, init *types.InitConfig) error {
+			return ProcessGitRepositories(data, "yaml", init)
+		},
+	},
+	{
+		name:      "scripts",
+		blueprint: "schema_version: 99\nscripts:\n  - name: hello\n    exec: bash\n    content: \"echo hi\"\n",
+		run: func(data []byte, osInfo *types.OSInfo, init *types.InitConfig) error {
+			return ProcessScripts(data, ".", "yaml", osInfo, init)
+		},
+	},
+	{
+		name:      "users",
+		blueprint: "schema_version: 99\nusers:\n  - name: tester\n    action: create\n",
+		run: func(data []byte, osInfo *types.OSInfo, init *types.InitConfig) error {
+			return ProcessUsers(data, "yaml", init)
+		},
+	},
+	{
+		name:      "configuration",
+		blueprint: "schema_version: 99\nconfiguration:\n  - name: theme\n    type: dconf\n    action: set\n    key: /org/gnome/theme\n    value: dark\n",
+		run: func(data []byte, osInfo *types.OSInfo, init *types.InitConfig) error {
+			return ProcessConfiguration(data, ".", "yaml", init)
+		},
+	},
+}
+
+func TestProcessors_RefuseUnsupportedSchemaVersion(t *testing.T) {
+	for _, tc := range unsupportedVersionCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := exectest.New()
+			defer system.SetExecutor(rec)()
+
+			init := &types.InitConfig{}
+			init.Init.Location = t.TempDir()
+
+			err := tc.run([]byte(tc.blueprint), newTestOSInfo(), init)
+			if err == nil {
+				t.Fatalf("schema_version 99 was accepted; blueprint applied with %d command(s): %+v",
+					len(rec.Calls), rec.Calls)
+			}
+			if !strings.Contains(err.Error(), "99") {
+				t.Errorf("error should name the requested version, got: %v", err)
+			}
+			if len(rec.Calls) != 0 {
+				t.Errorf("refused blueprint still ran %d command(s): %+v", len(rec.Calls), rec.Calls)
+			}
+		})
+	}
+}
+
+// A supported version must still work, or the check above passes for the wrong
+// reason.
+func TestProcessors_AcceptSupportedSchemaVersion(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	init := &types.InitConfig{}
+	init.Init.Location = t.TempDir()
+
+	blueprint := []byte("schema_version: 1\npackages:\n  - name: git\n    action: install\n    package_manager: pacman\n")
+	if err := ProcessPackages(blueprint, nil, "yaml", newTestOSInfo(), init); err != nil {
+		t.Fatalf("schema_version 1 should be accepted: %v", err)
+	}
+	if len(rec.Calls) == 0 {
+		t.Fatal("supported blueprint issued no command")
+	}
+}
+
+// No declaration resolves to the latest supported version, so an undeclared
+// blueprint keeps working without boilerplate.
+func TestProcessors_UndeclaredVersionIsAccepted(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	init := &types.InitConfig{}
+	init.Init.Location = t.TempDir()
+
+	blueprint := []byte("packages:\n  - name: git\n    action: install\n    package_manager: pacman\n")
+	if err := ProcessPackages(blueprint, nil, "yaml", newTestOSInfo(), init); err != nil {
+		t.Fatalf("undeclared version should resolve to latest: %v", err)
+	}
+	if len(rec.Calls) == 0 {
+		t.Fatal("undeclared blueprint issued no command")
+	}
+}
+
+// The tree-wide version from the init file applies to a blueprint that declares
+// none of its own.
+func TestProcessors_TreeVersionApplies(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	init := &types.InitConfig{}
+	init.Init.Location = t.TempDir()
+	init.Init.SchemaVersion = 99
+
+	blueprint := []byte("packages:\n  - name: git\n    action: install\n    package_manager: pacman\n")
+	err := ProcessPackages(blueprint, nil, "yaml", newTestOSInfo(), init)
+	if err == nil {
+		t.Fatalf("tree version 99 was accepted; %d command(s) ran: %+v", len(rec.Calls), rec.Calls)
+	}
+	if len(rec.Calls) != 0 {
+		t.Errorf("refused blueprint still ran %d command(s)", len(rec.Calls))
+	}
+}
+
+// A file's own declaration overrides the tree's. This is what makes a
+// single-resource migration possible, so it has to hold in both directions.
+func TestProcessors_FileVersionOverridesTree(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	init := &types.InitConfig{}
+	init.Init.Location = t.TempDir()
+	init.Init.SchemaVersion = 99 // unreadable tree-wide
+
+	blueprint := []byte("schema_version: 1\npackages:\n  - name: git\n    action: install\n    package_manager: pacman\n")
+	if err := ProcessPackages(blueprint, nil, "yaml", newTestOSInfo(), init); err != nil {
+		t.Fatalf("file declaration should override the tree version: %v", err)
+	}
+	if len(rec.Calls) == 0 {
+		t.Fatal("blueprint pinned to a supported version issued no command")
+	}
+}
+
+// Imported files are blueprints too, and an import is exactly where a file
+// written for a different rwr arrives from somebody else's repository.
+func TestProcessors_ImportedFileVersionIsEnforced(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	dir := t.TempDir()
+	imported := filepath.Join(dir, "extra.yaml")
+	if err := os.WriteFile(imported,
+		[]byte("schema_version: 99\npackages:\n  - name: curl\n    action: install\n    package_manager: pacman\n"),
+		0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	init := &types.InitConfig{}
+	init.Init.Location = dir
+
+	blueprint := []byte("packages:\n  - import: extra.yaml\n")
+	err := ProcessPackages(blueprint, nil, "yaml", newTestOSInfo(), init)
+	if err == nil {
+		t.Fatalf("imported blueprint with version 99 was accepted; %d command(s) ran: %+v",
+			len(rec.Calls), rec.Calls)
+	}
+	if len(rec.Calls) != 0 {
+		t.Errorf("refused import still ran %d command(s)", len(rec.Calls))
+	}
+}
+
+// The error has to say which version was asked for and which are supported —
+// "invalid blueprint" sends the operator looking in the wrong place.
+func TestProcessors_UnsupportedVersionErrorIsActionable(t *testing.T) {
+	defer system.SetExecutor(exectest.New())()
+
+	init := &types.InitConfig{}
+	init.Init.Location = t.TempDir()
+
+	blueprint := []byte("schema_version: 7\npackages:\n  - name: git\n    action: install\n")
+	err := ProcessPackages(blueprint, nil, "yaml", newTestOSInfo(), init)
+	if err == nil {
+		t.Fatal("expected refusal")
+	}
+	for _, want := range []string{"packages", "7", "supports 1", "upgrade rwr"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q: %v", want, err)
+		}
+	}
+}

--- a/internal/processors/schema_version_test.go
+++ b/internal/processors/schema_version_test.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -26,6 +27,42 @@ func newTestOSInfo() *types.OSInfo {
 		"pacman": osInfo.PackageManager.Default,
 	}
 	return osInfo
+}
+
+// useTestProvider installs a provider named "pacman" whose binary is one every
+// platform has, so these tests assert how rwr builds a command rather than
+// asserting what the runner happens to have installed.
+//
+// Without it the tests pass on a machine with pacman and fail on one without —
+// which is exactly what happened: green on an Arch workstation, red on CI's
+// Ubuntu runner.
+func useTestProvider(t *testing.T) {
+	t.Helper()
+
+	bin := "sh"
+	if runtime.GOOS == types.OSWindows {
+		bin = "cmd"
+	}
+
+	restore := system.SetProvidersForTest(map[string]*types.Provider{
+		"pacman": {
+			Name:     "pacman",
+			Elevated: true,
+			Detection: types.DetectionConfig{
+				Binary:        bin,
+				Distributions: []string{types.OSLinux, types.OSDarwin, types.OSWindows},
+			},
+			Commands: types.CommandConfig{
+				Install: "-Sy --noconfirm",
+				Remove:  "-Rns --noconfirm",
+				Update:  "-Syu --noconfirm",
+				Clean:   "-Sc --noconfirm",
+				List:    "-Q",
+				Search:  "-Ss",
+			},
+		},
+	})
+	t.Cleanup(restore)
 }
 
 // unsupportedVersionCases covers every blueprint type a processor decodes. Each
@@ -106,6 +143,7 @@ func TestProcessors_RefuseUnsupportedSchemaVersion(t *testing.T) {
 // A supported version must still work, or the check above passes for the wrong
 // reason.
 func TestProcessors_AcceptSupportedSchemaVersion(t *testing.T) {
+	useTestProvider(t)
 	rec := exectest.New()
 	defer system.SetExecutor(rec)()
 
@@ -124,6 +162,7 @@ func TestProcessors_AcceptSupportedSchemaVersion(t *testing.T) {
 // No declaration resolves to the latest supported version, so an undeclared
 // blueprint keeps working without boilerplate.
 func TestProcessors_UndeclaredVersionIsAccepted(t *testing.T) {
+	useTestProvider(t)
 	rec := exectest.New()
 	defer system.SetExecutor(rec)()
 
@@ -162,6 +201,7 @@ func TestProcessors_TreeVersionApplies(t *testing.T) {
 // A file's own declaration overrides the tree's. This is what makes a
 // single-resource migration possible, so it has to hold in both directions.
 func TestProcessors_FileVersionOverridesTree(t *testing.T) {
+	useTestProvider(t)
 	rec := exectest.New()
 	defer system.SetExecutor(rec)()
 

--- a/internal/processors/scripts.go
+++ b/internal/processors/scripts.go
@@ -20,7 +20,8 @@ func ProcessScripts(blueprintData []byte, blueprintDir string, format string, os
 	var err error
 
 	// Unmarshal the blueprint data
-	err = helpers.UnmarshalBlueprint(blueprintData, format, &scriptData)
+	err = helpers.DecodeBlueprintInto(blueprintData, format, types.BlueprintTypeScripts,
+		helpers.TreeSchemaVersion(initConfig), &scriptData)
 	if err != nil {
 		log.Errorf("Error unmarshaling scripts blueprint: %v", err)
 		return fmt.Errorf("error unmarshaling scripts blueprint: %w", err)
@@ -29,7 +30,7 @@ func ProcessScripts(blueprintData []byte, blueprintDir string, format string, os
 	log.Debugf("Unmarshaled scripts: %+v", scriptData.Scripts)
 
 	// Process imports and merge imported scripts
-	allScripts, err := processScriptImports(scriptData.Scripts, blueprintDir, format)
+	allScripts, err := processScriptImports(scriptData.Scripts, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return fmt.Errorf("error processing script imports: %w", err)
 	}
@@ -194,7 +195,7 @@ func runScript(script types.Script, osInfo *types.OSInfo, initConfig *types.Init
 	return nil
 }
 
-func processScriptImports(scripts []types.Script, blueprintDir string, format string) ([]types.Script, error) {
+func processScriptImports(scripts []types.Script, blueprintDir string, format string, treeVersion int) ([]types.Script, error) {
 	allScripts := make([]types.Script, 0)
 	visited := make(map[string]bool)
 
@@ -226,7 +227,7 @@ func processScriptImports(scripts []types.Script, blueprintDir string, format st
 			}
 
 			var importedScriptData types.ScriptData
-			if err := helpers.UnmarshalBlueprint(importData, fileFormat, &importedScriptData); err != nil {
+			if err := helpers.DecodeBlueprintInto(importData, fileFormat, types.BlueprintTypeScripts, treeVersion, &importedScriptData); err != nil {
 				return nil, fmt.Errorf("error unmarshaling import file %s: %w", importPath, err)
 			}
 

--- a/internal/processors/services.go
+++ b/internal/processors/services.go
@@ -20,14 +20,15 @@ func ProcessServices(blueprintData []byte, format string, osInfo *types.OSInfo, 
 	var err error
 
 	// Unmarshal the blueprint data
-	err = helpers.UnmarshalBlueprint(blueprintData, format, &servicesData)
+	err = helpers.DecodeBlueprintInto(blueprintData, format, types.BlueprintTypeServices,
+		helpers.TreeSchemaVersion(initConfig), &servicesData)
 	if err != nil {
 		return fmt.Errorf("error unmarshaling service blueprint: %w", err)
 	}
 
 	// Process imports and merge imported services
 	blueprintDir := initConfig.Init.Location
-	allServices, err := processServiceImports(servicesData.Services, blueprintDir, format)
+	allServices, err := processServiceImports(servicesData.Services, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return fmt.Errorf("error processing service imports: %w", err)
 	}
@@ -398,7 +399,7 @@ func processWindowsService(service types.Service, osInfo *types.OSInfo, initConf
 	return nil
 }
 
-func processServiceImports(services []types.Service, blueprintDir string, format string) ([]types.Service, error) {
+func processServiceImports(services []types.Service, blueprintDir string, format string, treeVersion int) ([]types.Service, error) {
 	allServices := make([]types.Service, 0)
 	visited := make(map[string]bool)
 
@@ -430,7 +431,7 @@ func processServiceImports(services []types.Service, blueprintDir string, format
 			}
 
 			var importedServiceData types.ServiceData
-			if err := helpers.UnmarshalBlueprint(importData, fileFormat, &importedServiceData); err != nil {
+			if err := helpers.DecodeBlueprintInto(importData, fileFormat, types.BlueprintTypeServices, treeVersion, &importedServiceData); err != nil {
 				return nil, fmt.Errorf("error unmarshaling import file %s: %w", importPath, err)
 			}
 

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -84,14 +84,15 @@ func ProcessSSHKeys(blueprintData []byte, format string, osInfo *types.OSInfo, i
 	log.Debugf("Processing SSH keys from blueprint")
 
 	// Unmarshal the blueprint data
-	err = helpers.UnmarshalBlueprint(blueprintData, format, &sshKeyData)
+	err = helpers.DecodeBlueprintInto(blueprintData, format, types.BlueprintTypeSSHKeys,
+		helpers.TreeSchemaVersion(initConfig), &sshKeyData)
 	if err != nil {
 		return fmt.Errorf("error unmarshaling SSH key blueprint: %v", err)
 	}
 
 	// Process imports and merge imported SSH keys
 	blueprintDir := initConfig.Init.Location
-	allSSHKeys, err := processSSHKeyImports(sshKeyData.SSHKeys, blueprintDir, format)
+	allSSHKeys, err := processSSHKeyImports(sshKeyData.SSHKeys, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return fmt.Errorf("error processing SSH key imports: %w", err)
 	}
@@ -531,7 +532,7 @@ func copySSHKeyToGitHub(sshKey types.SSHKey, initConfig *types.InitConfig) error
 	}
 }
 
-func processSSHKeyImports(sshKeys []types.SSHKey, blueprintDir string, format string) ([]types.SSHKey, error) {
+func processSSHKeyImports(sshKeys []types.SSHKey, blueprintDir string, format string, treeVersion int) ([]types.SSHKey, error) {
 	allSSHKeys := make([]types.SSHKey, 0)
 	visited := make(map[string]bool)
 
@@ -563,7 +564,7 @@ func processSSHKeyImports(sshKeys []types.SSHKey, blueprintDir string, format st
 			}
 
 			var importedSSHKeyData types.SSHKeyData
-			if err := helpers.UnmarshalBlueprint(importData, fileFormat, &importedSSHKeyData); err != nil {
+			if err := helpers.DecodeBlueprintInto(importData, fileFormat, types.BlueprintTypeSSHKeys, treeVersion, &importedSSHKeyData); err != nil {
 				return nil, fmt.Errorf("error unmarshaling import file %s: %w", importPath, err)
 			}
 

--- a/internal/processors/user.go
+++ b/internal/processors/user.go
@@ -19,7 +19,8 @@ func ProcessUsers(blueprintData []byte, format string, initConfig *types.InitCon
 	var err error
 
 	// Unmarshal the blueprint data
-	err = helpers.UnmarshalBlueprint(blueprintData, format, &usersData)
+	err = helpers.DecodeBlueprintInto(blueprintData, format, types.BlueprintTypeUsers,
+		helpers.TreeSchemaVersion(initConfig), &usersData)
 	if err != nil {
 		log.Errorf("Error unmarshaling users blueprint: %v", err)
 		return fmt.Errorf("error unmarshaling users blueprint: %w", err)
@@ -27,13 +28,13 @@ func ProcessUsers(blueprintData []byte, format string, initConfig *types.InitCon
 
 	// Process imports and merge imported users and groups
 	blueprintDir := initConfig.Init.Location
-	allGroups, err := processGroupImports(usersData.Groups, blueprintDir, format)
+	allGroups, err := processGroupImports(usersData.Groups, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return fmt.Errorf("error processing group imports: %w", err)
 	}
 	usersData.Groups = allGroups
 
-	allUsers, err := processUserImports(usersData.Users, blueprintDir, format)
+	allUsers, err := processUserImports(usersData.Users, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return fmt.Errorf("error processing user imports: %w", err)
 	}
@@ -344,7 +345,7 @@ func removeUser(user types.User, initConfig *types.InitConfig) error {
 	return nil
 }
 
-func processGroupImports(groups []types.Group, blueprintDir string, format string) ([]types.Group, error) {
+func processGroupImports(groups []types.Group, blueprintDir string, format string, treeVersion int) ([]types.Group, error) {
 	allGroups := make([]types.Group, 0)
 	visited := make(map[string]bool)
 
@@ -376,7 +377,7 @@ func processGroupImports(groups []types.Group, blueprintDir string, format strin
 			}
 
 			var importedUsersData types.UsersData
-			if err := helpers.UnmarshalBlueprint(importData, fileFormat, &importedUsersData); err != nil {
+			if err := helpers.DecodeBlueprintInto(importData, fileFormat, types.BlueprintTypeUsers, treeVersion, &importedUsersData); err != nil {
 				return nil, fmt.Errorf("error unmarshaling import file %s: %w", importPath, err)
 			}
 
@@ -390,7 +391,7 @@ func processGroupImports(groups []types.Group, blueprintDir string, format strin
 	return allGroups, nil
 }
 
-func processUserImports(users []types.User, blueprintDir string, format string) ([]types.User, error) {
+func processUserImports(users []types.User, blueprintDir string, format string, treeVersion int) ([]types.User, error) {
 	allUsers := make([]types.User, 0)
 	visited := make(map[string]bool)
 
@@ -422,7 +423,7 @@ func processUserImports(users []types.User, blueprintDir string, format string) 
 			}
 
 			var importedUsersData types.UsersData
-			if err := helpers.UnmarshalBlueprint(importData, fileFormat, &importedUsersData); err != nil {
+			if err := helpers.DecodeBlueprintInto(importData, fileFormat, types.BlueprintTypeUsers, treeVersion, &importedUsersData); err != nil {
 				return nil, fmt.Errorf("error unmarshaling import file %s: %w", importPath, err)
 			}
 

--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -486,3 +486,29 @@ func logDetectionSummary(currentOS, currentDistro string) {
 	}
 	log.Errorf("=== END DETECTION SUMMARY ===")
 }
+
+// SetProvidersForTest replaces the loaded provider set and returns a function
+// restoring the previous one.
+//
+// It exists because the processors resolve a package manager through the real
+// provider registry, which asks the host what it has installed. Tests written
+// against that answer pass on the machine they were written on and fail
+// everywhere else: the schema and import tests passed on an Arch workstation and
+// failed on CI's Ubuntu runner, because pacman is not there. A test asserting how
+// rwr builds a command should not depend on which package manager the runner
+// happens to have.
+//
+//	defer system.SetProvidersForTest(map[string]*types.Provider{...})()
+func SetProvidersForTest(provs map[string]*types.Provider) (restore func()) {
+	providersMu.Lock()
+	defer providersMu.Unlock()
+
+	previous, previousInit := providers, providersInit
+	providers, providersInit = provs, true
+
+	return func() {
+		providersMu.Lock()
+		defer providersMu.Unlock()
+		providers, providersInit = previous, previousInit
+	}
+}

--- a/internal/types/bootstrap.go
+++ b/internal/types/bootstrap.go
@@ -1,12 +1,14 @@
 package types
 
 type BootstrapData struct {
-	Packages    []Package   `mapstructure:"packages,omitempty" yaml:"packages,omitempty" json:"packages,omitempty" toml:"packages,omitempty"`             // Packages data
-	Files       []File      `mapstructure:"files,omitempty" yaml:"files,omitempty" json:"files,omitempty" toml:"files,omitempty"`                         // Files data
-	Directories []Directory `mapstructure:"directories,omitempty" yaml:"directories,omitempty" json:"directories,omitempty" toml:"directories,omitempty"` // Directories data
-	Git         []Git       `mapstructure:"git,omitempty" yaml:"git,omitempty" json:"git,omitempty" toml:"git,omitempty"`                                 // Git data
-	SSHKeys     []SSHKey    `mapstructure:"ssh_keys,omitempty" yaml:"ssh_keys,omitempty" json:"ssh_keys,omitempty" toml:"ssh_keys,omitempty"`             // SSHKey Data
-	Services    []Service   `mapstructure:"services,omitempty" yaml:"services,omitempty" json:"services,omitempty" toml:"services,omitempty"`             // Services data
-	Groups      []Group     `mapstructure:"groups,omitempty" yaml:"groups,omitempty" json:"groups,omitempty" toml:"groups,omitempty"`                     // Groups data
-	Users       []User      `mapstructure:"users,omitempty" yaml:"users,omitempty" json:"users,omitempty" toml:"users,omitempty"`                         // Users data
+	// SchemaVersion, when set, overrides the tree-wide version from the init file.
+	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
+	Packages      []Package   `mapstructure:"packages,omitempty" yaml:"packages,omitempty" json:"packages,omitempty" toml:"packages,omitempty"`             // Packages data
+	Files         []File      `mapstructure:"files,omitempty" yaml:"files,omitempty" json:"files,omitempty" toml:"files,omitempty"`                         // Files data
+	Directories   []Directory `mapstructure:"directories,omitempty" yaml:"directories,omitempty" json:"directories,omitempty" toml:"directories,omitempty"` // Directories data
+	Git           []Git       `mapstructure:"git,omitempty" yaml:"git,omitempty" json:"git,omitempty" toml:"git,omitempty"`                                 // Git data
+	SSHKeys       []SSHKey    `mapstructure:"ssh_keys,omitempty" yaml:"ssh_keys,omitempty" json:"ssh_keys,omitempty" toml:"ssh_keys,omitempty"`             // SSHKey Data
+	Services      []Service   `mapstructure:"services,omitempty" yaml:"services,omitempty" json:"services,omitempty" toml:"services,omitempty"`             // Services data
+	Groups        []Group     `mapstructure:"groups,omitempty" yaml:"groups,omitempty" json:"groups,omitempty" toml:"groups,omitempty"`                     // Groups data
+	Users         []User      `mapstructure:"users,omitempty" yaml:"users,omitempty" json:"users,omitempty" toml:"users,omitempty"`                         // Users data
 }

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -53,12 +53,33 @@ const (
 )
 
 // File actions for file management operations.
+//
+// This is the set the files processor actually dispatches on. It previously
+// listed append and template, which no branch handles, and omitted copy, move,
+// chmod, chown, chgrp and symlink, which every one of them does — so validation
+// rejected the actions the examples use and accepted two that do nothing.
 const (
-	FileActionCreate   = "create"
-	FileActionDelete   = "delete"
-	FileActionAppend   = "append"
-	FileActionTemplate = "template"
+	FileActionCreate  = "create"
+	FileActionDelete  = "delete"
+	FileActionCopy    = "copy"
+	FileActionMove    = "move"
+	FileActionChmod   = "chmod"
+	FileActionChown   = "chown"
+	FileActionChgrp   = "chgrp"
+	FileActionSymlink = "symlink"
 )
+
+// FileActions is every action a file or template entry may declare.
+var FileActions = []string{
+	FileActionCreate,
+	FileActionDelete,
+	FileActionCopy,
+	FileActionMove,
+	FileActionChmod,
+	FileActionChown,
+	FileActionChgrp,
+	FileActionSymlink,
+}
 
 // Repository actions for repository management operations.
 const (

--- a/internal/types/schema_registry.go
+++ b/internal/types/schema_registry.go
@@ -47,6 +47,7 @@ var schemaRegistry = map[string]map[int]variantFactory{
 	BlueprintTypeFonts:         {1: func() SchemaVariant { return &fontsV1{} }},
 	BlueprintTypeUsers:         {1: func() SchemaVariant { return &usersV1{} }},
 	BlueprintTypeConfiguration: {1: func() SchemaVariant { return &configurationV1{} }},
+	BlueprintTypeBootstrap:     {1: func() SchemaVariant { return &bootstrapV1{} }},
 }
 
 // NewSchemaVariant returns the struct that reads blueprintType at version.
@@ -125,6 +126,12 @@ type usersV1 struct{ UsersData }
 func (v *usersV1) Target() interface{}        { return &v.UsersData }
 func (v *usersV1) Canonical() interface{}     { return &v.UsersData }
 func (v *usersV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
+
+type bootstrapV1 struct{ BootstrapData }
+
+func (v *bootstrapV1) Target() interface{}        { return &v.BootstrapData }
+func (v *bootstrapV1) Canonical() interface{}     { return &v.BootstrapData }
+func (v *bootstrapV1) DeclaredSchemaVersion() int { return v.DeclaredVersion() }
 
 type configurationV1 struct{ ConfigData }
 

--- a/internal/validate/blueprints.go
+++ b/internal/validate/blueprints.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,31 +38,46 @@ func ValidateBlueprints(path string, verbose bool, results *types.ValidationResu
 		return nil
 	}
 
-	// Only validate files in the specified directory
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		return fmt.Errorf("error reading directory: %w", err)
-	}
-
-	// Get the init file extension to match other blueprint files
+	// Walk the whole tree, not just the top directory.
+	//
+	// Blueprints are organised by type — packages/, files/, services/ — which is the
+	// layout the documentation recommends and every example uses. Reading only the
+	// top directory meant `rwr validate` on such a tree checked the init file and
+	// nothing else, and reported success. The command an operator runs to find out
+	// whether their configuration is sound was inspecting one file out of dozens.
 	initExt := filepath.Ext(initFile)
 
-	for _, entry := range entries {
+	err = filepath.WalkDir(path, func(filePath string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if entry.IsDir() {
-			continue // Skip subdirectories
-		}
-
-		filePath := filepath.Join(path, entry.Name())
-		if filePath == initFile {
-			continue // Skip init file
-		}
-
-		// Only process files with the same extension as the init file
-		if filepath.Ext(filePath) == initExt {
-			if err := validateBlueprintFile(filePath, initConfig, results); err != nil {
-				AddIssue(results, types.ValidationError, fmt.Sprintf("Error validating blueprint file: %s", err), filePath, 0, "")
+			// Skip version-control and other dot directories: nothing under them is
+			// a blueprint, and .git in particular holds a great many files.
+			if filePath != path && strings.HasPrefix(entry.Name(), ".") {
+				return fs.SkipDir
 			}
+			return nil
 		}
+
+		if filePath == initFile || filepath.Ext(filePath) != initExt {
+			return nil
+		}
+
+		// A nested init file belongs to its own subtree; validating it as a
+		// blueprint reports every one of its keys as unknown.
+		if isInitFileName(entry.Name()) {
+			return nil
+		}
+
+		if err := validateBlueprintFile(filePath, initConfig, results); err != nil {
+			AddIssue(results, types.ValidationError, fmt.Sprintf("Error validating blueprint file: %s", err), filePath, 0, "")
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error walking blueprint directory: %w", err)
 	}
 
 	if verbose {
@@ -69,6 +85,12 @@ func ValidateBlueprints(path string, verbose bool, results *types.ValidationResu
 	}
 
 	return nil
+}
+
+// isInitFileName reports whether a filename is an init file for some subtree.
+func isInitFileName(name string) bool {
+	base := strings.TrimSuffix(name, filepath.Ext(name))
+	return base == "init"
 }
 
 // findInitFile searches for an init file in the specified directory (non-recursive).
@@ -101,6 +123,20 @@ func validateInitFile(initFile string, results *types.ValidationResults) (*types
 	if err != nil {
 		AddIssue(results, types.ValidationError, fmt.Sprintf("Error unmarshaling init file: %s", err), initFile, 0, "Check file format and syntax")
 		return nil, nil
+	}
+
+	// Blueprints are rendered as templates before they are read, so validation has
+	// to render them against the same variables a run would.
+	if variables, err := helpers.DefaultVariables(); err != nil {
+		log.Warnf("Could not resolve template variables for validation: %v", err)
+	} else {
+		initConfig.Variables = variables
+	}
+
+	// A tree-wide schema version has to be readable for every blueprint type.
+	if err := types.ValidateTreeSchemaVersion(initConfig.Init.SchemaVersion); err != nil {
+		AddIssue(results, types.ValidationError, err.Error(), initFile, 0,
+			"Declare the version per blueprint file instead, or upgrade rwr")
 	}
 
 	// Validate the Init field
@@ -155,12 +191,16 @@ func validateBlueprintFile(blueprintFile string, initConfig *types.InitConfig, r
 		return fmt.Errorf("error reading blueprint file: %w", err)
 	}
 
-	// Resolve template variables if it's a bootstrap file
-	if filepath.Base(blueprintFile) == "bootstrap.yaml" {
-		blueprintFileData, err = helpers.ResolveTemplate(blueprintFileData, initConfig.Variables)
-		if err != nil {
-			return fmt.Errorf("error resolving variables in bootstrap file: %w", err)
-		}
+	// Resolve template variables in every blueprint, as a real run does.
+	//
+	// This used to apply to bootstrap.yaml alone, which was survivable only because
+	// validation never looked past the top directory. A blueprint using
+	// {{ .User.home }} is not valid YAML until it is rendered — the braces read as a
+	// flow mapping — so validating the raw bytes reports a parse error against a
+	// blueprint that works.
+	blueprintFileData, err = helpers.ResolveTemplate(blueprintFileData, initConfig.Variables)
+	if err != nil {
+		return fmt.Errorf("error resolving variables in %s: %w", filepath.Base(blueprintFile), err)
 	}
 
 	// Determine blueprint type from filename or directory name
@@ -194,78 +234,106 @@ func validateBlueprintFile(blueprintFile string, initConfig *types.InitConfig, r
 // blueprintValidator unmarshals and validates a single blueprint type.
 type blueprintValidator func(data []byte, format string, file string, results *types.ValidationResults) error
 
-// blueprintValidators maps blueprint types to their unmarshal+validate functions.
+// blueprintValidators maps blueprint types to their decode+validate functions.
+//
+// Each one decodes into the same Data struct the matching processor uses. They
+// used to decode into a bare slice — []types.Repository for a file whose content
+// is `repositories:` followed by a list — which cannot succeed against any real
+// blueprint. Nothing caught it because validation never looked inside a
+// subdirectory, and blueprints live in subdirectories.
 var blueprintValidators = map[string]blueprintValidator{
 	types.BlueprintTypeBootstrap: func(data []byte, format string, file string, results *types.ValidationResults) error {
 		var d types.BootstrapData
-		if err := helpers.UnmarshalBlueprint(data, format, &d); err != nil {
-			return fmt.Errorf("error unmarshaling bootstrap blueprint: %w", err)
+		if err := decode(data, format, types.BlueprintTypeBootstrap, &d); err != nil {
+			return err
 		}
 		ValidateBootstrap(d, file, results)
 		return nil
 	},
 	types.BlueprintTypePackages: func(data []byte, format string, file string, results *types.ValidationResults) error {
 		var d types.PackagesData
-		if err := helpers.UnmarshalBlueprint(data, format, &d); err != nil {
-			return fmt.Errorf("error unmarshaling packages blueprint: %w", err)
+		if err := decode(data, format, types.BlueprintTypePackages, &d); err != nil {
+			return err
 		}
 		ValidatePackages(d.Packages, file, results)
 		return nil
 	},
 	types.BlueprintTypeRepositories: func(data []byte, format string, file string, results *types.ValidationResults) error {
-		var d []types.Repository
-		if err := helpers.UnmarshalBlueprint(data, format, &d); err != nil {
-			return fmt.Errorf("error unmarshaling repositories blueprint: %w", err)
+		var d types.RepositoriesData
+		if err := decode(data, format, types.BlueprintTypeRepositories, &d); err != nil {
+			return err
 		}
-		ValidateRepositories(d, file, results)
+		ValidateRepositories(d.Repositories, file, results)
 		return nil
 	},
 	types.BlueprintTypeFiles: func(data []byte, format string, file string, results *types.ValidationResults) error {
-		var d []types.File
-		if err := helpers.UnmarshalBlueprint(data, format, &d); err != nil {
-			return fmt.Errorf("error unmarshaling files blueprint: %w", err)
+		var d types.FileData
+		if err := decode(data, format, types.BlueprintTypeFiles, &d); err != nil {
+			return err
 		}
-		ValidateFiles(d, file, results)
+		// A files blueprint carries files, templates and directories together; the
+		// files processor reads all three, so validation has to as well.
+		ValidateFiles(append(append([]types.File{}, d.Files...), d.Templates...), file, results)
 		return nil
 	},
 	types.BlueprintTypeGit: func(data []byte, format string, file string, results *types.ValidationResults) error {
-		var d []types.Git
-		if err := helpers.UnmarshalBlueprint(data, format, &d); err != nil {
-			return fmt.Errorf("error unmarshaling git repositories blueprint: %w", err)
+		var d types.GitData
+		if err := decode(data, format, types.BlueprintTypeGit, &d); err != nil {
+			return err
 		}
-		ValidateGitRepositories(d, file, results)
+		ValidateGitRepositories(d.Repos, file, results)
 		return nil
 	},
 	types.BlueprintTypeScripts: func(data []byte, format string, file string, results *types.ValidationResults) error {
-		var d []types.Script
-		if err := helpers.UnmarshalBlueprint(data, format, &d); err != nil {
-			return fmt.Errorf("error unmarshaling scripts blueprint: %w", err)
+		var d types.ScriptData
+		if err := decode(data, format, types.BlueprintTypeScripts, &d); err != nil {
+			return err
 		}
-		ValidateScripts(d, file, results)
+		ValidateScripts(d.Scripts, file, results)
 		return nil
 	},
 	types.BlueprintTypeServices: func(data []byte, format string, file string, results *types.ValidationResults) error {
-		var d []types.Service
-		if err := helpers.UnmarshalBlueprint(data, format, &d); err != nil {
-			return fmt.Errorf("error unmarshaling services blueprint: %w", err)
+		var d types.ServiceData
+		if err := decode(data, format, types.BlueprintTypeServices, &d); err != nil {
+			return err
 		}
-		ValidateServices(d, file, results)
+		ValidateServices(d.Services, file, results)
 		return nil
 	},
 	types.BlueprintTypeSSHKeys: func(data []byte, format string, file string, results *types.ValidationResults) error {
-		var d []types.SSHKey
-		if err := helpers.UnmarshalBlueprint(data, format, &d); err != nil {
-			return fmt.Errorf("error unmarshaling ssh keys blueprint: %w", err)
+		var d types.SSHKeyData
+		if err := decode(data, format, types.BlueprintTypeSSHKeys, &d); err != nil {
+			return err
 		}
-		ValidateSSHKeys(d, file, results)
+		ValidateSSHKeys(d.SSHKeys, file, results)
 		return nil
 	},
 	types.BlueprintTypeUsers: func(data []byte, format string, file string, results *types.ValidationResults) error {
 		var d types.UsersData
-		if err := helpers.UnmarshalBlueprint(data, format, &d); err != nil {
-			return fmt.Errorf("error unmarshaling users blueprint: %w", err)
+		if err := decode(data, format, types.BlueprintTypeUsers, &d); err != nil {
+			return err
 		}
 		ValidateUsers(d.Users, file, results)
 		return nil
 	},
+	// fonts and configuration were absent, so every fonts and configuration
+	// blueprint was reported as an unsupported type. They decode like the rest;
+	// the schema check alone is worth running against them.
+	types.BlueprintTypeFonts: func(data []byte, format string, file string, results *types.ValidationResults) error {
+		var d types.FontsData
+		return decode(data, format, types.BlueprintTypeFonts, &d)
+	},
+	types.BlueprintTypeConfiguration: func(data []byte, format string, file string, results *types.ValidationResults) error {
+		var d types.ConfigData
+		return decode(data, format, types.BlueprintTypeConfiguration, &d)
+	},
+}
+
+// decode reads a blueprint the way a run does, so validation enforces the same
+// schema version the processors do.
+func decode[T any](data []byte, format, blueprintType string, out *T) error {
+	if err := helpers.DecodeBlueprintInto(data, format, blueprintType, 0, out); err != nil {
+		return fmt.Errorf("error unmarshaling %s blueprint: %w", blueprintType, err)
+	}
+	return nil
 }

--- a/internal/validate/components.go
+++ b/internal/validate/components.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/fynxlabs/rwr/internal/types"
 )
@@ -19,19 +20,22 @@ func ValidatePackages(packages []types.Package, file string, results *types.Vali
 			continue
 		}
 
-		validateRequired(pkg.Name, fmt.Sprintf("packages[%d].name", i), file, results, "Add name field to package")
+		// A package entry names one package with `name` or several with `names`.
+		// Requiring `name` and separately warning on an empty `names` reported two
+		// problems against every correct entry, whichever form it used.
+		if pkg.Name == "" && len(pkg.Names) == 0 {
+			AddIssue(results, types.ValidationError,
+				fmt.Sprintf("Missing required field 'packages[%d].name'", i), file, 0,
+				"Add a name field, or a names list, to the package")
+		}
 
 		validateEnum(pkg.Action, fmt.Sprintf("packages[%d].action", i),
 			[]string{types.ActionInstall, types.ActionRemove, types.ActionUpdate}, file, results)
 
-		if pkg.PackageManager == "" {
-			AddIssue(results, types.ValidationWarning, fmt.Sprintf("No package manager specified for package '%s'", pkg.Name), file, 0, "Add package_manager field to package")
-		} else {
-			validateProviderExists(pkg.PackageManager, "package", pkg.Name, file, results)
-		}
-
-		if len(pkg.Names) == 0 {
-			AddIssue(results, types.ValidationWarning, fmt.Sprintf("No package names specified for package '%s'", pkg.Name), file, 0, "Add names field to package")
+		// package_manager is optional: without one, the package is installed by the
+		// default manager detected for this machine, which is the common case.
+		if pkg.PackageManager != "" {
+			validateProviderExists(pkg.PackageManager, "package", packageLabel(pkg), file, results)
 		}
 	}
 }
@@ -76,10 +80,9 @@ func ValidateFiles(files []types.File, file string, results *types.ValidationRes
 
 		validateRequired(f.Target, fmt.Sprintf("files[%d].target", i), file, results, "Add target field to file")
 
-		validateEnum(f.Action, fmt.Sprintf("files[%d].action", i),
-			[]string{types.FileActionCreate, types.FileActionDelete, types.FileActionAppend, types.FileActionTemplate}, file, results)
+		validateEnum(f.Action, fmt.Sprintf("files[%d].action", i), types.FileActions, file, results)
 
-		if f.Action == types.FileActionCreate || f.Action == types.FileActionAppend || f.Action == types.FileActionTemplate {
+		if f.Action == types.FileActionCreate || f.Action == types.FileActionCopy || f.Action == types.FileActionMove {
 			if f.Content == "" && f.Source == "" {
 				AddIssue(results, types.ValidationWarning, fmt.Sprintf("No content or source specified for file '%s'", f.Target), file, 0, "Add content or source field to file")
 			}
@@ -120,8 +123,14 @@ func ValidateScripts(scripts []types.Script, file string, results *types.Validat
 
 		validateRequired(script.Name, fmt.Sprintf("scripts[%d].name", i), file, results, "Add name field to script")
 
-		if script.Exec == "" && script.Content == "" {
-			AddIssue(results, types.ValidationError, fmt.Sprintf("Missing required field 'scripts[%d].exec' or 'scripts[%d].content'", i, i), file, 0, "Add exec or content field to script")
+		// A script comes from a file on disk (source), from inline content, or is a
+		// program named by exec. The processor accepts all three and defaults exec to
+		// the platform shell; validation used to accept only two, so every script
+		// declared with `source` was reported as missing a required field.
+		if script.Exec == "" && script.Content == "" && script.Source == "" {
+			AddIssue(results, types.ValidationError,
+				fmt.Sprintf("Missing required field 'scripts[%d].exec', 'scripts[%d].content' or 'scripts[%d].source'", i, i, i),
+				file, 0, "Add an exec, content, or source field to the script")
 		}
 	}
 }
@@ -187,4 +196,15 @@ func ValidateUsers(users []types.User, file string, results *types.ValidationRes
 		validateEnum(user.Action, fmt.Sprintf("users[%d].action", i),
 			[]string{types.UserActionCreate, types.UserActionModify, types.UserActionDelete}, file, results)
 	}
+}
+
+// packageLabel names a package entry for a message, whichever form it uses.
+func packageLabel(pkg types.Package) string {
+	if pkg.Name != "" {
+		return pkg.Name
+	}
+	if len(pkg.Names) > 0 {
+		return strings.Join(pkg.Names, ", ")
+	}
+	return "(unnamed)"
 }

--- a/internal/validate/components_test.go
+++ b/internal/validate/components_test.go
@@ -18,8 +18,16 @@ func TestValidatePackages(t *testing.T) {
 			0,
 		},
 		{
-			"missing name",
-			[]types.Package{{Action: "install", PackageManager: "apt", Names: []string{"vim"}}},
+			// `names` alone is a complete entry: it is how the examples declare
+			// several packages at once. This case used to expect an error, which is
+			// what made every multi-package entry in the shipped examples fail.
+			"names without name",
+			[]types.Package{{Action: "install", PackageManager: "apt", Names: []string{"vim", "curl"}}},
+			0,
+		},
+		{
+			"neither name nor names",
+			[]types.Package{{Action: "install", PackageManager: "apt"}},
 			1,
 		},
 		{

--- a/internal/validate/recursion_test.go
+++ b/internal/validate/recursion_test.go
@@ -1,0 +1,182 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// Blueprints live in subdirectories — packages/, files/, services/ — which is the
+// layout the documentation recommends and every shipped example uses. Validation
+// read only the top directory, so `rwr validate` on a real tree checked the init
+// file and reported success. These tests use that layout.
+
+func writeTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, content := range files {
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestValidateBlueprints_FindsProblemsInSubdirectories(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"init.yaml": "blueprints:\n  format: yaml\n",
+		// action "explode" is not a package action; nothing but recursion finds it.
+		"packages/dev.yaml": "packages:\n  - name: git\n    action: explode\n",
+	})
+
+	results := &types.ValidationResults{}
+	if err := ValidateBlueprints(root, false, results, nil); err != nil {
+		t.Fatalf("validation returned an error: %v", err)
+	}
+
+	var found bool
+	for _, issue := range results.Issues {
+		if strings.Contains(issue.Message, "explode") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("invalid action in packages/dev.yaml was not reported; issues were: %+v", results.Issues)
+	}
+}
+
+func TestValidateBlueprints_AcceptsAValidNestedTree(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"init.yaml":             "blueprints:\n  format: yaml\n",
+		"packages/base.yaml":    "packages:\n  - name: git\n    action: install\n",
+		"packages/many.yaml":    "packages:\n  - names: [curl, wget]\n    action: install\n",
+		"services/base.yaml":    "services:\n  - name: sshd\n    action: enable\n",
+		"files/dotfiles.yaml":   "files:\n  - source: ./src/vimrc\n    target: /tmp/vimrc\n    action: copy\n",
+		"scripts/setup.yaml":    "scripts:\n  - name: setup.sh\n    action: run\n    source: ./bin\n",
+		"git/repos.yaml":        "git:\n  - name: dots\n    action: clone\n    url: https://example.invalid/d.git\n    path: /tmp/dots\n",
+		"fonts/nerd.yaml":       "fonts:\n  - name: FiraCode\n    action: install\n",
+		"configuration/ui.yaml": "configuration:\n  - name: theme\n    type: dconf\n    action: set\n    key: /org/gnome/theme\n    value: dark\n",
+	})
+
+	results := &types.ValidationResults{}
+	if err := ValidateBlueprints(root, false, results, nil); err != nil {
+		t.Fatalf("validation returned an error: %v", err)
+	}
+
+	for _, issue := range results.Issues {
+		if issue.Severity == types.ValidationError {
+			t.Errorf("valid tree reported an error: %s [%s]", issue.Message, issue.File)
+		}
+	}
+}
+
+// A package entry names one package with `name` or several with `names`. Both
+// forms are used throughout the examples and both must validate.
+func TestValidatePackages_AcceptsNameOrNames(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"init.yaml":          "blueprints:\n  format: yaml\n",
+		"packages/one.yaml":  "packages:\n  - name: git\n    action: install\n",
+		"packages/many.yaml": "packages:\n  - names: [curl, wget]\n    action: install\n",
+	})
+
+	results := &types.ValidationResults{}
+	if err := ValidateBlueprints(root, false, results, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, issue := range results.Issues {
+		if issue.Severity == types.ValidationError {
+			t.Errorf("unexpected error: %s [%s]", issue.Message, issue.File)
+		}
+	}
+}
+
+// An entry with neither is genuinely wrong and must still be caught.
+func TestValidatePackages_RejectsEntryWithNoName(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"init.yaml":            "blueprints:\n  format: yaml\n",
+		"packages/broken.yaml": "packages:\n  - action: install\n",
+	})
+
+	results := &types.ValidationResults{}
+	if err := ValidateBlueprints(root, false, results, nil); err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, issue := range results.Issues {
+		if issue.Severity == types.ValidationError && strings.Contains(issue.Message, "name") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("a package with neither name nor names was accepted; issues: %+v", results.Issues)
+	}
+}
+
+// Blueprints are rendered as templates before they are read. Validating the raw
+// bytes reports a parse error against a blueprint that works, because {{ }} is a
+// flow mapping in YAML.
+func TestValidateBlueprints_RendersTemplates(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"init.yaml": "blueprints:\n  format: yaml\n",
+		"files/dotfiles.yaml": "files:\n  - source: ./src/vimrc\n" +
+			"    target: \"{{ .User.home }}/.vimrc\"\n    action: copy\n",
+	})
+
+	results := &types.ValidationResults{}
+	if err := ValidateBlueprints(root, false, results, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, issue := range results.Issues {
+		if issue.Severity == types.ValidationError {
+			t.Errorf("templated blueprint reported an error: %s", issue.Message)
+		}
+	}
+}
+
+// A schema version this build cannot read must be refused by validation too, or
+// `rwr validate` says a tree is sound that a run will refuse.
+func TestValidateBlueprints_RejectsUnsupportedSchemaVersion(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"init.yaml":         "blueprints:\n  format: yaml\n",
+		"packages/new.yaml": "schema_version: 99\npackages:\n  - name: git\n    action: install\n",
+	})
+
+	results := &types.ValidationResults{}
+	if err := ValidateBlueprints(root, false, results, nil); err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, issue := range results.Issues {
+		if strings.Contains(issue.Message, "99") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("unsupported schema version was not reported; issues: %+v", results.Issues)
+	}
+}
+
+// .git holds a great many files and none of them are blueprints.
+func TestValidateBlueprints_SkipsDotDirectories(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"init.yaml":            "blueprints:\n  format: yaml\n",
+		".git/packages/x.yaml": "packages:\n  - action: explode\n",
+	})
+
+	results := &types.ValidationResults{}
+	if err := ValidateBlueprints(root, false, results, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, issue := range results.Issues {
+		if strings.Contains(issue.File, ".git") {
+			t.Errorf("validated a file under .git: %s", issue.File)
+		}
+	}
+}

--- a/openspec/specs/blueprint-processing/spec.md
+++ b/openspec/specs/blueprint-processing/spec.md
@@ -1,0 +1,216 @@
+# Blueprint Processing Specification
+
+## Purpose
+
+A blueprint declares what a machine should look like. This capability defines the
+blueprint types, how files are discovered and ordered, how imports and profiles
+narrow what applies, and how variables are resolved before anything runs.
+
+## Requirements
+
+### Requirement: Blueprints are written in YAML, JSON, or TOML
+
+RWR SHALL read blueprints in YAML, JSON, and TOML, and SHALL treat the three as
+interchangeable. The same declaration in any format SHALL produce the same result.
+
+The tree declares its format in the init file, and RWR SHALL discover blueprint files
+by that extension.
+
+#### Scenario: The same blueprint in three formats
+
+- **WHEN** an equivalent blueprint is written in YAML, JSON, and TOML
+- **THEN** each decodes to the same structure and produces the same operations
+
+### Requirement: There is one blueprint type per resource RWR manages
+
+RWR SHALL support these blueprint types: `repositories`, `packages`, `ssh_keys`,
+`users`, `files`, `fonts`, `services`, `git`, `scripts`, and `configuration`.
+
+`directories` SHALL NOT be a blueprint type of its own. The `directories` key SHALL
+be part of a files blueprint, alongside `files` and `templates`, and the files
+processor SHALL read all three.
+
+`packageManagers` SHALL NOT be a blueprint type. Package managers are installed from
+the init file's own `packageManagers` section, ahead of the blueprint loop.
+
+#### Scenario: A files blueprint with all three keys
+
+- **WHEN** a files blueprint declares `directories`, `files`, and `templates`
+- **THEN** the files processor acts on all three
+
+#### Scenario: Package managers in the init file
+
+- **WHEN** the init file declares `packageManagers`
+- **THEN** they are installed before any blueprint type runs
+- **AND** no processor is dispatched for a `packageManagers` blueprint type
+
+### Requirement: The default run order covers every blueprint type
+
+When the init file declares no order, RWR SHALL run blueprint types in this order:
+
+1. `repositories`
+2. `packages`
+3. `ssh_keys`
+4. `users`
+5. `files`
+6. `fonts`
+7. `services`
+8. `git`
+9. `scripts`
+10. `configuration`
+
+`users` SHALL be present. Its previous absence meant `rwr all` never created users
+unless the init file hand-wrote its own order, while `rwr run users` worked — which
+made the omission easy to miss.
+
+An init file that declares `blueprints.order` SHALL override this order.
+
+#### Scenario: A default run
+
+- **WHEN** `rwr all` runs against a tree whose init file declares no order
+- **THEN** each declared blueprint type is dispatched exactly once, in the order above
+
+#### Scenario: A tree with users but no declared order
+
+- **WHEN** a tree contains a users blueprint and the init file declares no order
+- **THEN** `rwr all` creates the users
+
+#### Scenario: A custom order
+
+- **WHEN** the init file declares an order of `repositories`, `packages`, `files`
+- **THEN** only those three run, in that sequence
+
+### Requirement: Bootstrap runs before the ordered blueprint types
+
+When the blueprint tree contains a bootstrap file, RWR SHALL process it before the
+ordered blueprint types.
+
+RWR SHALL record that bootstrap ran and SHALL NOT repeat it, unless
+`--force-bootstrap` is given.
+
+#### Scenario: A second run on a bootstrapped machine
+
+- **WHEN** `rwr all` runs on a machine that has already bootstrapped
+- **THEN** bootstrap is skipped
+
+#### Scenario: Forcing bootstrap
+
+- **WHEN** `rwr all --force-bootstrap` runs
+- **THEN** bootstrap runs again
+
+### Requirement: Variables resolve before a blueprint is decoded
+
+RWR SHALL render each blueprint file as a template before decoding it, exposing
+`User`, `System`, `Flags`, and `UserDefined` variables.
+
+`UserDefined` SHALL include every `RWR_`-prefixed environment variable, with the
+prefix removed.
+
+Template resolution SHALL apply to every blueprint type, including fonts.
+
+#### Scenario: A blueprint referencing the current user
+
+- **WHEN** a blueprint declares a target of `{{ .User.home }}/.config`
+- **THEN** the path resolves to the running user's home directory
+
+#### Scenario: A fonts blueprint with a variable
+
+- **WHEN** a fonts blueprint references `{{ .UserDefined.fontDir }}`
+- **THEN** the value is rendered before the fonts processor reads the blueprint
+
+### Requirement: Any blueprint entry can import another file
+
+RWR SHALL accept an `import` field on a blueprint entry, naming another blueprint
+file whose definitions are merged in.
+
+Import paths SHALL resolve relative to the importing blueprint's directory. An
+imported file MAY be in any supported format. Imported entries SHALL be subject to
+profile filtering like any other entry. Import SHALL work for every blueprint type.
+
+RWR SHALL detect a circular import and SHALL NOT loop.
+
+#### Scenario: Sharing a common package set
+
+- **WHEN** a machine-specific blueprint imports `../../Common/packages/base.yaml`
+- **AND** adds its own entries
+- **THEN** both the imported and the local entries are applied
+
+#### Scenario: A circular import
+
+- **WHEN** file A imports B and B imports A
+- **THEN** the cycle is detected and the run does not loop
+
+#### Scenario: A nested import chain
+
+- **WHEN** A imports B and B imports C
+- **THEN** the definitions from all three files are applied
+
+### Requirement: Profiles narrow what applies, permissively by default
+
+RWR SHALL include a blueprint entry when any of these hold:
+
+- The entry declares no profiles. Such an entry is a base item and always applies.
+- No profiles are active. With no `--profile` given, everything applies.
+- `all` is an active profile.
+- One of the entry's profiles is active.
+
+The permissive default exists so a tree works without the operator knowing anything
+about profiles.
+
+#### Scenario: A run with no profile flag
+
+- **WHEN** `rwr all` runs with no `--profile`
+- **THEN** every entry applies, profiled or not
+
+#### Scenario: A run scoped to one profile
+
+- **WHEN** `rwr all --profile work` runs
+- **THEN** entries with no profiles apply
+- **AND** entries listing `work` apply
+- **AND** entries listing only `personal` do not
+
+#### Scenario: The all profile
+
+- **WHEN** `rwr all --profile all` runs
+- **THEN** every entry applies
+
+### Requirement: Blueprints may be cloned from a git repository
+
+When the init file declares git options, RWR SHALL clone the blueprint repository to
+the declared target, or update it in place when it is already a valid clone.
+
+When the target exists but is not a git repository, RWR SHALL remove it and clone
+fresh.
+
+RWR SHALL fail when the resulting directory is empty.
+
+#### Scenario: First run on a new machine
+
+- **WHEN** the init file declares a blueprint repository and the target does not exist
+- **THEN** the repository is cloned to the target
+
+#### Scenario: A later run with updates enabled
+
+- **WHEN** the target is a valid clone and updates are enabled
+- **THEN** the repository is pulled before blueprints are processed
+
+### Requirement: A missing blueprint file does not stop the run
+
+RWR SHALL warn and continue when a file listed in the run order does not exist. RWR
+SHALL stop when a blueprint that does exist fails to process.
+
+#### Scenario: An order entry naming a removed file
+
+- **WHEN** the init file's order names a file that is no longer present
+- **THEN** RWR warns and processes the remaining blueprints
+
+## Known Gaps
+
+- **Missing template keys render as `<no value>`.** Template resolution parses with
+  `missingkey=error` but executes with `missingkey=invalid`, so an unresolved
+  variable produces `<no value>` in the output instead of an error. The examples
+  check detects this in CI; a run against an operator's own tree does not.
+- **The import resolver is duplicated per blueprint type.** Each processor carries
+  its own copy, none of which recurses, while the tested recursive resolver in
+  `helpers` has no callers. Nested import chains therefore resolve only one level
+  deep, and the cycle detection in the per-processor copies is unreachable.

--- a/openspec/specs/blueprint-schema-versioning/spec.md
+++ b/openspec/specs/blueprint-schema-versioning/spec.md
@@ -1,0 +1,134 @@
+# Blueprint Schema Versioning Specification
+
+## Purpose
+
+RWR reads blueprints written by operators who upgrade the binary on their own
+schedule. This capability defines how a blueprint declares the schema it is written
+in, so a format change can land without invalidating trees that already work.
+
+## Requirements
+
+### Requirement: Each blueprint type carries its own version
+
+RWR SHALL track a schema version per blueprint type, not one version for the whole
+schema.
+
+A breaking change to `packages` SHALL move `packages` to v2 and leave `files`, `git`,
+`scripts` and every other type at v1.
+
+A single version number for the whole schema drags unchanged types forward on every
+change, arrives at v11 over a handful of edits, and stops telling anyone which type
+actually changed.
+
+#### Scenario: One type changes
+
+- **WHEN** `packages` gains a v2 wire format
+- **THEN** `packages` supports v1 and v2
+- **AND** every other blueprint type still supports v1 only
+- **AND** existing `files` blueprints continue to read unchanged
+
+### Requirement: The most specific declaration wins
+
+RWR SHALL resolve a blueprint's schema version in this order:
+
+1. the `schema_version` declared in the blueprint file
+2. the `schema_version` declared for the tree in the init file
+3. the latest version this build supports for that blueprint type
+
+A file-level declaration SHALL override the tree-wide one. That is what makes a
+single-resource migration possible: move one `packages` file to v2 and leave the
+rest of the tree alone.
+
+#### Scenario: A file overriding the tree
+
+- **WHEN** the init file declares `schema_version: 1` for the tree
+- **AND** one packages blueprint declares `schema_version: 2`
+- **THEN** that file is read as v2 and every other file as v1, in the same run
+
+#### Scenario: A tree-wide declaration
+
+- **WHEN** the init file declares `schema_version: 1` and no file declares a version
+- **THEN** every blueprint is read as v1
+
+### Requirement: No declaration means the latest version
+
+RWR SHALL read a blueprint that declares no version as the latest version it
+supports for that type.
+
+A blueprint written today then gets today's schema with no boilerplate, and the
+version field becomes what an operator adds to pin rather than what they must add to
+start.
+
+The consequence is that an undeclared blueprint follows the schema forward across
+upgrades. A tree that must stay on one version SHALL say so, which is what the
+declaration is for.
+
+#### Scenario: A new blueprint with no version field
+
+- **WHEN** a packages blueprint declares no `schema_version`
+- **AND** the latest supported version for `packages` is 2
+- **THEN** it is read as v2
+
+#### Scenario: Latest differs per type
+
+- **WHEN** `packages` is at v2 and `files` is at v1
+- **AND** neither blueprint declares a version
+- **THEN** the packages blueprint is read as v2 and the files blueprint as v1
+
+### Requirement: An unsupported version stops the run
+
+RWR SHALL refuse a blueprint that declares a version this build cannot read, and
+SHALL report the requested version, the type, and the versions this build supports.
+
+RWR installs packages, writes files, and runs scripts with elevation. A v2 blueprint
+misread as v1 does the wrong thing to somebody's machine, which is worse than
+refusing.
+
+A tree-wide declaration applies to every blueprint type, so RWR SHALL reject a
+tree-wide version that any type cannot read, and SHALL say which types cannot.
+
+#### Scenario: A blueprint from a newer RWR
+
+- **WHEN** a packages blueprint declares `schema_version: 2` and this build supports
+  only v1
+- **THEN** the run stops with an error naming the type, the requested version, and
+  the supported versions
+
+#### Scenario: A tree-wide version no type supports
+
+- **WHEN** an init file declares `schema_version: 2` and no type supports v2
+- **THEN** the run stops and the error names the unsupported types and suggests
+  declaring the version per file instead
+
+### Requirement: The wire format and the processor type are separate
+
+RWR SHALL represent each supported version of a blueprint type as its own struct
+describing exactly what that version accepts on disk. Decoding SHALL select the
+struct by resolved version and then convert it to the canonical type the processors
+consume.
+
+Nothing downstream of the decoder SHALL need to know that more than one version
+exists.
+
+Adding a version SHALL require only: the new wire struct, a conversion to the
+canonical type, a registry entry, and the version added to that type's supported
+list.
+
+#### Scenario: Adding a version
+
+- **WHEN** a contributor adds a v2 for `packages`
+- **THEN** the packages processor still consumes the canonical packages type
+  unchanged
+- **AND** no other blueprint type is touched
+
+### Requirement: A version declaration is readable even when the rest is not
+
+RWR SHALL read the `schema_version` key independently of the rest of the file, so a
+blueprint written in a version this build cannot decode still reports which version
+it wanted rather than failing as malformed.
+
+#### Scenario: A future format that will not decode
+
+- **WHEN** a blueprint is written in a wire format this build does not understand
+- **AND** it declares `schema_version: 3`
+- **THEN** the error reports version 3 as unsupported, rather than a parse failure

--- a/openspec/specs/blueprint-validation/spec.md
+++ b/openspec/specs/blueprint-validation/spec.md
@@ -1,0 +1,179 @@
+# Blueprint Validation Specification
+
+## Purpose
+
+`rwr validate` is the check an operator runs before letting RWR touch a machine, and
+the check CI runs to catch a change that breaks trees already in the wild. This
+capability defines what validation inspects and what it reports.
+
+## Requirements
+
+### Requirement: Validation reports issues by severity and fails on errors
+
+RWR SHALL classify each validation issue as error, warning, or info, and SHALL report
+counts for each.
+
+`rwr validate` SHALL exit non-zero when any error is found, and SHALL succeed with a
+count when only warnings are found.
+
+#### Scenario: A tree with a structural error
+
+- **WHEN** `rwr validate` runs against a tree containing an invalid blueprint
+- **THEN** the command exits non-zero and reports the error and warning counts
+
+#### Scenario: A clean tree
+
+- **WHEN** `rwr validate` runs against a valid tree
+- **THEN** the command succeeds and reports success
+
+### Requirement: Validation chooses blueprint or provider mode from the path
+
+RWR SHALL validate as providers when the target is a directory named `providers` or
+a single `.toml` file, and as blueprints otherwise.
+
+RWR SHALL accept `--blueprints` and `--providers` to force either mode.
+
+#### Scenario: Validating a provider file
+
+- **WHEN** `rwr validate providers/paru.toml` runs
+- **THEN** the file is checked as a provider definition
+
+#### Scenario: Forcing blueprint mode
+
+- **WHEN** `rwr validate path/to/dir --blueprints` runs on a directory
+- **THEN** the contents are checked as blueprints
+
+### Requirement: Validation runs without initializing the system
+
+`rwr validate` SHALL detect the operating system and set paths, but SHALL NOT load
+the init file, clone the blueprint repository, or perform any other initialization.
+
+Validation is what an operator runs when something is wrong; it must not require the
+thing being validated to already work.
+
+#### Scenario: Validating a tree with a broken init file
+
+- **WHEN** `rwr validate` runs against a tree whose init file has a structural error
+- **THEN** the error is reported rather than causing the command to fail during
+  startup
+
+### Requirement: The shipped examples validate in CI
+
+The example blueprints SHALL be checked on every pull request. The check SHALL cover
+every example, in every supported format, for every platform directory.
+
+The examples are the backwards-compatibility contract: a change that stops an
+example from parsing, rendering, or decoding is a change that breaks trees in the
+wild, and CI is where that must surface.
+
+#### Scenario: A change that breaks a blueprint format
+
+- **WHEN** a change alters how a blueprint field is read
+- **AND** a shipped example uses that field
+- **THEN** CI fails on the examples check
+
+#### Scenario: Cross-format agreement
+
+- **WHEN** the same example is provided in YAML, JSON, and TOML
+- **THEN** all three decode to the same structure
+
+#### Scenario: An unresolved template variable
+
+- **WHEN** an example references a variable that does not resolve
+- **THEN** the check fails rather than rendering `<no value>` into the output
+
+### Requirement: Validation inspects the whole tree
+
+`rwr validate` SHALL walk the blueprint tree and check every blueprint file, not
+only the files in the top directory.
+
+Blueprints are organised by type — `packages/`, `files/`, `services/` — which is the
+layout the documentation recommends and every example uses. Reading only the top
+directory means checking the init file and reporting success.
+
+RWR SHALL skip dot directories, and SHALL NOT validate a nested init file as a
+blueprint.
+
+#### Scenario: A tree organised by type
+
+- **WHEN** `rwr validate` runs on a tree with an invalid action in
+  `packages/dev.yaml`
+- **THEN** the invalid action is reported
+
+#### Scenario: A tree under version control
+
+- **WHEN** the blueprint tree contains a `.git` directory
+- **THEN** nothing under it is validated
+
+### Requirement: Validation reads blueprints the way a run does
+
+`rwr validate` SHALL render each blueprint as a template before decoding it, decode
+it into the same structure the matching processor uses, and enforce the same schema
+version.
+
+Anything else validates a different document than the one that will be applied. A
+blueprint using `{{ .User.home }}` is not valid YAML until it is rendered, because
+the braces read as a flow mapping.
+
+#### Scenario: A blueprint using a variable
+
+- **WHEN** a files blueprint declares `target: "{{ .User.home }}/.vimrc"`
+- **THEN** validation reports no error
+
+#### Scenario: A blueprint declaring an unsupported schema version
+
+- **WHEN** a blueprint declares a `schema_version` this build cannot read
+- **THEN** validation reports it, rather than passing a tree a run will refuse
+
+### Requirement: Validation accepts every form the processors accept
+
+A validation rule SHALL accept exactly what the matching processor accepts. A rule
+that rejects what a processor accepts is a false report, and a rule that accepts
+what a processor rejects is a missed one. Specifically:
+
+- A package entry SHALL be valid with `name` or with `names`.
+- `package_manager` SHALL be optional; without one the default manager applies.
+- A file entry's action SHALL be one of `create`, `delete`, `copy`, `move`,
+  `chmod`, `chown`, `chgrp`, `symlink` — the set the files processor dispatches on.
+- A script SHALL be valid with `exec`, `content`, or `source`.
+- Every blueprint type SHALL have a validator, including `fonts` and
+  `configuration`.
+
+#### Scenario: A multi-package entry
+
+- **WHEN** a package entry declares `names: [curl, wget]` and no `name`
+- **THEN** validation reports no error
+
+#### Scenario: A copied dotfile
+
+- **WHEN** a file entry declares `action: copy`
+- **THEN** validation reports no error
+
+#### Scenario: A script from a file
+
+- **WHEN** a script declares `source` and no `exec` or `content`
+- **THEN** validation reports no error
+
+#### Scenario: An entry naming nothing
+
+- **WHEN** a package entry declares neither `name` nor `names`
+- **THEN** validation reports an error
+
+### Requirement: Unknown keys are rejected when decoding strictly
+
+Strict decoding SHALL reject a blueprint containing a key the schema does not
+define, across YAML, JSON, and TOML.
+
+A silently ignored key is a blueprint that looks applied and is not — a misspelled
+`profiles` key means an entry runs on every machine instead of the one it was
+scoped to.
+
+#### Scenario: A misspelled key
+
+- **WHEN** a blueprint declares `packagess:` instead of `packages:`
+- **THEN** strict decoding reports the unknown key
+
+## Known Gaps
+
+- **Strict decoding is not enabled.** The requirement above describes the intended
+  contract; the shipped decoders still ignore unknown keys.

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -1,0 +1,121 @@
+# CLI Specification
+
+## Purpose
+
+The command surface an operator actually touches. This capability defines the
+commands, the global flags, and which commands need a working configuration.
+
+## Requirements
+
+### Requirement: `rwr all` applies the whole tree
+
+`rwr all` SHALL run every blueprint type in the resolved run order. This is the
+new-machine command.
+
+#### Scenario: Setting up a new machine
+
+- **WHEN** `rwr all` runs with a valid init file
+- **THEN** package managers, then bootstrap, then each blueprint type run in order
+
+### Requirement: `rwr run <type>` applies one blueprint type
+
+`rwr run` SHALL provide a subcommand for each blueprint type: `packages`,
+`repository`, `services`, `files`, `configuration`, `users`, `git`, `scripts`,
+`ssh_keys`, and `fonts`.
+
+Each SHALL apply only that type, using the same processing path as `rwr all`.
+
+#### Scenario: Reapplying packages only
+
+- **WHEN** `rwr run packages` runs
+- **THEN** only the packages blueprints are processed
+
+### Requirement: `rwr validate` checks configuration without applying it
+
+`rwr validate [path]` SHALL check blueprints or providers and SHALL make no change to
+the machine. It SHALL default to the current directory.
+
+`rwr validate` SHALL NOT require the init file to load successfully.
+
+#### Scenario: Checking before applying
+
+- **WHEN** `rwr validate ./blueprints` runs
+- **THEN** issues are reported and no package, file, or service is touched
+
+### Requirement: `rwr config --create` writes the configuration file
+
+`rwr config --create` SHALL write RWR's own configuration file. Without the flag it
+SHALL show help.
+
+The written file SHALL be owner-readable only, because it holds credentials.
+
+#### Scenario: First-time setup
+
+- **WHEN** `rwr config --create` runs
+- **THEN** `~/.config/rwr/config.yaml` is written at `0600`
+
+### Requirement: `rwr profiles` lists the profiles a tree defines
+
+`rwr profiles` SHALL read the blueprint tree and report every profile its entries
+declare, with the number of entries carrying each and the number of base items that
+always apply.
+
+Reading only the init file's inline arrays reports nothing for a tree that declares
+profiles on blueprint entries, which is where they are normally declared.
+
+The usage examples it prints SHALL be commands that exist.
+
+#### Scenario: Discovering profiles
+
+- **WHEN** `rwr profiles` runs against a tree whose blueprints declare `work` and
+  `personal`
+- **THEN** both names are listed with their entry counts
+
+#### Scenario: A tree with no profiles
+
+- **WHEN** no blueprint entry declares a profile
+- **THEN** RWR reports that all items are base items and always apply
+
+### Requirement: Global flags apply to every command
+
+RWR SHALL accept these flags on any command:
+
+| Flag | Effect |
+|---|---|
+| `--init-file`, `-i` | Path, directory, or URL of the init file |
+| `--profile`, `-p` | Activate a profile; may be repeated |
+| `--dry-run` / `--no-op` | Log operations without performing them |
+| `--debug`, `-d` | Debug logging |
+| `--log-level` | `debug`, `info`, `warn`, or `error` |
+| `--interactive`, `-I` | Interactive mode; on by default |
+| `--force-bootstrap` | Run bootstrap again |
+| `--show-secrets` | Print credential values instead of redacting |
+| `--gh-api-key` / `--gh-key` | GitHub API token |
+| `--gh-auth` | Authenticate with GitHub by OAuth device flow |
+| `--ssh-key` | SSH private key path or base64 value |
+| `--skip-version-check` | Do not check for a newer RWR |
+
+#### Scenario: A non-interactive run
+
+- **WHEN** `rwr all --interactive=false` runs and a choice is needed
+- **THEN** RWR takes the documented default rather than prompting
+
+### Requirement: Commands that do not act on the system skip initialization
+
+RWR SHALL skip loading the init file, cloning the blueprint repository, and detecting
+package managers for `help`, `version`, `config`, and `validate`.
+
+`validate` SHALL still detect the operating system and set paths, because validation
+reports on the current platform.
+
+#### Scenario: Getting help with no configuration
+
+- **WHEN** `rwr help` runs on a machine with no init file
+- **THEN** help is shown without error
+
+## Known Gaps
+
+- **`--gh-api-key` and `--gh-key` bind the same configuration key.** Passing both
+  silently lets one win rather than reporting the conflict.
+- **`rwr run` is twelve near-identical subcommands.** One command taking the type as
+  an argument would do the same work.

--- a/openspec/specs/command-execution/spec.md
+++ b/openspec/specs/command-execution/spec.md
@@ -1,0 +1,148 @@
+# Command Execution Specification
+
+## Purpose
+
+RWR configures a machine by running other programs — package managers, `systemctl`,
+`ssh-keygen`, `useradd`, operator scripts. Every one of those invocations carries
+values that came out of a blueprint file, and blueprints are cloned from git
+repositories. This capability defines how a `types.Command` becomes a real process,
+how elevation is applied, how output is captured, and how the whole path is made
+observable in tests without spawning anything.
+
+## Requirements
+
+### Requirement: Commands execute as argv, never as a shell string
+
+RWR SHALL build every command as an argument vector handed directly to the kernel.
+RWR SHALL NOT interpose a shell, and SHALL NOT construct a command by concatenating
+strings.
+
+Each element of `Command.Args` SHALL reach the target program as exactly one
+argument. A blueprint SHALL be able to supply a value containing shell
+metacharacters, spaces, or newlines without that value being reinterpreted.
+
+A provider that genuinely needs a shell SHALL request one explicitly, by naming the
+shell as `Exec` and passing the script as an argument.
+
+#### Scenario: A package name containing shell syntax
+
+- **WHEN** a blueprint declares a package named `vim; touch /tmp/pwned`
+- **THEN** the spawned process receives `install` and `vim; touch /tmp/pwned` as two
+  discrete arguments
+- **AND** no file `/tmp/pwned` is created
+
+#### Scenario: An argument containing spaces
+
+- **WHEN** a command is built with the argument `Some Name`
+- **THEN** the target program receives `Some Name` as a single argument, not two
+
+#### Scenario: A provider that wants a shell
+
+- **WHEN** a provider declares `exec = "sh"` with `args = ["-c", "cd /tmp/paru && makepkg"]`
+- **THEN** the shell runs and interprets the script, because the provider asked for it
+
+### Requirement: Elevation is per-command and terminates option parsing
+
+RWR SHALL apply elevation per command, from the command's own `Elevated` and
+`AsUser` fields. RWR SHALL NOT acquire elevation for the whole run.
+
+On a non-Windows host:
+
+- `Elevated: true` SHALL produce `sudo -- <exec> <args...>`.
+- `AsUser: "<name>"` SHALL produce `sudo -u <name> -- <exec> <args...>`.
+- Neither set SHALL produce `<exec> <args...>` with no `sudo`.
+
+The `--` separator SHALL be present so a program whose name begins with a dash
+cannot be absorbed as a `sudo` option.
+
+On Windows, `Elevated` SHALL be a no-op: there is no `sudo` equivalent, and the
+process must already be elevated.
+
+#### Scenario: An elevated command on Linux
+
+- **WHEN** a command with `Elevated: true` runs `pacman` with `-S git`
+- **THEN** the argv is `sudo -- pacman -S git`
+
+#### Scenario: A command run as another user
+
+- **WHEN** a command with `AsUser: "levi"` runs `paru` with `-S foo`
+- **THEN** the argv is `sudo -u levi -- paru -S foo`
+
+#### Scenario: An unelevated command
+
+- **WHEN** a command with `Elevated: false` and no `AsUser` runs
+- **THEN** the argv contains no `sudo` and no shell
+
+#### Scenario: Elevation on Windows
+
+- **WHEN** `GOOS` is `windows` and a command declares `Elevated: true`
+- **THEN** the program is spawned directly
+- **AND** the argv contains no `sh`, no `cmd /C`, and no `sudo`
+
+### Requirement: Interactive commands reach the terminal
+
+RWR SHALL connect an interactive command's stdin, stdout, and stderr to the
+terminal. RWR SHALL NOT buffer stderr for an interactive command.
+
+This exists because `sudo` writes its password prompt to stderr. Capturing it
+leaves the run blocked with no indication of what it waits for.
+
+#### Scenario: A command that prompts for a password
+
+- **WHEN** an interactive elevated command runs and `sudo` requires a password
+- **THEN** the prompt appears on the terminal and the operator can answer it
+
+### Requirement: A command's log file stays open while the command runs
+
+When a command declares `LogName` and debug output is off, RWR SHALL open that file
+and point the command's stdout at it. RWR SHALL close the file after the command
+finishes, not before.
+
+#### Scenario: A script that writes to its declared log
+
+- **WHEN** a blueprint declares `log: build.log` for a command that writes output
+- **THEN** `build.log` contains what the command wrote
+
+### Requirement: Dry-run reports commands without running them
+
+When dry-run mode is on, RWR SHALL log each command it would execute and SHALL NOT
+spawn a process. RWR SHALL report dry-run mode at the start of the run and summarize
+at the end.
+
+`--dry-run` and `--no-op` SHALL select the same behavior.
+
+#### Scenario: A full run in dry-run mode
+
+- **WHEN** `rwr all --dry-run` runs against a blueprint tree
+- **THEN** every command is logged with a `[DRY-RUN]` marker
+- **AND** no package is installed, no file is written, and no service changes state
+
+### Requirement: Command execution is replaceable for tests
+
+RWR SHALL route every command through an `Executor` interface, and SHALL provide a
+way to substitute a different implementation and restore the previous one.
+
+A test SHALL be able to run a real processor against real fixture blueprints and
+assert on the exact argv, elevation, target user, log name, and variables that the
+processor produced, without any process being spawned.
+
+#### Scenario: A processor under test
+
+- **WHEN** a test installs a recording executor and invokes a real processor
+- **THEN** every command the processor built is recorded with its exec, args,
+  elevation, target user, log name, and variables
+- **AND** no package manager runs
+
+### Requirement: The command environment carries no credentials
+
+RWR SHALL copy the current process environment into each spawned command, append
+the command's own variables, and extend `PATH` with the common binary directories.
+
+The GitHub API token and the SSH private key SHALL NOT be in that environment unless
+the init file opted into them by name. See the credential-handling specification.
+
+#### Scenario: A script spawned by a blueprint
+
+- **WHEN** a blueprint runs a script and the init file names no exposed credentials
+- **THEN** `RWR_VAR_REPOSITORY_GH_API_TOKEN` and `RWR_VAR_REPOSITORY_SSH_PRIVATE_KEY`
+  are absent from the script's environment

--- a/openspec/specs/credential-handling/spec.md
+++ b/openspec/specs/credential-handling/spec.md
@@ -1,0 +1,128 @@
+# Credential Handling Specification
+
+## Purpose
+
+RWR holds two credentials: a GitHub API token and an SSH private key. Blueprints are
+cloned from git repositories, and everything a blueprint can read, the author of that
+blueprint can read — a template writes its result to a path the same blueprint
+chooses, and a script inherits the environment RWR hands it. RWR cannot tell a
+blueprint the operator wrote from one they pulled in.
+
+This capability defines where credentials may go, how an operator opts a blueprint
+tree into the ones it genuinely needs, and how values are kept out of logs.
+
+## Requirements
+
+### Requirement: Credentials are withheld from blueprints by default
+
+RWR SHALL NOT place the GitHub API token or the SSH private key into blueprint
+template scope, and SHALL NOT export them into the environment of any command it
+spawns, unless the init file opted into them by name.
+
+Every other configuration key SHALL continue to be exported as `RWR_VAR_*`.
+
+#### Scenario: A default tree running a script
+
+- **WHEN** an init file names no exposed credentials and a blueprint runs a script
+- **THEN** `RWR_VAR_REPOSITORY_GH_API_TOKEN` and `RWR_VAR_REPOSITORY_SSH_PRIVATE_KEY`
+  are absent from the script's environment
+
+#### Scenario: A default tree rendering a template
+
+- **WHEN** a template references `{{ .Flags.ghAPIToken }}` and no opt-in was given
+- **THEN** the value does not appear in the rendered output
+
+### Requirement: A tree opts into the credentials it needs, by name
+
+RWR SHALL accept an `exposeCredentials` list in the init file naming the credentials
+that this tree's blueprints may read. RWR SHALL share only the named credentials.
+
+RWR SHALL accept both the bare name (`gh_api_token`) and the full configuration key
+(`repository.gh_api_token`) as the same credential.
+
+RWR SHALL warn at the start of the run when any credential is exposed, so the change
+is visible rather than silent.
+
+This is opt-in rather than unavailable because some blueprints legitimately need a
+token — writing a `.netrc`, configuring `gh`, calling the GitHub API from a script.
+
+#### Scenario: Opting into the token only
+
+- **WHEN** an init file declares `exposeCredentials: [gh_api_token]`
+- **THEN** `{{ .Flags.ghAPIToken }}` renders and `RWR_VAR_REPOSITORY_GH_API_TOKEN`
+  is present in spawned commands
+- **AND** the SSH private key remains withheld
+
+#### Scenario: Exposure is announced
+
+- **WHEN** a run starts with any credential exposed
+- **THEN** RWR logs a warning naming the exposed credentials
+
+### Requirement: Credential values are redacted in logs
+
+RWR SHALL substitute a redaction placeholder wherever a credential value would
+otherwise be printed, including when a value is formatted as part of a larger
+structure.
+
+Redaction SHALL apply to exposed credentials as well as withheld ones.
+
+#### Scenario: Debug logging with a token configured
+
+- **WHEN** debug logging is on and a GitHub token is configured
+- **THEN** the token value does not appear in the log output
+
+#### Scenario: A flags value formatted into a log line
+
+- **WHEN** the flags structure is printed with `%v` or `%+v`
+- **THEN** the credential fields render as the redaction placeholder
+
+### Requirement: Showing credential values requires an explicit flag
+
+RWR SHALL provide a `--show-secrets` flag that prints credential values instead of
+redacting them, and SHALL warn while that flag is active.
+
+This exists because "is RWR even reading my token?" has no other answer. It is not
+tied to debug logging, so turning debug on does not reveal values as a side effect.
+
+#### Scenario: Confirming a token is being read
+
+- **WHEN** `--show-secrets` is passed
+- **THEN** credential values appear in the log
+- **AND** RWR warns that values will appear in logs
+
+### Requirement: RWR's own config tree is owner-only
+
+RWR SHALL create its config and state directories at `0700` and SHALL restrict its
+written config file to `0600`, because that file holds the GitHub token and a
+base64-encoded SSH private key.
+
+Tightening SHALL never widen: a directory or file an operator restricted further
+SHALL keep their setting.
+
+#### Scenario: A fresh config directory
+
+- **WHEN** RWR creates `~/.config/rwr` for the first time
+- **THEN** the directory mode is `0700`
+
+#### Scenario: An existing permissive directory
+
+- **WHEN** `~/.config/rwr` exists at `0777`
+- **THEN** RWR tightens it to `0700`
+
+#### Scenario: An operator who restricted further
+
+- **WHEN** `~/.config/rwr` exists at `0500`
+- **THEN** RWR leaves it at `0500`
+
+### Requirement: RWR does the credentialed work itself where it can
+
+Where RWR can perform a credentialed operation on the blueprint's behalf, it SHALL
+do so rather than handing the credential over. Registering a generated SSH key with
+GitHub SHALL use the token from RWR's own configuration; the blueprint SHALL NOT
+need to read it.
+
+#### Scenario: Publishing a generated key
+
+- **WHEN** an `ssh_keys` blueprint asks for a key to be added to GitHub
+- **THEN** RWR calls the GitHub API with the configured token
+- **AND** the blueprint never receives the token

--- a/openspec/specs/distribution/spec.md
+++ b/openspec/specs/distribution/spec.md
@@ -1,0 +1,91 @@
+# Distribution Specification
+
+## Purpose
+
+RWR is the first thing installed on a new machine, often by piping a script into a
+root shell. This capability defines what is published, for which platforms, and what
+the install scripts must verify before running anything.
+
+## Requirements
+
+### Requirement: Builds are published for every supported platform
+
+RWR SHALL publish a build for each of:
+
+| Operating system | Architectures |
+|---|---|
+| Linux | `x86_64`, `arm64`, `armv7`, `riscv64` |
+| macOS | `x86_64`, `arm64` |
+| Windows | `x86_64`, `arm64` |
+
+RWR SHALL publish archives, Debian, RPM, Alpine, and Arch packages, and a Homebrew
+tap.
+
+There SHALL be no Arch package for `riscv64`, because Arch has no official riscv64
+port.
+
+#### Scenario: Installing on a riscv64 Linux machine
+
+- **WHEN** an operator installs on riscv64
+- **THEN** an archive, `.deb`, `.rpm`, and `.apk` are available and no `.pkg.tar.zst`
+
+### Requirement: Install scripts verify what they download
+
+Each install script SHALL detect the machine's operating system and architecture,
+select the matching build, fetch the published checksums, and compare the download
+against them. A script SHALL abort when the checksums do not agree.
+
+A script SHALL use a per-run temporary directory rather than a fixed path, because a
+fixed path in a world-writable directory combined with an elevated move is a local
+privilege-escalation route.
+
+#### Scenario: A tampered download
+
+- **WHEN** the downloaded archive does not match the published checksum
+- **THEN** the script aborts and installs nothing
+
+#### Scenario: Detecting architecture on Windows
+
+- **WHEN** the PowerShell installer runs on an arm64 machine
+- **THEN** it selects the arm64 build
+
+### Requirement: Every merge to master publishes a prerelease
+
+Each merge to `master` SHALL publish a prerelease under a fixed `nightly` tag, so a
+correction can be tested before the next release. RWR SHALL replace the tag and its
+files on each merge, leaving the download addresses stable.
+
+The version SHALL contain the commit, as `<next-patch>-master-<short-sha>`, so a
+binary can be traced to the commit that produced it.
+
+A prerelease SHALL be marked as not a release: it is master at the time of the build,
+CI-passing but untested.
+
+#### Scenario: Identifying a nightly build
+
+- **WHEN** `rwr version` runs on a nightly build
+- **THEN** the version contains the short commit SHA it was built from
+
+### Requirement: CI enforces the security checks
+
+Every pull request SHALL run the build, the tests, the linter, a static security
+scan, and a vulnerability check against the module dependencies.
+
+A suppression SHALL be scoped to a specific rule and carry a justification. Blanket
+suppressions SHALL NOT be used.
+
+#### Scenario: A change that introduces a vulnerable dependency
+
+- **WHEN** a pull request upgrades to a module with a known advisory
+- **THEN** CI fails on the vulnerability check
+
+### Requirement: Documentation states what is tested
+
+Documentation SHALL describe only commands and fields that exist. Windows support
+SHALL be described honestly as incompletely tested rather than as equivalent to Linux
+and macOS.
+
+#### Scenario: An operator following the documentation
+
+- **WHEN** an operator runs a command exactly as documented
+- **THEN** the command exists and behaves as described

--- a/openspec/specs/initialization/spec.md
+++ b/openspec/specs/initialization/spec.md
@@ -1,0 +1,128 @@
+# Initialization Specification
+
+## Purpose
+
+The init file is the entry point: it says where the blueprints are, what format they
+are in, what order to run them, which package managers to install first, and which
+credentials the tree may read. Making a new machine a one-shot operation means making
+that file easy to point at from anywhere.
+
+## Requirements
+
+### Requirement: The init file can be a path, a directory, or a URL
+
+RWR SHALL accept an init file given as:
+
+- a path to a file
+- a path to a directory, in which case RWR SHALL look for `init.yaml`, `init.yml`,
+  `init.json`, then `init.toml` inside it
+- an `https://` URL to a raw file
+- a GitHub blob URL, which RWR SHALL rewrite to its raw form
+
+When no init file is given, RWR SHALL look for `init.yaml`, `init.yml`, `init.json`,
+then `init.toml` in the current directory.
+
+The init file location MAY also be set in RWR's own configuration.
+
+#### Scenario: Pointing at a directory
+
+- **WHEN** `--init-file ./blueprints` is given and that directory holds `init.yaml`
+- **THEN** that file is used
+
+#### Scenario: A GitHub blob URL
+
+- **WHEN** the init file is given as a `github.com/.../blob/...` URL
+- **THEN** RWR downloads the corresponding `raw.githubusercontent.com` content
+
+#### Scenario: No init file given
+
+- **WHEN** `rwr all` runs in a directory containing `init.yaml`
+- **THEN** that file is used
+
+### Requirement: The init file is rendered as a template before it is read
+
+RWR SHALL resolve template variables in the init file before parsing it, with the
+same `User`, `System`, `Flags`, and `UserDefined` variables available to blueprints.
+
+#### Scenario: A blueprint location under the user's home
+
+- **WHEN** the init file declares `location: {{ .User.home }}/blueprints`
+- **THEN** the location resolves to the running user's home directory
+
+### Requirement: The blueprint location resolves against the init file
+
+RWR SHALL resolve the blueprint location as follows:
+
+- empty or `.` — the directory containing the init file
+- beginning with `~` — relative to the user's home directory
+- a relative path — relative to the directory containing the init file
+- an absolute path — used as given
+
+#### Scenario: A relative location
+
+- **WHEN** an init file at `/srv/cfg/init.yaml` declares `location: blueprints`
+- **THEN** the blueprint location is `/srv/cfg/blueprints`
+
+### Requirement: Paths are expanded by RWR, not by a shell
+
+RWR SHALL expand a leading `~` in every blueprint-supplied path before that path
+reaches a command or a filesystem call.
+
+Commands are built as argv with no shell interposed, so nothing else performs this
+expansion. Without it, a blueprint declaring `path: ~/.ssh` creates a directory
+literally named `~` in the working directory.
+
+#### Scenario: An SSH key path
+
+- **WHEN** an `ssh_keys` blueprint declares `path: ~/.ssh`
+- **THEN** `ssh-keygen` receives the absolute path under the user's home directory
+- **AND** no directory named `~` is created
+
+#### Scenario: A git clone target
+
+- **WHEN** a git blueprint declares a target beginning with `~`
+- **THEN** the repository is cloned under the user's home directory
+
+### Requirement: Configuration comes from flags, the config file, and the environment
+
+RWR SHALL read its own configuration from `~/.config/rwr/config.yaml`, and SHALL
+allow any key to be set from the environment with an `RWR_` prefix. Command-line
+flags SHALL take precedence.
+
+RWR SHALL create its config directory and its run-once state directory at startup,
+at owner-only permissions.
+
+#### Scenario: A token supplied by flag
+
+- **WHEN** `--gh-api-key` is given and a token is also in the config file
+- **THEN** the flag value is used
+
+### Requirement: TOML init files are converted before parsing
+
+RWR SHALL convert a TOML init file to YAML before reading it, because the
+configuration reader does not handle the TOML directly.
+
+#### Scenario: A TOML init file
+
+- **WHEN** the init file is `init.toml`
+- **THEN** it is parsed correctly and produces the same configuration as the
+  equivalent YAML
+
+## Known Gaps
+
+These are wanted and not yet implemented.
+
+- **GitHub repository shorthands.** `owner/repo`, `owner/repo@ref`, and
+  `owner/repo/path/to/init.yaml` are not accepted. Only a full URL, a local path, or
+  a directory works.
+- **Init source resolution is not centralized.** The forms above are handled in two
+  places rather than by one resolver, which is what makes adding shorthands awkward.
+- **`http://` is accepted.** A plaintext init file is downloaded without complaint.
+  It should require an explicit opt-in flag.
+- **The installer does not take an init path.** A `curl | bash` one-liner cannot yet
+  pass the init file through to a first run, which is what would make new-machine
+  setup a single command.
+- **Managed GitHub auth and SSH bootstrap.** Detecting missing GitHub auth during
+  init, running an interactive device-flow login, generating or importing a key,
+  registering it, and verifying the handshake is wanted and unbuilt. The OAuth
+  device flow exists behind `--gh-auth`; the rest does not.

--- a/openspec/specs/provider-detection/spec.md
+++ b/openspec/specs/provider-detection/spec.md
@@ -1,0 +1,134 @@
+# Provider Detection Specification
+
+## Purpose
+
+A provider is a declarative description of a package manager: the binary that
+identifies it, the files that prove it is in use, the distributions it belongs to,
+and the command templates for install, remove, update, list, search, and clean.
+Providers are what let RWR put "the annoying bits on rails" — a blueprint says
+`action: install`, and the provider decides what that means on this machine.
+
+This capability defines how providers are loaded, how RWR decides which ones are
+usable, and how it picks a default.
+
+## Requirements
+
+### Requirement: Providers ship embedded and can be overridden from disk
+
+RWR SHALL embed its provider definitions in the binary, so a fresh machine with no
+files on it can still install packages.
+
+RWR SHALL also load provider definitions from a filesystem directory when one is
+found. A filesystem provider SHALL replace an embedded provider of the same name.
+
+RWR SHALL fail only when it has no providers at all.
+
+#### Scenario: A machine with no provider directory
+
+- **WHEN** RWR starts on a machine with no `providers/` directory anywhere
+- **THEN** the embedded providers load and the run proceeds
+
+#### Scenario: An operator overriding a provider
+
+- **WHEN** a `providers/` directory contains a definition named `pacman`
+- **THEN** that definition replaces the embedded `pacman`
+
+### Requirement: Provider availability is decided by evidence on the machine
+
+RWR SHALL treat a provider as available when all of these hold:
+
+1. The provider targets this operating system.
+2. The provider's declared binary is on `PATH`.
+3. Every file the provider declares as detection evidence exists.
+
+When those hold and the provider's distribution list also names this distribution
+or its family, the provider SHALL be available.
+
+When those hold but the distribution is not named, RWR SHALL still treat the
+provider as available if it declares detection files — because a machine that has
+`pacman` on `PATH`, `/etc/pacman.conf`, and `/var/lib/pacman` is running `pacman`
+whatever `/etc/os-release` calls itself.
+
+A provider that declares no detection files SHALL have only its distribution list to
+go on, and SHALL be unavailable on an unrecognised distribution.
+
+This exists because derivatives outnumber any list that can be maintained. It was
+found on PrismLinux, which reports `ID=prismlinux`, sets no `ID_LIKE`, and is named
+by no provider — yet is plainly an Arch system.
+
+#### Scenario: An unrecognised Arch derivative
+
+- **WHEN** `/etc/os-release` reports a distribution no provider names
+- **AND** `pacman` is on `PATH` with `/etc/pacman.conf` and `/var/lib/pacman` present
+- **THEN** the `pacman` provider is available
+
+#### Scenario: A distribution that lies about itself
+
+- **WHEN** a machine calls itself Arch but installs packages with `apt`
+- **AND** neither the `apt` binary nor `/etc/apt` is present
+- **THEN** the `apt` provider is unavailable
+
+#### Scenario: A Windows provider on Linux
+
+- **WHEN** a provider names `windows` in its distributions and the host is Linux
+- **THEN** the provider is unavailable regardless of any other evidence
+
+### Requirement: Distribution families are resolved without enumerating derivatives
+
+RWR SHALL map a distribution to its family, so a provider that names `arch` matches
+EndeavourOS, Manjaro, Garuda and the rest without naming each one.
+
+RWR SHALL consult `/etc/os-release` `ID_LIKE` only when the distribution being asked
+about is the host's own. `ID_LIKE` describes the host and nothing else; consulting
+it for an arbitrary distribution answers every question in terms of whatever the
+host happens to be, which silently maps unrecognised distributions onto the host's
+family.
+
+#### Scenario: A known derivative
+
+- **WHEN** the family of `endeavouros` is requested
+- **THEN** the answer is `arch`
+
+#### Scenario: ID_LIKE scoped to the host
+
+- **WHEN** the host reports `ID_LIKE=debian`
+- **AND** RWR is asked whether `arch` is in the `debian` family
+- **THEN** the answer is no
+
+### Requirement: Every available provider is recorded as a package manager
+
+RWR SHALL record each available provider in the detected package-manager map, with
+its resolved binary path and its command templates.
+
+RWR SHALL NOT re-filter that map by matching the provider's distribution list
+against a literal OS name. Doing so excluded every provider that names concrete
+distributions — `apt`, `dnf`, `pacman`, `zypper`, and the AUR helpers — leaving
+cache cleaning and core-package resolution operating on a map that held only
+wildcard providers.
+
+#### Scenario: An Arch machine with paru installed
+
+- **WHEN** provider detection runs on a machine with `pacman` and `paru` available
+- **THEN** both appear in the package-manager map with usable binary paths
+- **AND** cache cleaning issues a `pacman` clean command
+
+### Requirement: The default package manager is deterministic
+
+RWR SHALL choose the default package manager as the first entry of the platform's
+preference list that is present. When no preferred manager is present, RWR SHALL
+fall back to the alphabetically first available manager.
+
+RWR SHALL NOT choose by map iteration order. Go randomizes map iteration, so a
+package with no explicit `package_manager` could otherwise be installed by a
+different tool on each run.
+
+#### Scenario: Repeated runs on the same machine
+
+- **WHEN** default selection runs many times on an unchanged machine
+- **THEN** it resolves to the same manager every time
+
+#### Scenario: A machine with only unpreferred managers
+
+- **WHEN** no manager from the preference list is installed
+- **AND** `flatpak` and `snap` are both available
+- **THEN** the default is `flatpak`, chosen by sorted name rather than at random


### PR DESCRIPTION
Three things that were built and never connected. Found by writing the OpenSpec capability specs — `openspec/` was scaffolded and `specs/` was never populated, so there was nothing to review changes against.

## 1. Schema versioning was wired to nothing

`helpers.DecodeBlueprint` resolved the version, validated it, and picked the registry variant. **No processor called it.** Every one still called `UnmarshalBlueprint` directly.

Proven, not inferred:

```
blueprint: schema_version: 99
ProcessPackages error = <nil>
commands recorded = 1: [/usr/bin/pacman -Sy --noconfirm git] (elevated=true)
```

A blueprint asking for a schema this build cannot read installed packages as root instead of refusing — the opposite of what `docs/schema-versioning.md` documents.

It returned `interface{}`, which is why nothing adopted it. `DecodeBlueprintInto` writes into the caller's typed target; every processor and both import paths now use it. The tree-wide version is checked once at `Initialize`.

## 2. `rwr validate` skipped subdirectories

`if entry.IsDir() { continue }`. Blueprints live in `packages/`, `files/`, `services/` — the layout the docs recommend and every example uses — so `rwr validate` checked the init file and reported success.

Now walks the tree, skipping dot directories and nested init files.

## 3. Walking the tree exposed that most of the validator had never run

17 errors against `examples/linux/Arch/yaml` the moment recursion landed:

- Six types decoded into a bare slice — `[]types.Repository` for a file whose content is `repositories:` followed by a list. Cannot succeed against any real blueprint.
- `fonts` and `configuration` had no validator; both reported "Unsupported blueprint type".
- `packages` required `name` and separately warned on empty `names` — two errors against every correct entry, whichever form it used.
- `files` allowed `append` and `template`, which no branch handles, and rejected `copy`, `move`, `chmod`, `chown`, `chgrp`, `symlink`, which all do.
- `scripts` rejected `source`.
- Templates were resolved for `bootstrap.yaml` only, so `{{ .User.home }}` parsed as a YAML flow mapping.

All eleven example trees now validate clean.

## 4. `rwr profiles` read only the init file's inline arrays

Profiles are declared on blueprint entries, so the command that tells you what `--profile` accepts answered "No profiles found" for every tree that uses them. Against `examples/linux/Arch/yaml` it now reports 22 profiles with counts.

## Tests

Real processors, real validator, real blueprints. The schema tests fail on the previous code with the exact symptom quoted above.

The existing `missing name` package test **asserted the bug** — it declared `names: [vim]` and expected an error. Replaced with the two cases that match the processor.

## Also

Nine OpenSpec capability specs covering command execution, provider detection, credentials, schema versioning, blueprint processing, validation, initialization, CLI, and distribution. Remaining known gaps are recorded in the specs rather than left implicit.

`go test ./...`, `golangci-lint run`, `gosec ./...`, `openspec validate --specs --strict` all clean.

Note: commits are unsigned — GPG pinentry was timing out locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)