### PR TITLE
fix(configuration): feed dconf load its keyfile on stdin

### DIFF
--- a/internal/processors/configuration.go
+++ b/internal/processors/configuration.go
@@ -88,13 +88,21 @@ func processDconf(blueprintDir string, config types.Configuration, initConfig *t
 		}
 	}
 
+	// dconf load reads the keyfile from stdin; there is no file argument. A
+	// literal "<" in argv is not a redirection — commands run without a shell.
+	keyfile, err := os.ReadFile(file) // #nosec G304 -- blueprint-relative path, resolved above
+	if err != nil {
+		return fmt.Errorf("error reading dconf keyfile: %w", err)
+	}
+
 	cmd := types.Command{
 		Exec:     "dconf",
-		Args:     []string{"load", "/", "<", file},
+		Args:     []string{"load", "/"},
+		Stdin:    string(keyfile),
 		Elevated: config.Elevated,
 	}
 
-	err := system.RunCommand(cmd, initConfig.Variables.Flags.Debug)
+	err = system.RunCommand(cmd, initConfig.Variables.Flags.Debug)
 
 	if err != nil {
 		return fmt.Errorf("error applying dconf configuration: %w", err)

--- a/internal/processors/configuration_dconf_test.go
+++ b/internal/processors/configuration_dconf_test.go
@@ -1,0 +1,68 @@
+package processors
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// dconf load takes the keyfile on stdin. Commands run without a shell, so a
+// "<" in argv is not a redirection — it reaches dconf as a literal argument
+// and the keyfile is never read.
+func TestProcessDconf_LoadsKeyfileViaStdin(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	blueprintDir := t.TempDir()
+	keyfile := "[org/gnome/desktop/interface]\ncolor-scheme='prefer-dark'\n"
+	if err := os.WriteFile(filepath.Join(blueprintDir, "desktop.ini"), []byte(keyfile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	config := types.Configuration{
+		Name: "desktop",
+		Tool: "dconf",
+		File: "desktop.ini",
+	}
+	initConfig := &types.InitConfig{}
+
+	if err := processDconf(blueprintDir, config, initConfig); err != nil {
+		t.Fatalf("processDconf: %v", err)
+	}
+
+	if len(rec.Calls) != 1 {
+		t.Fatalf("recorded %d calls, want 1: %v", len(rec.Calls), rec.Calls)
+	}
+	call := rec.Calls[0]
+
+	if want := []string{"dconf", "load", "/"}; !reflect.DeepEqual(call.Argv(), want) {
+		t.Errorf("argv = %v, want %v", call.Argv(), want)
+	}
+	if call.Stdin != keyfile {
+		t.Errorf("stdin = %q, want the keyfile contents %q", call.Stdin, keyfile)
+	}
+}
+
+// A missing keyfile must error before any command runs.
+func TestProcessDconf_MissingKeyfile(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	config := types.Configuration{
+		Name: "desktop",
+		Tool: "dconf",
+		File: "nope.ini",
+	}
+
+	if err := processDconf(t.TempDir(), config, &types.InitConfig{}); err == nil {
+		t.Fatal("expected an error for a missing keyfile")
+	}
+	if len(rec.Calls) != 0 {
+		t.Fatalf("no command should run, got %v", rec.Calls)
+	}
+}


### PR DESCRIPTION
## Summary
`dconf` configurations have never applied: the command was built as `dconf load / < file`, but commands are exec'd without a shell, so `<` reached dconf as a literal argument and the keyfile was never read.

## Changes
- `processDconf` reads the keyfile and passes it via `Command.Stdin` (the mechanism `setLinuxPassword` already uses), invoking `dconf load /` as dconf expects.
- A missing keyfile now errors before any command runs.

## Tests
Recorder-based (`exectest` + `system.SetExecutor`), asserting the exact argv `[dconf load /]` and that stdin carries the keyfile contents. Both fail on master — the argv there is `[dconf load / < …/desktop.ini]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)