### PR TITLE
fix(blueprints): decode strictly, and make the ignored config keys real

### DIFF
--- a/internal/helpers/blueprints.go
+++ b/internal/helpers/blueprints.go
@@ -6,8 +6,11 @@
 package helpers
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/user"
 	"runtime"
@@ -22,25 +25,78 @@ import (
 // UnmarshalBlueprint parses blueprint data into the provided struct.
 // It supports YAML, JSON, and TOML formats specified by the format parameter.
 // Format accepts file extensions (".yaml", ".json", ".toml") or format names ("yaml", "json", "toml").
+//
+// Unknown keys are ignored. Use UnmarshalBlueprintStrict for blueprint content;
+// this lenient form exists for probes that deliberately read one key out of a
+// document, such as the schema_version declaration.
 func UnmarshalBlueprint(data []byte, format string, v interface{}) error {
+	return unmarshalBlueprint(data, format, v, false)
+}
+
+// UnmarshalBlueprintStrict parses blueprint data and rejects any key the target
+// struct does not define.
+//
+// A silently ignored key is a blueprint that looks applied and is not: `pacakges:`
+// yields an empty section, every processor finds nothing to do, and the run
+// reports success having changed nothing. A misspelled `profiles` is worse — the
+// entry loses its scoping and runs on every machine. Both failures are invisible
+// at any log level, so they surface as "rwr didn't do anything" long after the
+// typo was written.
+func UnmarshalBlueprintStrict(data []byte, format string, v interface{}) error {
+	return unmarshalBlueprint(data, format, v, true)
+}
+
+func unmarshalBlueprint(data []byte, format string, v interface{}, strict bool) error {
 	switch format {
 	case types.FormatExtYAML, types.FormatExtYAMLAlt, types.FormatYAML, types.FormatYAMLAlt:
 		log.Debug("Unmarshaling YAML")
-		err := yaml.Unmarshal(data, v)
-		if err != nil {
+		if !strict {
+			if err := yaml.Unmarshal(data, v); err != nil {
+				return fmt.Errorf("error unmarshaling YAML: %w", err)
+			}
+			break
+		}
+		dec := yaml.NewDecoder(bytes.NewReader(data))
+		dec.KnownFields(true)
+		if err := dec.Decode(v); err != nil {
+			// An empty document is a valid blueprint section with nothing in it.
+			if errors.Is(err, io.EOF) {
+				break
+			}
 			return fmt.Errorf("error unmarshaling YAML: %w", err)
 		}
 	case types.FormatExtJSON, types.FormatJSON:
 		log.Debug("Unmarshaling JSON")
-		err := json.Unmarshal(data, v)
-		if err != nil {
+		if !strict {
+			if err := json.Unmarshal(data, v); err != nil {
+				return fmt.Errorf("error unmarshaling JSON: %w", err)
+			}
+			break
+		}
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(v); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
 			return fmt.Errorf("error unmarshaling JSON: %w", err)
 		}
 	case types.FormatExtTOML, types.FormatTOML:
 		log.Debug("Unmarshaling TOML")
-		err := toml.Unmarshal(data, v)
+		meta, err := toml.Decode(string(data), v)
 		if err != nil {
 			return fmt.Errorf("error unmarshaling TOML: %w", err)
+		}
+		// BurntSushi has no strict mode; it reports what it could not place
+		// instead, so the check has to happen here rather than in the decoder.
+		if strict {
+			if undecoded := meta.Undecoded(); len(undecoded) > 0 {
+				keys := make([]string, 0, len(undecoded))
+				for _, key := range undecoded {
+					keys = append(keys, key.String())
+				}
+				return fmt.Errorf("error unmarshaling TOML: unknown key(s): %s", strings.Join(keys, ", "))
+			}
 		}
 	default:
 		return fmt.Errorf("unsupported blueprint format: %s", format)

--- a/internal/helpers/schema.go
+++ b/internal/helpers/schema.go
@@ -34,7 +34,7 @@ func DecodeBlueprint(data []byte, format, blueprintType string, treeVersion int)
 		return nil, version, err
 	}
 
-	if err := UnmarshalBlueprint(data, format, variant.Target()); err != nil {
+	if err := UnmarshalBlueprintStrict(data, format, variant.Target()); err != nil {
 		return nil, version, fmt.Errorf("reading %s blueprint as schema v%d: %w",
 			blueprintType, version, err)
 	}

--- a/internal/helpers/strict_test.go
+++ b/internal/helpers/strict_test.go
@@ -1,0 +1,92 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// A misspelled key used to produce an empty section and a run that reported
+// success having done nothing. These assert it is now an error in every format.
+func TestUnmarshalBlueprintStrict_RejectsUnknownKeys(t *testing.T) {
+	cases := []struct {
+		name   string
+		format string
+		data   string
+		want   string
+	}{
+		{
+			name:   "yaml misspelled section",
+			format: types.FormatYAML,
+			data:   "packagess:\n  - name: git\n    action: install\n",
+			want:   "packagess",
+		},
+		{
+			name:   "yaml misspelled entry key",
+			format: types.FormatYAML,
+			data:   "packages:\n  - name: git\n    action: install\n    profile: work\n",
+			want:   "profile",
+		},
+		{
+			name:   "json misspelled section",
+			format: types.FormatJSON,
+			data:   `{"packagess":[{"name":"git","action":"install"}]}`,
+			want:   "packagess",
+		},
+		{
+			name:   "toml misspelled section",
+			format: types.FormatTOML,
+			data:   "[[packagess]]\nname = \"git\"\naction = \"install\"\n",
+			want:   "packagess",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var data types.PackagesData
+			err := UnmarshalBlueprintStrict([]byte(tc.data), tc.format, &data)
+			if err == nil {
+				t.Fatalf("strict decode accepted unknown key %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not name the offending key %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestUnmarshalBlueprintStrict_AcceptsKnownKeys(t *testing.T) {
+	cases := []struct {
+		name   string
+		format string
+		data   string
+	}{
+		{"yaml", types.FormatYAML, "packages:\n  - name: git\n    action: install\n    profiles: [work]\n"},
+		{"json", types.FormatJSON, `{"packages":[{"name":"git","action":"install"}]}`},
+		{"toml", types.FormatTOML, "[[packages]]\nname = \"git\"\naction = \"install\"\n"},
+		{"yaml empty document", types.FormatYAML, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var data types.PackagesData
+			if err := UnmarshalBlueprintStrict([]byte(tc.data), tc.format, &data); err != nil {
+				t.Fatalf("strict decode rejected a valid blueprint: %v", err)
+			}
+		})
+	}
+}
+
+// The schema_version probe deliberately reads one key out of a full document, so
+// it must stay lenient or every blueprint would fail before its version is known.
+func TestUnmarshalBlueprint_LenientForVersionProbe(t *testing.T) {
+	var probe types.SchemaVersion
+	data := "schema_version: 1\npackages:\n  - name: git\n    action: install\n"
+	if err := UnmarshalBlueprint([]byte(data), types.FormatYAML, &probe); err != nil {
+		t.Fatalf("version probe rejected a full document: %v", err)
+	}
+	if probe.DeclaredVersion() != 1 {
+		t.Errorf("probe read version %d, want 1", probe.DeclaredVersion())
+	}
+}

--- a/internal/processors/git.go
+++ b/internal/processors/git.go
@@ -55,6 +55,17 @@ func processGitRepositories(gitRepos []types.Git, initConfig *types.InitConfig) 
 			log.Infof("[DRY-RUN] Would clone/update git repository: %s -> %s", repo.URL, repo.Path)
 			continue
 		}
+		// The action field was decoded and never read, so `action: pull` cloned and
+		// `action: banana` was accepted. Empty and "clone" keep the original
+		// behavior — clone when missing, pull when present.
+		switch repo.Action {
+		case "", types.GitActionClone, types.GitActionPull:
+		default:
+			recordFailure("git", repo.Name,
+				fmt.Errorf("unsupported action %q: use %q or %q", repo.Action, types.GitActionClone, types.GitActionPull))
+			continue
+		}
+
 		gitOpts := types.GitOptions{
 			URL:     repo.URL,
 			Private: repo.Private,
@@ -68,63 +79,38 @@ func processGitRepositories(gitRepos []types.Git, initConfig *types.InitConfig) 
 			log.Infof("Git repository %s already exists at %s", repo.Name, gitOpts.Target)
 			err = helpers.CheckAndUpdateRemoteURL(gitOpts.Target, gitOpts.URL)
 			if err != nil {
-				log.Warnf("Error checking/updating remote URL for %s: %v", repo.Name, err)
-				// Continue with other repositories instead of returning
+				recordFailure("git", repo.Name, fmt.Errorf("checking/updating remote URL: %w", err))
 				continue
 			}
 
 			// Pull latest changes
 			err = helpers.HandleGitPull(gitOpts, initConfig)
 			if err != nil {
-				log.Warnf("Error pulling latest changes for %s: %v", repo.Name, err)
-				// Continue with other repositories instead of returning
+				recordFailure("git", repo.Name, fmt.Errorf("pulling latest changes: %w", err))
 				continue
 			}
 			log.Infof("Git repository %s updated successfully", repo.Name)
 		} else if os.IsNotExist(err) {
+			if repo.Action == types.GitActionPull {
+				recordFailure("git", repo.Name,
+					fmt.Errorf("action is %q but nothing is checked out at %s", types.GitActionPull, gitOpts.Target))
+				continue
+			}
 			// Repository doesn't exist, clone it
 			err = helpers.HandleGitClone(gitOpts, initConfig)
 			if err != nil {
-				log.Warnf("Error cloning Git repository %s: %v", repo.Name, err)
-				// Continue with other repositories instead of returning
+				recordFailure("git", repo.Name, fmt.Errorf("cloning: %w", err))
 				continue
 			}
 			log.Infof("Git repository %s cloned successfully", repo.Name)
 		} else {
 			// Some other error occurred
-			log.Warnf("Error checking Git repository %s: %v", repo.Name, err)
-			// Continue with other repositories instead of returning
+			recordFailure("git", repo.Name, fmt.Errorf("checking repository path: %w", err))
 			continue
 		}
 	}
 	return nil
 }
-
-// func cloneGitRepository(repo types.Git, initConfig *types.InitConfig) error {
-// 	gitOpts := types.GitOptions{
-// 		URL:     repo.URL,
-// 		Private: repo.Private,
-// 		Target:  repo.Path,
-// 		Branch:  repo.Branch,
-// 	}
-
-// 	_, err := os.Stat(gitOpts.Target)
-// 	if err == nil {
-// 		// Repository already exists
-// 		log.Infof("Git repository %s already exists at %s", repo.Name, gitOpts.Target)
-// 		return nil
-// 	} else if !os.IsNotExist(err) {
-// 		// Some other error occurred
-// 		return fmt.Errorf("error checking Git repository %s: %w", repo.Name, err)
-// 	}
-
-// 	err = helpers.HandleGitClone(gitOpts, initConfig)
-// 	if err != nil {
-// 		return fmt.Errorf("error cloning Git repository %s: %w", repo.Name, err)
-// 	}
-
-// 	return nil
-// }
 
 func processGitImports(items []types.Git, blueprintDir string, format string, treeVersion int) ([]types.Git, error) {
 	return helpers.ResolveImports(items, blueprintDir,

--- a/internal/processors/git_test.go
+++ b/internal/processors/git_test.go
@@ -1,0 +1,49 @@
+package processors
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// The action field was decoded and never read, so `action: banana` was accepted
+// and `action: pull` cloned anyway.
+func TestProcessGitRepositories_RejectsUnknownAction(t *testing.T) {
+	resetFailures()
+	t.Cleanup(resetFailures)
+
+	repos := []types.Git{{Name: "dotfiles", URL: "https://example.com/x.git", Path: t.TempDir(), Action: "banana"}}
+	if err := processGitRepositories(repos, newTestInitConfig()); err != nil {
+		t.Fatalf("processGitRepositories: %v", err)
+	}
+
+	err := failureError()
+	if err == nil {
+		t.Fatal("an unsupported git action was accepted silently")
+	}
+	if !strings.Contains(err.Error(), "banana") {
+		t.Errorf("failure does not name the bad action: %v", err)
+	}
+}
+
+// `action: pull` against a path with nothing checked out used to clone instead.
+func TestProcessGitRepositories_PullDoesNotClone(t *testing.T) {
+	resetFailures()
+	t.Cleanup(resetFailures)
+
+	target := filepath.Join(t.TempDir(), "missing")
+	repos := []types.Git{{Name: "dotfiles", URL: "https://example.com/x.git", Path: target, Action: "pull"}}
+	if err := processGitRepositories(repos, newTestInitConfig()); err != nil {
+		t.Fatalf("processGitRepositories: %v", err)
+	}
+
+	if _, statErr := os.Stat(target); statErr == nil {
+		t.Error("pull created the target; it must not clone")
+	}
+	if err := failureError(); err == nil || !strings.Contains(err.Error(), "pull") {
+		t.Errorf("pull against a missing checkout was not reported: %v", err)
+	}
+}

--- a/internal/processors/initialize.go
+++ b/internal/processors/initialize.go
@@ -31,8 +31,15 @@ func Initialize(initFilePath string, flags types.Flags) (*types.InitConfig, erro
 	}
 	defer os.RemoveAll(tempDir) //nolint:errcheck
 
+	// The init file decides the run order, the blueprint git remote and which
+	// credentials blueprints may read, so anyone who can rewrite it in flight owns
+	// the run. Over http:// that is anyone on the path between here and the server.
+	if strings.HasPrefix(initFilePath, "http://") {
+		return nil, fmt.Errorf("refusing to fetch the init file over http://: it is served in cleartext and drives everything rwr runs; use https:// instead (%s)", initFilePath)
+	}
+
 	// Handle URL or local file
-	if strings.HasPrefix(initFilePath, "http://") || strings.HasPrefix(initFilePath, "https://") {
+	if strings.HasPrefix(initFilePath, "https://") {
 		log.Debugf("Init File is a Web URL, Downloading %s", initFilePath)
 
 		fileExt = filepath.Ext(initFilePath)
@@ -124,9 +131,19 @@ func Initialize(initFilePath string, flags types.Flags) (*types.InitConfig, erro
 		return nil, fmt.Errorf("error in %s: %w", initFilePath, err)
 	}
 
-	// Set additional config values
+	// The runtime halves of Variables (user, system, flags) are computed, not
+	// declared, so they are filled in here. userDefined is the one part that comes
+	// from the init file, so it has to survive: assigning the whole struct threw
+	// away everything the operator wrote under `variables:`.
+	declared := initConfig.Variables.UserDefined
 	initConfig.Variables = variables
 	initConfig.Variables.Flags = flags
+	if initConfig.Variables.UserDefined == nil {
+		initConfig.Variables.UserDefined = make(map[string]interface{})
+	}
+	for key, value := range declared {
+		initConfig.Variables.UserDefined[key] = value
+	}
 
 	// Set the blueprints location
 	setBlueprintsLocation(&initConfig, initFilePath)

--- a/internal/processors/initialize_test.go
+++ b/internal/processors/initialize_test.go
@@ -326,3 +326,51 @@ blueprints:
 		}
 	}
 }
+
+// The `variables.userDefined` block is documented in docs/variables.md and used by
+// the shipped examples, but it decoded into nothing: Variables carried only
+// mapstructure tags and was embedded with `mapstructure:",squash"`, and Initialize
+// then overwrote the whole struct with the computed defaults. Every
+// {{ .UserDefined.x }} in a blueprint rendered "<no value>".
+func TestInitialize_UserDefinedVariablesAreReadFromInitFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	initContent := `
+blueprints:
+  location: "blueprints"
+  format: "yaml"
+
+variables:
+  userDefined:
+    project_name: "rwr"
+    server_port: 8080
+    editors:
+      - vim
+      - helix
+`
+
+	initFile := filepath.Join(tempDir, "init.yaml")
+	if err := os.WriteFile(initFile, []byte(initContent), 0644); err != nil {
+		t.Fatalf("Failed to create test init file: %v", err)
+	}
+
+	config, err := Initialize(initFile, types.Flags{})
+	if err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	if got := config.Variables.UserDefined["project_name"]; got != "rwr" {
+		t.Errorf("UserDefined[project_name] = %v, want \"rwr\"", got)
+	}
+	if got := config.Variables.UserDefined["server_port"]; got != 8080 {
+		t.Errorf("UserDefined[server_port] = %v (%T), want 8080", got, got)
+	}
+	if _, ok := config.Variables.UserDefined["editors"]; !ok {
+		t.Error("UserDefined[editors] is missing; list values must survive decoding")
+	}
+
+	// The computed halves must still be filled in alongside the declared ones.
+	if config.Variables.User.Username == "" {
+		t.Error("User.Username was not populated")
+	}
+}

--- a/internal/processors/packages.go
+++ b/internal/processors/packages.go
@@ -1,6 +1,7 @@
 package processors
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -113,11 +114,19 @@ func ProcessPackages(data []byte, packages *types.PackagesData, format string, o
 			case "remove":
 				args = append(args, strings.Fields(provider.Commands.Remove)...)
 			default:
-				log.Warnf("Unknown action %s for package %s", pkg.Action, name)
+				recordFailure("packages", name, fmt.Errorf("unknown action %q", pkg.Action))
 				continue
 			}
 
-			// Add package name
+			// A name beginning with "-" is read as an option by every package
+			// manager, not as a package: "--allow-downgrades", "-U <url>". Commands
+			// are argv-exec'd so this is not shell injection, but it still lets a
+			// blueprint change what the elevated package manager does.
+			if strings.HasPrefix(name, "-") {
+				recordFailure("packages", name, errors.New("package name may not begin with '-'; it would be read as an option by the package manager"))
+				continue
+			}
+
 			args = append(args, name)
 
 			// Add any additional arguments
@@ -127,14 +136,17 @@ func ProcessPackages(data []byte, packages *types.PackagesData, format string, o
 
 			// Execute command directly with environment variables
 			cmd := types.Command{
-				Exec:        provider.BinPath,
-				Args:        args,
-				Elevated:    provider.Elevated,
+				Exec: provider.BinPath,
+				Args: args,
+				// The provider decides whether its package manager needs elevation;
+				// a blueprint may ask for it on top (a user-scoped manager invoked
+				// against a system path), but may not take it away.
+				Elevated:    provider.Elevated || pkg.Elevated,
 				Variables:   provider.Environment,
 				Interactive: helpers.ResolveInteractive(pkg.Interactive, initConfig.Variables.Flags.Interactive),
 			}
 			if err := system.RunCommand(cmd, initConfig.Variables.Flags.Debug); err != nil {
-				log.Warnf("Error %s package %s: %v", pkg.Action, name, err)
+				recordFailure("packages", name, fmt.Errorf("%s failed: %w", pkg.Action, err))
 				continue
 			}
 

--- a/internal/processors/scripts.go
+++ b/internal/processors/scripts.go
@@ -181,6 +181,17 @@ func runScript(script types.Script, osInfo *types.OSInfo, initConfig *types.Init
 	// Set the elevated flag
 	scriptCmd.Elevated = script.Elevated
 
+	// buildCommand checks Elevated first, so asking for both silently ignored one
+	// of them. Say which one won rather than letting the script run as the wrong
+	// account.
+	if script.AsUser != "" {
+		if script.Elevated {
+			log.Warnf("Script %s declares both elevated and asUser: running elevated and ignoring asUser %q", script.Name, script.AsUser)
+		} else {
+			scriptCmd.AsUser = script.AsUser
+		}
+	}
+
 	// Set the interactive flag using per-blueprint override or global default
 	scriptCmd.Interactive = helpers.ResolveInteractive(script.Interactive, initConfig.Variables.Flags.Interactive)
 

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -136,16 +136,16 @@ func processSSHKeys(sshKeys []types.SSHKey, osInfo *types.OSInfo, initConfig *ty
 		// Generate SSH key
 		keyPath, err := generateSSHKey(sshKey, initConfig)
 		if err != nil {
-			log.Errorf("Error generating SSH key %s: %v", sshKey.Name, err)
-			continue // Continue with the next key instead of returning
+			recordFailure("ssh_keys", sshKey.Name, fmt.Errorf("generating key: %w", err))
+			continue
 		}
 
 		// Copy public key to GitHub if requested
 		if sshKey.CopyToGitHub {
 			err = copySSHKeyToGitHub(sshKey, initConfig)
 			if err != nil {
-				log.Errorf("Error copying SSH key %s to GitHub: %v", sshKey.Name, err)
-				continue // Continue with the next key instead of returning
+				recordFailure("ssh_keys", sshKey.Name, fmt.Errorf("copying public key to GitHub: %w", err))
+				continue
 			}
 		}
 
@@ -153,8 +153,8 @@ func processSSHKeys(sshKeys []types.SSHKey, osInfo *types.OSInfo, initConfig *ty
 		if sshKey.SetAsRWRSSHKey {
 			err = setAsRWRSSHKey(keyPath)
 			if err != nil {
-				log.Errorf("Error setting SSH key %s as RWR SSH Key: %v", sshKey.Name, err)
-				continue // Continue with the next key instead of returning
+				recordFailure("ssh_keys", sshKey.Name, fmt.Errorf("setting as RWR SSH key: %w", err))
+				continue
 			}
 		}
 	}
@@ -184,7 +184,28 @@ func ensureSSHPackages(osInfo *types.OSInfo, initConfig *types.InitConfig) error
 	}
 }
 
+// defaultSSHKeyType and defaultSSHKeyPath fill in the two fields that read as
+// optional but had no defaults: omitting `type` produced `ssh-keygen -t ""` and
+// omitting `path` wrote the key into the current working directory.
+const (
+	defaultSSHKeyType = "ed25519"
+	defaultSSHKeyPath = "~/.ssh"
+)
+
+// withSSHKeyDefaults returns sshKey with its optional fields filled in.
+func withSSHKeyDefaults(sshKey types.SSHKey) types.SSHKey {
+	if sshKey.Type == "" {
+		sshKey.Type = defaultSSHKeyType
+	}
+	if sshKey.Path == "" {
+		sshKey.Path = defaultSSHKeyPath
+	}
+	return sshKey
+}
+
 func generateSSHKey(sshKey types.SSHKey, initConfig *types.InitConfig) (string, error) {
+	sshKey = withSSHKeyDefaults(sshKey)
+
 	// Expand a leading ~ here. Commands are argv now, so no shell expands it on
 	// the way to ssh-keygen — an unexpanded "~/.ssh" would create a directory
 	// literally named "~" in the working directory.
@@ -426,6 +447,8 @@ func getGitHubToken(initConfig *types.InitConfig) (string, string, error) {
 }
 
 func copySSHKeyToGitHub(sshKey types.SSHKey, initConfig *types.InitConfig) error {
+	sshKey = withSSHKeyDefaults(sshKey)
+
 	// Get GitHub token with fallback hierarchy
 	token, source, err := getGitHubToken(initConfig)
 	if err != nil {
@@ -435,7 +458,10 @@ func copySSHKeyToGitHub(sshKey types.SSHKey, initConfig *types.InitConfig) error
 	log.Infof("Using GitHub token from: %s", source)
 
 	// Read SSH public key
-	sshPath := filepath.Join(sshKey.Path, sshKey.Name)
+	// generateSSHKey writes to the expanded path; reading it back unexpanded meant
+	// a literal "~/.ssh/..." relative to the cwd, so every upload for the common
+	// `path: ~/.ssh` failed and the error was swallowed as a skipped key.
+	sshPath := filepath.Join(system.ExpandPath(sshKey.Path), sshKey.Name)
 	publicKeyPath := sshPath + ".pub"
 	publicKeyBytes, err := os.ReadFile(publicKeyPath) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
 	if err != nil {

--- a/internal/types/blueprints.go
+++ b/internal/types/blueprints.go
@@ -10,15 +10,9 @@ type Init struct {
 	// applies to every blueprint type, and an individual blueprint file may
 	// override it by declaring its own. Zero means undeclared, which resolves to
 	// types.DefaultSchemaVersion.
-	SchemaVersion    int           `mapstructure:"schema_version,omitempty" yaml:"schema_version,omitempty" json:"schema_version,omitempty" toml:"schema_version,omitempty"`
-	Location         string        `mapstructure:"location,omitempty" yaml:"location,omitempty" json:"location,omitempty" toml:"location,omitempty"`
-	Order            []interface{} `mapstructure:"order,omitempty" yaml:"order,omitempty" json:"order,omitempty" toml:"order,omitempty"`
-	Git              *GitOptions   `mapstructure:"git,omitempty" yaml:"git,omitempty" json:"git,omitempty" toml:"git,omitempty"`
-	RunOnlyListed    bool          `mapstructure:"runOnlyListed,omitempty" yaml:"runOnlyListed,omitempty" json:"runOnlyListed,omitempty" toml:"runOnlyListed,omitempty"`
-	TemplatesEnabled bool          `mapstructure:"templatesEnabled,omitempty" yaml:"templatesEnabled,omitempty" json:"templatesEnabled,omitempty" toml:"templatesEnabled,omitempty"`
-}
-
-type BlueprintOrder struct {
-	Source string   `mapstructure:"source" yaml:"source,omitempty" json:"source,omitempty" toml:"source,omitempty"`
-	Files  []string `mapstructure:"files" yaml:"files,omitempty" json:"files,omitempty" toml:"files,omitempty"`
+	SchemaVersion int           `mapstructure:"schema_version,omitempty" yaml:"schema_version,omitempty" json:"schema_version,omitempty" toml:"schema_version,omitempty"`
+	Location      string        `mapstructure:"location,omitempty" yaml:"location,omitempty" json:"location,omitempty" toml:"location,omitempty"`
+	Order         []interface{} `mapstructure:"order,omitempty" yaml:"order,omitempty" json:"order,omitempty" toml:"order,omitempty"`
+	Git           *GitOptions   `mapstructure:"git,omitempty" yaml:"git,omitempty" json:"git,omitempty" toml:"git,omitempty"`
+	RunOnlyListed bool          `mapstructure:"runOnlyListed,omitempty" yaml:"runOnlyListed,omitempty" json:"runOnlyListed,omitempty" toml:"runOnlyListed,omitempty"`
 }

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -40,11 +40,20 @@ const (
 const (
 	ActionInstall = "install"
 	ActionRemove  = "remove"
-	ActionUpdate  = "update"
+	// There is deliberately no per-package "update" action. Validation accepted one
+	// and the processor never implemented it, so `action: update` passed
+	// `rwr validate` and then failed the run. It cannot be implemented on top of
+	// the providers' `update` commands either: they disagree about what update
+	// means — apt's refreshes the package lists, while pacman's is a full system
+	// upgrade — so appending a package name would do something different, and in
+	// pacman's case drastic, on each distribution.
 )
 
 // Service actions for service management operations.
 const (
+	GitActionClone = "clone"
+	GitActionPull  = "pull"
+
 	// ConfigurationActionSet is the only action the configuration tools implement.
 	ConfigurationActionSet = "set"
 

--- a/internal/types/initialize.go
+++ b/internal/types/initialize.go
@@ -40,11 +40,16 @@ type System struct {
 	OSArch    string // OS Arch - amd64, arm64
 }
 
+// Variables is the data every blueprint template renders against.
+//
+// Only UserDefined comes from the init file; Flags, User and System are filled in
+// at runtime and are explicitly not decodable, so a blueprint cannot claim to be
+// running as a different user or with different flags than it is.
 type Variables struct {
-	Flags       Flags
-	User        UserInfo
-	System      System
-	UserDefined map[string]interface{}
+	Flags       Flags                  `mapstructure:"-" yaml:"-" json:"-" toml:"-"`
+	User        UserInfo               `mapstructure:"-" yaml:"-" json:"-" toml:"-"`
+	System      System                 `mapstructure:"-" yaml:"-" json:"-" toml:"-"`
+	UserDefined map[string]interface{} `mapstructure:"userDefined,omitempty" yaml:"userDefined,omitempty" json:"userDefined,omitempty" toml:"userDefined,omitempty"`
 }
 
 // InitConfig represents the configuration for the initialization processor.
@@ -58,7 +63,9 @@ type InitConfig struct {
 	Templates       []File               `mapstructure:"templates,omitempty" yaml:"templates,omitempty" json:"templates,omitempty" toml:"templates,omitempty"`
 	Directories     []Directory          `mapstructure:"directories,omitempty" yaml:"directories,omitempty" json:"directories,omitempty" toml:"directories,omitempty"`
 	Configuration   []Configuration      `mapstructure:"configuration,omitempty" yaml:"configuration,omitempty" json:"configuration,omitempty" toml:"configuration,omitempty"`
-	Variables       Variables            `mapstructure:",squash"`
+	// Squashing this made the `variables:` block in the init file decode into
+	// nothing at all, so every {{ .UserDefined.x }} in a blueprint rendered empty.
+	Variables Variables `mapstructure:"variables,omitempty" yaml:"variables,omitempty" json:"variables,omitempty" toml:"variables,omitempty"`
 	// ExposeCredentials names the credentials this tree's blueprints are allowed
 	// to read, e.g. ["gh_api_token"]. Empty — the default — means blueprints get
 	// none of them. See docs/credentials.md.

--- a/internal/types/scripts.go
+++ b/internal/types/scripts.go
@@ -1,17 +1,20 @@
 package types
 
 type Script struct {
-	Name        string   `mapstructure:"name" yaml:"name" json:"name" toml:"name"`
-	Profiles    []string `mapstructure:"profiles,omitempty" yaml:"profiles,omitempty" json:"profiles,omitempty" toml:"profiles,omitempty"`
-	Action      string   `mapstructure:"action" yaml:"action" json:"action" toml:"action"`
-	Exec        string   `mapstructure:"exec" yaml:"exec" json:"exec" toml:"exec"`
-	Source      string   `mapstructure:"source,omitempty" yaml:"source,omitempty" json:"source,omitempty" toml:"source,omitempty"`
-	Content     string   `mapstructure:"content,omitempty" yaml:"content,omitempty" json:"content,omitempty" toml:"content,omitempty"`
-	Args        string   `mapstructure:"args,omitempty" yaml:"args,omitempty" json:"args,omitempty" toml:"args,omitempty"`
-	Elevated    bool     `mapstructure:"elevated,omitempty" yaml:"elevated,omitempty" json:"elevated,omitempty" toml:"elevated,omitempty"`
-	Log         string   `mapstructure:"log,omitempty" yaml:"log,omitempty" json:"log,omitempty" toml:"log,omitempty"`
-	Interactive *bool    `mapstructure:"interactive,omitempty" yaml:"interactive,omitempty" json:"interactive,omitempty" toml:"interactive,omitempty"`
-	Import      string   `mapstructure:"import,omitempty" yaml:"import,omitempty" json:"import,omitempty" toml:"import,omitempty"`
+	Name     string   `mapstructure:"name" yaml:"name" json:"name" toml:"name"`
+	Profiles []string `mapstructure:"profiles,omitempty" yaml:"profiles,omitempty" json:"profiles,omitempty" toml:"profiles,omitempty"`
+	Action   string   `mapstructure:"action" yaml:"action" json:"action" toml:"action"`
+	Exec     string   `mapstructure:"exec" yaml:"exec" json:"exec" toml:"exec"`
+	Source   string   `mapstructure:"source,omitempty" yaml:"source,omitempty" json:"source,omitempty" toml:"source,omitempty"`
+	Content  string   `mapstructure:"content,omitempty" yaml:"content,omitempty" json:"content,omitempty" toml:"content,omitempty"`
+	Args     string   `mapstructure:"args,omitempty" yaml:"args,omitempty" json:"args,omitempty" toml:"args,omitempty"`
+	Elevated bool     `mapstructure:"elevated,omitempty" yaml:"elevated,omitempty" json:"elevated,omitempty" toml:"elevated,omitempty"`
+	// AsUser runs the script as another account (sudo -u). Elevated takes
+	// precedence when both are set, since sudo cannot do both at once.
+	AsUser      string `mapstructure:"asUser,omitempty" yaml:"asUser,omitempty" json:"asUser,omitempty" toml:"asUser,omitempty"`
+	Log         string `mapstructure:"log,omitempty" yaml:"log,omitempty" json:"log,omitempty" toml:"log,omitempty"`
+	Interactive *bool  `mapstructure:"interactive,omitempty" yaml:"interactive,omitempty" json:"interactive,omitempty" toml:"interactive,omitempty"`
+	Import      string `mapstructure:"import,omitempty" yaml:"import,omitempty" json:"import,omitempty" toml:"import,omitempty"`
 }
 
 type ScriptData struct {

--- a/internal/validate/components.go
+++ b/internal/validate/components.go
@@ -30,7 +30,7 @@ func ValidatePackages(packages []types.Package, file string, results *types.Vali
 		}
 
 		validateEnum(pkg.Action, fmt.Sprintf("packages[%d].action", i),
-			[]string{types.ActionInstall, types.ActionRemove, types.ActionUpdate}, file, results)
+			[]string{types.ActionInstall, types.ActionRemove}, file, results)
 
 		// package_manager is optional: without one, the package is installed by the
 		// default manager detected for this machine, which is the common case.
@@ -107,6 +107,11 @@ func ValidateGitRepositories(gitRepositories []types.Git, file string, results *
 		validateRequired(repo.Path, fmt.Sprintf("git[%d].path", i), file, results, "Add path field to git repository")
 
 		validatePath(repo.Path, fmt.Sprintf("git repository '%s'", repo.URL), file, results)
+
+		if repo.Action != "" {
+			validateEnum(repo.Action, fmt.Sprintf("git[%d].action", i),
+				[]string{types.GitActionClone, types.GitActionPull}, file, results)
+		}
 	}
 }
 

--- a/internal/validate/helpers.go
+++ b/internal/validate/helpers.go
@@ -170,7 +170,7 @@ func validatePackagesWithVisited(packages []types.Package, file string, results 
 		}
 		validateRequired(pkg.Name, fmt.Sprintf("packages[%d].name", i), file, results, "Add name field to package")
 		validateEnum(pkg.Action, fmt.Sprintf("packages[%d].action", i),
-			[]string{types.ActionInstall, types.ActionRemove, types.ActionUpdate}, file, results)
+			[]string{types.ActionInstall, types.ActionRemove}, file, results)
 	}
 }
 
@@ -202,6 +202,10 @@ func validateGitWithVisited(repos []types.Git, file string, results *types.Valid
 		if repo.Import != "" {
 			validateImportWithVisited(repo.Import, fmt.Sprintf("git[%d]", i), blueprintDir, file, results, &types.GitData{}, visited)
 			continue
+		}
+		if repo.Action != "" {
+			validateEnum(repo.Action, fmt.Sprintf("git[%d].action", i),
+				[]string{types.GitActionClone, types.GitActionPull}, file, results)
 		}
 		validateRequired(repo.URL, fmt.Sprintf("git[%d].url", i), file, results, "Add URL field to git repository")
 	}

--- a/internal/validate/recursion_test.go
+++ b/internal/validate/recursion_test.go
@@ -62,7 +62,7 @@ func TestValidateBlueprints_AcceptsAValidNestedTree(t *testing.T) {
 		"scripts/setup.yaml":    "scripts:\n  - name: setup.sh\n    action: run\n    source: ./bin\n",
 		"git/repos.yaml":        "git:\n  - name: dots\n    action: clone\n    url: https://example.invalid/d.git\n    path: /tmp/dots\n",
 		"fonts/nerd.yaml":       "fonts:\n  - name: FiraCode\n    action: install\n",
-		"configuration/ui.yaml": "configuration:\n  - name: theme\n    type: dconf\n    action: set\n    key: /org/gnome/theme\n    value: dark\n",
+		"configuration/ui.yaml": "configurations:\n  - name: theme\n    tool: dconf\n    action: set\n    key: /org/gnome/theme\n    value: dark\n",
 	})
 
 	results := &types.ValidationResults{}


### PR DESCRIPTION
Stacked on #163. **Behaviorally the most user-visible PR in the stack.**

Blueprints now **decode strictly**: an unknown key is an error in YAML, JSON and TOML. A silently ignored key is a blueprint that looks applied and is not — `pacakges:` yielded an empty section, every processor found nothing to do, and the run reported success having changed nothing. A misspelled `profiles` is worse: the entry loses its scoping and runs on every machine. The `blueprint-validation` spec already required this and listed it as an unimplemented gap. Enabling it immediately caught a wrong key in one of our own test fixtures. The `schema_version` probe stays lenient, since it reads one key out of a document whose version is not yet known.

Several fields were accepted from blueprints and read by nothing — the same failure wearing a different hat:

- **`variables.userDefined`** — documented in `docs/variables.md`, used by the shipped examples — decoded into nothing (`Variables` carried only mapstructure tags and was embedded squashed) *and* was overwritten with the computed defaults immediately after. Every `{{ .UserDefined.x }}` rendered empty. It now decodes and survives, while Flags/User/System stay non-decodable so a blueprint cannot claim to run as a different user than it does.
- **`asUser` on a script** had no field on `types.Script` at all, though the examples used it. Now maps to `sudo -u`, with `elevated` winning and warning if both are set.
- **`git` `action`** was decoded and never read, so `action: pull` cloned anyway and `action: banana` was accepted. Now honored and validated.
- **The per-package `update` action is removed rather than implemented.** Validation accepted it and the processor rejected it, so it passed `rwr validate` and then failed the run — and it cannot be built on the providers' `update` commands, which disagree about what update means (apt refreshes lists, pacman does a full system upgrade).
- **`remove`/`delete` on users**: each name previously failed at the opposite end of the run. Both are accepted now.
- `blueprints.templatesEnabled` is deleted; templates were always processed regardless.
- Package `elevated` is honored; package names may not begin with `-` (read as options by every package manager); `ssh_keys` `type`/`path` get defaults instead of producing `ssh-keygen -t ""` and a key in the cwd.

Package, git and ssh_key failures move onto the run ledger. The GitHub key upload now expands `~` — with `path: ~/.ssh` it read a literal `~/.ssh` relative to the cwd, failed, and was swallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)