### PR TITLE
fix(processors): make registryInt compile on 32-bit platforms

### DIFF
--- a/internal/processors/configuration.go
+++ b/internal/processors/configuration.go
@@ -427,7 +427,7 @@ func registryInt(value interface{}) (int64, error) {
 	case int64:
 		return v, nil
 	case uint:
-		if v > math.MaxInt64 {
+		if uint64(v) > math.MaxInt64 {
 			return 0, fmt.Errorf("value %d is too large for a registry integer", v)
 		}
 		return int64(v), nil


### PR DESCRIPTION
## Summary
The release build failed for the `linux_arm_7` target:

```
internal/processors/configuration.go:430:10: math.MaxInt64 (untyped int constant 9223372036854775807) overflows uint
```

On 32-bit platforms `uint` is 32 bits, so the constant comparison `v > math.MaxInt64` in `registryInt` doesn't compile. This widens the value to `uint64` before comparing, which is correct on all platforms (on 32-bit the branch is simply never taken).

Verified with `GOOS=linux GOARCH=arm GOARM=7 go build ./...` plus a host build, `go vet`, and the full test suite (ran in the pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)