### PR TITLE
fix(exec): keep secrets out of argv and logs, refuse symlinked log paths

### DIFF
--- a/internal/exectest/recorder.go
+++ b/internal/exectest/recorder.go
@@ -19,6 +19,7 @@ type Call struct {
 	AsUser   string
 	LogName  string
 	Vars     map[string]string
+	Stdin    string
 }
 
 // Argv is the full argument vector as the target program would receive it:
@@ -67,6 +68,7 @@ func (r *Recorder) record(cmd types.Command) {
 		AsUser:   cmd.AsUser,
 		LogName:  cmd.LogName,
 		Vars:     cmd.Variables,
+		Stdin:    cmd.Stdin,
 	})
 }
 

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -37,18 +37,18 @@ import (
 func buildCommand(cmd types.Command) *exec.Cmd {
 	if runtime.GOOS != "windows" {
 		if cmd.Elevated {
-			log.Debugf("Running command as sudo - Running Command: %v %v", cmd.Exec, cmd.Args)
+			log.Debugf("Running command as sudo - Running Command: %v %v", cmd.Exec, cmd.LogArgs())
 			return exec.Command("sudo", append([]string{"--", cmd.Exec}, cmd.Args...)...) // #nosec G204 -- argv, not a shell string: args are passed as discrete arguments
 		}
 		if cmd.AsUser != "" {
-			log.Debugf("Running command as user: %v - Running Command: %v %v", cmd.AsUser, cmd.Exec, cmd.Args)
+			log.Debugf("Running command as user: %v - Running Command: %v %v", cmd.AsUser, cmd.Exec, cmd.LogArgs())
 			return exec.Command("sudo", append([]string{"-u", cmd.AsUser, "--", cmd.Exec}, cmd.Args...)...) // #nosec G204 -- argv, not a shell string: args are passed as discrete arguments
 		}
 	} else if cmd.Elevated {
-		log.Debugf("Elevated requested on Windows; running in-process (no sudo equivalent): %v %v", cmd.Exec, cmd.Args)
+		log.Debugf("Elevated requested on Windows; running in-process (no sudo equivalent): %v %v", cmd.Exec, cmd.LogArgs())
 	}
 
-	log.Debugf("Running command: %v %v", cmd.Exec, cmd.Args)
+	log.Debugf("Running command: %v %v", cmd.Exec, cmd.LogArgs())
 	return exec.Command(cmd.Exec, cmd.Args...) // #nosec G204 -- argv, not a shell string: args are passed as discrete arguments
 }
 
@@ -99,7 +99,7 @@ func RunCommand(cmd types.Command, debug bool) error {
 // runCommand is the real implementation behind osExecutor.Run.
 func runCommand(cmd types.Command, debug bool) error {
 	if dryRunMode {
-		log.Infof("[DRY-RUN] Would execute: %s %s", cmd.Exec, strings.Join(cmd.Args, " "))
+		log.Infof("[DRY-RUN] Would execute: %s %s", cmd.Exec, strings.Join(cmd.LogArgs(), " "))
 		return nil
 	}
 
@@ -108,11 +108,20 @@ func runCommand(cmd types.Command, debug bool) error {
 
 	var stderr bytes.Buffer
 
+	if cmd.Stdin != "" {
+		// Supplied input wins over the terminal even for an interactive command:
+		// the caller is feeding the tool something specific, and inheriting
+		// os.Stdin instead would hang waiting for a human.
+		command.Stdin = strings.NewReader(cmd.Stdin)
+	}
+
 	if cmd.Interactive {
 		// Interactive commands must reach the terminal directly. Capturing stderr
 		// here would swallow sudo's password prompt and hang the run with no
 		// indication of what it was waiting for.
-		command.Stdin = os.Stdin
+		if cmd.Stdin == "" {
+			command.Stdin = os.Stdin
+		}
 		command.Stdout = os.Stdout
 		command.Stderr = os.Stderr
 	} else {
@@ -151,7 +160,7 @@ func RunCommandOutput(cmd types.Command, debug bool) (string, error) {
 // runCommandOutput is the real implementation behind osExecutor.Output.
 func runCommandOutput(cmd types.Command, debug bool) (string, error) {
 	if dryRunMode {
-		log.Infof("[DRY-RUN] Would execute: %s %s", cmd.Exec, strings.Join(cmd.Args, " "))
+		log.Infof("[DRY-RUN] Would execute: %s %s", cmd.Exec, strings.Join(cmd.LogArgs(), " "))
 		return "", nil
 	}
 
@@ -160,6 +169,9 @@ func runCommandOutput(cmd types.Command, debug bool) (string, error) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+	if cmd.Stdin != "" {
+		command.Stdin = strings.NewReader(cmd.Stdin)
+	}
 	command.Stdout = &stdout
 	command.Stderr = &stderr
 
@@ -191,7 +203,17 @@ func setOutputStreams(cmd *exec.Cmd, debug bool, logName string) (*os.File, erro
 		return nil, nil
 	}
 
-	file, err := os.OpenFile(logName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644) // #nosec G302 G304 -- TODO(PR8): create with target mode instead of chmod-after; path is operator-supplied blueprint/config input; containment added in PR8
+	// The log path comes from the blueprint (`log:` on a script), so it is
+	// attacker-influenced whenever the blueprint is. Appending through a symlink
+	// would let command output be written into ~/.ssh/authorized_keys or ~/.bashrc
+	// without the blueprint containing anything that looks like it writes a file.
+	// Refuse to follow a symlink, and create at 0600 — command output routinely
+	// contains more than the operator expects.
+	if info, err := os.Lstat(logName); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing to write command log through symlink %q", logName)
+	}
+
+	file, err := os.OpenFile(logName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600) // #nosec G304 -- path is operator-supplied blueprint input; symlinks refused above
 	if err != nil {
 		log.Errorf("Error opening log file: %v", err)
 		return nil, fmt.Errorf("error opening log file %q: %w", logName, err)

--- a/internal/types/command.go
+++ b/internal/types/command.go
@@ -1,5 +1,11 @@
 package types
 
+import "strings"
+
+// minRedactableSecret is the shortest secret worth substring-replacing in a log
+// line. See LogArgs.
+const minRedactableSecret = 4
+
 type Command struct {
 	Exec        string            `mapstructure:"exec" yaml:"exec" json:"exec" toml:"exec"`
 	Variables   map[string]string `mapstructure:"variables,omitempty" yaml:"variables,omitempty" json:"variables,omitempty" toml:"variables,omitempty"`
@@ -8,4 +14,40 @@ type Command struct {
 	AsUser      string            `mapstructure:"asUser,omitempty" yaml:"asUser,omitempty" json:"asUser,omitempty" toml:"asUser,omitempty"`
 	Interactive bool              `mapstructure:"interactive" yaml:"interactive" json:"interactive" toml:"interactive"`
 	Elevated    bool              `mapstructure:"elevated" yaml:"elevated" json:"elevated" toml:"elevated"`
+
+	// Stdin is fed to the command on standard input. It is deliberately not a
+	// blueprint field: it exists so secrets can be handed to a tool without
+	// appearing in argv, where every local user can read them out of `ps` and
+	// where the debug logger would print them. `chpasswd` is the reason it exists.
+	Stdin string `mapstructure:"-" yaml:"-" json:"-" toml:"-"`
+
+	// Secrets lists values that must be scrubbed from any log line describing this
+	// command. Some tools accept a credential only as an argument (chocolatey's
+	// --password, cargo's login token), so the value cannot always be moved to
+	// Stdin — but it should still never be written to a log file. Callers that put
+	// a credential in Args are expected to list it here.
+	Secrets []string `mapstructure:"-" yaml:"-" json:"-" toml:"-"`
+}
+
+// LogArgs returns Args with every value in Secrets replaced, for logging.
+func (c Command) LogArgs() []string {
+	if len(c.Secrets) == 0 {
+		return c.Args
+	}
+
+	safe := make([]string, len(c.Args))
+	for i, arg := range c.Args {
+		for _, secret := range c.Secrets {
+			// Substring replacement on a very short secret would corrupt unrelated
+			// arguments — a password of "1" would rewrite every digit in the argv.
+			// Below this length the log damage outweighs the disclosure, and a
+			// secret that short is not protecting anything anyway.
+			if len(secret) < minRedactableSecret {
+				continue
+			}
+			arg = strings.ReplaceAll(arg, secret, RedactedPlaceholder)
+		}
+		safe[i] = arg
+	}
+	return safe
 }

--- a/internal/types/command_test.go
+++ b/internal/types/command_test.go
@@ -1,0 +1,48 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+// Some tools take a credential only as an argument, so it cannot always be moved
+// to Stdin — but it must still never reach a log file. buildCommand logs argv at
+// debug level and the dry-run path logs it at info.
+func TestCommandLogArgs_RedactsSecrets(t *testing.T) {
+	cmd := Command{
+		Exec:    "choco",
+		Args:    []string{"source", "add", "--user=alice", "--password=s3cr3t", "--name=internal"},
+		Secrets: []string{"s3cr3t"},
+	}
+
+	got := strings.Join(cmd.LogArgs(), " ")
+	if strings.Contains(got, "s3cr3t") {
+		t.Errorf("log args leak the secret: %s", got)
+	}
+	if !strings.Contains(got, RedactedPlaceholder) {
+		t.Errorf("log args do not show a redaction marker: %s", got)
+	}
+	for _, want := range []string{"source", "add", "--user=alice", "--name=internal"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("log args dropped non-secret %q: %s", want, got)
+		}
+	}
+}
+
+func TestCommandLogArgs_LeavesArgsAloneWithoutSecrets(t *testing.T) {
+	cmd := Command{Exec: "apt", Args: []string{"install", "git"}}
+
+	got := cmd.LogArgs()
+	if len(got) != 2 || got[0] != "install" || got[1] != "git" {
+		t.Errorf("LogArgs altered a command with no secrets: %v", got)
+	}
+}
+
+// An empty entry must not turn every argument into the placeholder.
+func TestCommandLogArgs_IgnoresEmptySecret(t *testing.T) {
+	cmd := Command{Exec: "apt", Args: []string{"install", "git"}, Secrets: []string{""}}
+
+	if got := strings.Join(cmd.LogArgs(), " "); got != "install git" {
+		t.Errorf("empty secret corrupted the args: %q", got)
+	}
+}

--- a/internal/types/secrets.go
+++ b/internal/types/secrets.go
@@ -84,11 +84,6 @@ func SetShowSecrets(enabled bool) {
 	showSecrets = enabled
 }
 
-// ShowSecrets reports whether secret values may be printed.
-func ShowSecrets() bool {
-	return showSecrets
-}
-
 // Redact returns value unless the operator asked to see secrets.
 //
 // The escape hatch exists because "is rwr even reading my token?" is a real


### PR DESCRIPTION
First of a 10-PR stack splitting a full-project review. Each PR builds and passes tests on its own; review in order.

`types.Command` gains a `Stdin` field so a credential can be handed to a tool without appearing in argv — where every local user can read it via `ps`, and where the debug logger prints it. It also gains `Secrets` plus `LogArgs()` for tools that accept a credential *only* as an argument and leave no other option; those values are scrubbed from the debug and `[DRY-RUN]` log lines.

The command log path comes from the blueprint (`log:` on a script), so it is attacker-influenced whenever the blueprint is. Appending through a symlink would let command output land in `~/.ssh/authorized_keys` without the blueprint containing anything that looks like it writes a file. The log is now refused if the path is a symlink, and created `0600` rather than `0644`.

Callers are wired up in later PRs in the stack.

**Stack:** #1 ← you are here · then failure ledger, security, dry-run, idempotency/macOS, strict decoding, repositories, CLI, validation, docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)