### PR TITLE
fix(files): resolve absolute and URL sources instead of mangling them

### DIFF
--- a/internal/processors/files.go
+++ b/internal/processors/files.go
@@ -133,7 +133,11 @@ func processFile(file types.File, blueprintDir string, osInfo *types.OSInfo) err
 		}()
 
 		log.Debug("Downloading Source File")
-		downloadPath := filepath.Join(tempDir, filepath.Base(file.Source))
+		name := file.Name
+		if name == "" {
+			name = filepath.Base(file.Source)
+		}
+		downloadPath := filepath.Join(tempDir, name)
 		err = system.DownloadFile(file.Source, downloadPath, false)
 		if err != nil {
 			return fmt.Errorf("error downloading file: %v", err)
@@ -141,7 +145,7 @@ func processFile(file types.File, blueprintDir string, osInfo *types.OSInfo) err
 
 		log.Debug("Setting File Source and Name")
 		file.Source = filepath.Dir(downloadPath)
-		file.Name = filepath.Base(downloadPath)
+		file.Name = name
 	}
 
 	// If Content exists, we'll always use it and perform a create action
@@ -745,6 +749,11 @@ func determineSourceAndTargetPaths(file types.File, blueprintDir string) (string
 	} else if file.Content != "" {
 		log.Debug("File Content present, sourcePath will be empty")
 		sourcePath = ""
+	} else if filepath.IsAbs(file.Source) {
+		// An absolute source stands on its own: joining it under blueprintDir
+		// would silently produce <blueprintDir>/<abs path>, a path that never
+		// exists. URL downloads land here too, via their absolute temp dir.
+		sourcePath = filepath.Join(file.Source, file.Name)
 	} else {
 		sourcePath = filepath.Join(blueprintDir, file.Source, file.Name)
 	}

--- a/internal/processors/files_test.go
+++ b/internal/processors/files_test.go
@@ -1,6 +1,8 @@
 package processors
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -797,5 +799,98 @@ files:
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
 		t.Errorf("copied file mode = %04o, want 0600", got)
+	}
+}
+
+// A URL source downloads to an absolute temp path; the path resolution must
+// use that path as-is, not join it under the blueprint directory.
+func TestProcessFiles_URLSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("downloaded contents"))
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	blueprintDir := filepath.Join(tempDir, "blueprints")
+
+	config := &types.InitConfig{
+		Init: types.Init{
+			Location: blueprintDir,
+			Format:   "yaml",
+		},
+		Variables: types.Variables{
+			Flags: types.Flags{
+				Debug: true,
+			},
+		},
+	}
+
+	osInfo := &types.OSInfo{}
+
+	blueprintData := `
+files:
+  - name: "fetched.conf"
+    action: "copy"
+    source: "` + server.URL + `/remote.conf"
+    target: "` + tempDir + `/"
+`
+
+	if err := ProcessFiles([]byte(blueprintData), blueprintDir, "yaml", osInfo, config); err != nil {
+		t.Fatalf("ProcessFiles with URL source failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(tempDir, "fetched.conf"))
+	if err != nil {
+		t.Fatalf("expected downloaded file at target: %v", err)
+	}
+	if string(got) != "downloaded contents" {
+		t.Errorf("target content = %q, want %q", got, "downloaded contents")
+	}
+}
+
+// An absolute local source must not be joined under the blueprint directory.
+func TestProcessFiles_AbsoluteSource(t *testing.T) {
+	tempDir := t.TempDir()
+	blueprintDir := filepath.Join(tempDir, "blueprints")
+	srcDir := filepath.Join(tempDir, "srcdir")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "abs.conf"), []byte("abs contents"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	config := &types.InitConfig{
+		Init: types.Init{
+			Location: blueprintDir,
+			Format:   "yaml",
+		},
+		Variables: types.Variables{
+			Flags: types.Flags{
+				Debug: true,
+			},
+		},
+	}
+
+	osInfo := &types.OSInfo{}
+
+	blueprintData := `
+files:
+  - name: "abs.conf"
+    action: "copy"
+    source: "` + srcDir + `"
+    target: "` + tempDir + `/out/"
+`
+
+	if err := ProcessFiles([]byte(blueprintData), blueprintDir, "yaml", osInfo, config); err != nil {
+		t.Fatalf("ProcessFiles with absolute source failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(tempDir, "out", "abs.conf"))
+	if err != nil {
+		t.Fatalf("expected copied file at target: %v", err)
+	}
+	if string(got) != "abs contents" {
+		t.Errorf("target content = %q, want %q", got, "abs contents")
 	}
 }


### PR DESCRIPTION
## Summary
URL file sources have never worked: the download succeeds into an absolute temp dir, but `determineSourceAndTargetPaths` joins every source under `blueprintDir`. `filepath.Join` doesn't reset on an absolute element, so the source resolves to `<blueprintDir>/tmp/rwr-download-X/<name>` — which never exists — and the copy fails on every run. Absolute local sources were mangled identically.

## Changes
- `determineSourceAndTargetPaths` treats an absolute `source` as its own root instead of joining it under the blueprint dir. URL downloads land here via their absolute temp dir.
- The download no longer overwrites a user-specified `name` with the URL basename, so `name:` controls the target filename as documented.

## Tests
- `TestProcessFiles_URLSource` — httptest server → real `ProcessFiles` → asserts downloaded content lands at the target. Fails on master with the mangled-path error.
- `TestProcessFiles_AbsoluteSource` — absolute local source dir → asserts the copy lands. Also fails on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)