### PR TITLE
ci: cross-compile every release target on pull requests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,6 +58,36 @@ jobs:
         continue-on-error: true
         run: go test -race -v ./...
 
+  # The build matrix above compiles natively: linux/amd64, darwin/arm64,
+  # windows/amd64. The release ships more targets than that — linux/arm 32-bit,
+  # linux/riscv64, linux/arm64, windows/arm64, darwin/amd64 — and none of them
+  # was compiled before merge, so a target-specific break (a constant that
+  # overflows 32-bit int, a missing syscall) surfaced only when the release ran.
+  # That is exactly how the linux_arm_7 math.MaxInt64 break reached master.
+  #
+  # goreleaser build compiles every target from .goreleaser.yaml itself, so this
+  # job can never drift from the release matrix. CGO is off; all targets
+  # cross-compile from one runner.
+  cross-compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # goreleaser reads git state; a shallow clone breaks its version math.
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: ">=1.26.5"
+
+      - name: Build every release target
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: build --snapshot --clean
+
   # golangci-lint gates every commit locally, through mise (`mise run lint`) and
   # the hk pre-commit hook — but only for contributors who ran `mise install`.
   # Anyone else got no lint at all, and neither did any pull request.


### PR DESCRIPTION
## Summary
PR CI builds natively on ubuntu/macos/windows — linux/amd64, darwin/arm64, windows/amd64. The release matrix additionally ships linux/arm (32-bit), linux/riscv64, linux/arm64, windows/arm64, and darwin/amd64, none of which were compiled before merge. A target-specific break therefore surfaced only at release time — exactly how the `linux_arm_7` `math.MaxInt64` overflow (fixed in #169) reached master with green CI.

## Changes
Adds a `cross-compile` job running `goreleaser build --snapshot --clean` on PRs and master pushes. It compiles every target from `.goreleaser.yaml` itself, so the gate can't drift from the release matrix. CGO is off, so everything cross-compiles from one ubuntu runner (~3 min, parallel with the other jobs).

## Verification
The job's own first run on this PR is the test; as a negative check, reverting #169 locally and running `goreleaser build --snapshot` fails on `linux_arm_7` — this job would have blocked that merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)