### PR TITLE
fix(run): make skipped failures reach the exit code

### DIFF
--- a/internal/processors/all.go
+++ b/internal/processors/all.go
@@ -16,12 +16,26 @@ import (
 	"github.com/fynxlabs/rwr/internal/types"
 )
 
+// findBootstrapFile returns the bootstrap blueprint in dir, in whichever format it
+// is written, or "" when the tree has none.
+func findBootstrapFile(dir string) string {
+	for _, ext := range []string{types.FormatExtYAML, types.FormatExtYAMLAlt, types.FormatExtJSON, types.FormatExtTOML} {
+		candidate := filepath.Join(dir, "bootstrap"+ext)
+		if system.FileExists(candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
 // All orchestrates the execution of all blueprint processors in the defined run order.
 // It handles bootstrap, package installation, file management, services, and other
 // operations sequentially, cleaning up package manager caches on completion.
 func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) error {
 	var err error
 	var blueprintRunOrder []string
+
+	resetFailures()
 
 	log.Debugf("ForceBootstrap: %v", initConfig.Variables.Flags.ForceBootstrap)
 
@@ -94,15 +108,23 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 		}
 	}
 
+	if err := checkRequestedProfiles(initConfig); err != nil {
+		return err
+	}
+
 	// Get the blueprint file order
 	fileOrder, err := GetBlueprintFileOrder(initConfig.Init.Location, initConfig.Init.Order, initConfig.Init.RunOnlyListed, initConfig)
 	if err != nil {
 		return fmt.Errorf("error getting blueprint file order: %w", err)
 	}
 
-	// Run the bootstrap processor first if it exists
-	bootstrapFile := filepath.Join(initConfig.Init.Location, "bootstrap.yaml")
-	if system.FileExists(bootstrapFile) {
+	// Run the bootstrap processor first if it exists.
+	//
+	// Every extension is checked, not just .yaml: a tree written in TOML or JSON
+	// declares its format in the init file, and `rwr validate` already accepts all
+	// four. Looking only for bootstrap.yaml meant those trees silently never
+	// bootstrapped, with no message saying so.
+	if bootstrapFile := findBootstrapFile(initConfig.Init.Location); bootstrapFile != "" {
 		err = ProcessBootstrap(bootstrapFile, initConfig, osInfo)
 		if err != nil {
 			return fmt.Errorf("error processing bootstrap: %w", err)
@@ -200,6 +222,49 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 		log.Infof("No changes were made to the system.")
 	}
 
+	// Processors that skip a failed item and continue record it rather than
+	// aborting. Reporting completion without consulting that ledger is how a run
+	// where every package failed still exited 0.
+	if err := failureError(); err != nil {
+		log.Errorf("RWR run finished with %d failure(s)", failureCount())
+		return err
+	}
+
 	log.Info("RWR Run Complete!")
 	return nil
+}
+
+// checkRequestedProfiles refuses a --profile the tree does not declare.
+//
+// A misspelled profile name was silent: FilterByProfiles matched nothing, every
+// profile-scoped entry was skipped, and the run reported success having installed
+// only the base items. A mistyped profile looked exactly like a working run.
+func checkRequestedProfiles(initConfig *types.InitConfig) error {
+	requested := initConfig.Variables.Flags.Profiles
+	if len(requested) == 0 {
+		return nil
+	}
+
+	summary, err := CollectProfiles(initConfig)
+	if err != nil {
+		// Discovery is a convenience, not a gate: if the tree cannot be walked the
+		// processors below will report why, with better context than this can.
+		log.Debugf("Could not collect profiles to validate --profile: %v", err)
+		return nil
+	}
+
+	invalid := helpers.ValidateProfiles(requested, summary.Names)
+	if len(invalid) == 0 {
+		return nil
+	}
+
+	// Only a tree that declares profiles gives a trustworthy set to check against.
+	// When it declares none, the discovery walk is as likely to be the thing at
+	// fault as the operator, so say so rather than refusing to run.
+	if len(summary.Names) == 0 {
+		log.Warnf("--profile %v was given, but no blueprint in this tree declares any profiles; every profile-scoped entry will be skipped", invalid)
+		return nil
+	}
+
+	return fmt.Errorf("no profile named %v exists in this blueprint tree; available profiles: %v", invalid, summary.Names)
 }

--- a/internal/processors/failures.go
+++ b/internal/processors/failures.go
@@ -1,0 +1,74 @@
+package processors
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"charm.land/log/v2"
+)
+
+// Several processors deliberately keep going when one item fails: a package that
+// is not in the repositories should not stop the twenty after it, and a git repo
+// that is temporarily unreachable should not abandon the rest of the run. That is
+// the right behavior. What was wrong is that those failures then vanished — they
+// were logged and the run exited 0 with "RWR Run Complete!", so a run in which
+// every single package failed to install was indistinguishable from a clean one.
+//
+// The ledger records them instead. Processors keep going and keep logging; All()
+// asks at the end whether anything failed and returns a non-nil error if so, which
+// is what puts it in the exit code.
+type runFailures struct {
+	mu    sync.Mutex
+	items []runFailure
+}
+
+type runFailure struct {
+	component string
+	subject   string
+	err       error
+}
+
+var failures runFailures
+
+// recordFailure notes a non-fatal failure and logs it. Call it instead of a bare
+// log.Warnf/log.Errorf wherever a processor swallows an error and continues.
+func recordFailure(component, subject string, err error) {
+	failures.mu.Lock()
+	failures.items = append(failures.items, runFailure{component: component, subject: subject, err: err})
+	failures.mu.Unlock()
+
+	log.Errorf("%s: %s: %v", component, subject, err)
+}
+
+// resetFailures clears the ledger at the start of a run.
+func resetFailures() {
+	failures.mu.Lock()
+	failures.items = nil
+	failures.mu.Unlock()
+}
+
+// failureCount reports how many non-fatal failures the run has accumulated.
+func failureCount() int {
+	failures.mu.Lock()
+	defer failures.mu.Unlock()
+	return len(failures.items)
+}
+
+// failureError summarizes the ledger as a single error, or nil when the run was
+// clean. The summary lists every failure so the exit code is not the only signal.
+func failureError() error {
+	failures.mu.Lock()
+	defer failures.mu.Unlock()
+
+	if len(failures.items) == 0 {
+		return nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d operation(s) failed:", len(failures.items))
+	for _, item := range failures.items {
+		fmt.Fprintf(&b, "\n  - %s: %s: %v", item.component, item.subject, item.err)
+	}
+	return fmt.Errorf("%s", b.String())
+}

--- a/internal/processors/failures_test.go
+++ b/internal/processors/failures_test.go
@@ -1,0 +1,53 @@
+package processors
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestFailureLedger_CleanRunReportsNoError(t *testing.T) {
+	resetFailures()
+
+	if got := failureCount(); got != 0 {
+		t.Fatalf("fresh ledger has %d failures, want 0", got)
+	}
+	if err := failureError(); err != nil {
+		t.Errorf("clean run returned %v, want nil", err)
+	}
+}
+
+// The failure this guards against: every package fails to install, each one is
+// logged and skipped, and the run still exits 0.
+func TestFailureLedger_RecordedFailuresSurface(t *testing.T) {
+	resetFailures()
+	t.Cleanup(resetFailures)
+
+	recordFailure("packages", "git", errors.New("not found in repositories"))
+	recordFailure("ssh_keys", "id_ed25519", errors.New("permission denied"))
+
+	if got := failureCount(); got != 2 {
+		t.Fatalf("ledger recorded %d failures, want 2", got)
+	}
+
+	err := failureError()
+	if err == nil {
+		t.Fatal("recorded failures produced a nil error")
+	}
+
+	for _, want := range []string{"2 operation(s) failed", "packages", "git", "not found in repositories", "ssh_keys", "id_ed25519", "permission denied"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("summary is missing %q:\n%s", want, err)
+		}
+	}
+}
+
+func TestFailureLedger_ResetClearsPreviousRun(t *testing.T) {
+	resetFailures()
+	recordFailure("packages", "vim", errors.New("boom"))
+	resetFailures()
+
+	if err := failureError(); err != nil {
+		t.Errorf("reset ledger still reports %v", err)
+	}
+}


### PR DESCRIPTION
Stacked on #159.

Several processors deliberately keep going when one item fails: a package that is not in the repositories should not stop the twenty after it. That is right. What was wrong is that those failures then **vanished** — they were logged and the run exited 0 with "RWR Run Complete!", so a run in which *every* package failed to install was indistinguishable from a clean one.

Failures now go into a run ledger. Processors keep going and keep logging; `All()` asks at the end, lists every failure, and returns an error. Individual processors are moved onto it in later PRs.

Two other run-mechanics fixes ride along in `All()`:

- The bootstrap file is found in any of the four supported formats, not only `bootstrap.yaml`. A TOML or JSON tree silently never bootstrapped, with no message saying so — even though `rwr validate` already accepted all four.
- A `--profile` the tree does not declare is refused, listing the ones that exist. A misspelled name matched nothing, every profile-scoped entry was skipped, and the run reported success having installed only the base items. When the tree declares no profiles at all, the discovery walk is as likely to be at fault as the operator, so that case warns instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)