### PR TITLE
fix(providers): never search the CWD when HOME is unset

### DIFF
--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -291,10 +291,18 @@ func GetProvidersPath() (string, error) {
 
 	// Check common locations for the providers directory
 	locations := []string{
-		filepath.Join(execDir, "providers"),                       // Next to executable
-		"/usr/local/share/rwr/providers",                          // System-wide installation
-		"/usr/share/rwr/providers",                                // System-wide installation
-		filepath.Join(os.Getenv("HOME"), ".config/rwr/providers"), // RWR Config Path
+		filepath.Join(execDir, "providers"), // Next to executable
+		"/usr/local/share/rwr/providers",    // System-wide installation
+		"/usr/share/rwr/providers",          // System-wide installation
+	}
+
+	// $HOME via Getenv would be empty under systemd/cron/sudo env -i (and always
+	// on Windows), and joining "" yields a relative path that os.Stat resolves
+	// against the CWD — exactly the directory this search must never honour.
+	if home, err := os.UserHomeDir(); err == nil {
+		locations = append(locations, filepath.Join(home, ".config/rwr/providers")) // RWR Config Path
+	} else {
+		log.Debugf("Skipping user provider path: no home directory: %v", err)
 	}
 
 	// Add macOS-specific paths
@@ -307,6 +315,10 @@ func GetProvidersPath() (string, error) {
 	}
 
 	for _, loc := range locations {
+		// A relative candidate would resolve against the CWD; never probe one.
+		if !filepath.IsAbs(loc) {
+			continue
+		}
 		if _, err := os.Stat(loc); err == nil { // #nosec G703 -- TODO(PR8): path derived from operator blueprint input; containment added in PR8
 			log.Debugf("Found providers directory at: %s", loc)
 			return loc, nil

--- a/internal/system/providers_path_test.go
+++ b/internal/system/providers_path_test.go
@@ -1,0 +1,52 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// With HOME unset, the user-config candidate must be dropped, not degrade to
+// the relative path ".config/rwr/providers" — which os.Stat would resolve
+// against the CWD, honouring a providers directory planted in whatever
+// directory rwr is run from (a cloned repo, /tmp). GetProvidersPath's own doc
+// comment rules the CWD out of the search.
+func TestGetProvidersPath_UnsetHomeNeverSearchesCWD(t *testing.T) {
+	// A CWD that contains the path the buggy join produces.
+	cwd := t.TempDir()
+	planted := filepath.Join(cwd, ".config/rwr/providers")
+	if err := os.MkdirAll(planted, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(orig); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// t.Setenv restores these afterwards. Empty HOME makes os.UserHomeDir fail
+	// on unix; USERPROFILE covers windows.
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+
+	got, err := GetProvidersPath()
+	if err != nil {
+		// No providers directory found at all is the correct outcome when the
+		// only candidate was the planted CWD one.
+		return
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("GetProvidersPath returned a relative path %q — resolved against the CWD", got)
+	}
+	if got == planted || got == ".config/rwr/providers" {
+		t.Fatalf("GetProvidersPath honoured a providers directory under the CWD: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
With `HOME` unset (systemd units, cron, `sudo env -i`, and always on Windows), `filepath.Join(os.Getenv("HOME"), ".config/rwr/providers")` degrades to the **relative** path `.config/rwr/providers`, which `os.Stat` resolves against the CWD. That reopens exactly the hole the function's doc comment closes: a `.config/rwr/providers/evil.toml` in a cloned repo gets its `exec`/`args`/`elevated=true` run verbatim.

## Changes
- Use `os.UserHomeDir()` (also correct on Windows via `USERPROFILE`) and skip the user-config candidate when no home directory exists.
- Backstop: the search loop refuses to probe any non-absolute candidate.

## Tests
`TestGetProvidersPath_UnsetHomeNeverSearchesCWD` plants `.config/rwr/providers` in a temp CWD, blanks `HOME`/`USERPROFILE`, and asserts the CWD directory is never honoured. On master it fails: the function returns the relative path `.config/rwr/providers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)