### PR TITLE
fix(repositories): give snap and gnome-extensions their missing fields

### DIFF
--- a/internal/processors/repository.go
+++ b/internal/processors/repository.go
@@ -264,6 +264,12 @@ func repositoryStepData(repo types.Repository, paths types.RepositoryPaths, prov
 		"ProxyURL":    repo.ProxyURL,
 		"UUID":        repo.UUID,
 		"ExtensionID": repo.ExtensionID,
+		"Interface":   repo.Interface,
+		"Slot":        repo.Slot,
+
+		// Not a derived predicate: whether removing a GNOME extension also
+		// resets its settings is operator intent, straight from the blueprint.
+		"ResetSettings": repo.ResetSettings,
 
 		// Credentials reach the provider's argv because that is the only way
 		// chocolatey and cargo can be told about a private source. They are kept out
@@ -295,6 +301,8 @@ func repositoryPredicates(repo types.Repository, provider *types.Provider) map[s
 
 	return map[string]any{
 		"HasKey":            repo.KeyURL != "" || repo.KeyID != "",
+		"HasInterfaces":     repo.Interface != "",
+		"HasSlot":           repo.Slot != "",
 		"HasProxy":          repo.ProxyURL != "",
 		"HasToken":          repo.Token != "",
 		"HasAuthentication": repo.Username != "" || repo.Password != "",

--- a/internal/processors/repository_snap_gnome_test.go
+++ b/internal/processors/repository_snap_gnome_test.go
@@ -1,0 +1,136 @@
+package processors
+
+import (
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// The shipped snap provider gates its last add step on HasInterfaces, which was
+// absent from the predicates map — an underivable predicate is a hard error, so
+// every snap repository add failed at that step, interface or no interface.
+func TestProcessRepositories_SnapAddWithoutInterface(t *testing.T) {
+	sourcesDir, keysDir := repoDirs(t)
+	provider := providerForTest(t, "snap", sourcesDir, keysDir)
+
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+	defer system.SetProvidersForTest(map[string]*types.Provider{"snap": provider})()
+
+	if err := processRepositories([]types.Repository{{
+		Name:           "bitwarden",
+		PackageManager: "snap",
+		Action:         "add",
+		URL:            "https://snapcraft.io/bitwarden",
+	}}, &types.OSInfo{}, &types.InitConfig{}); err != nil {
+		t.Fatalf("processRepositories: %v", err)
+	}
+
+	calls := rec.Find("snap")
+	if len(calls) != 1 {
+		t.Fatalf("recorded %d snap calls, want 1 (install only): %v", len(calls), rec.Calls)
+	}
+	want := []string{"snap", "install", "bitwarden"}
+	if got := calls[0].Argv(); !equalStrings(got, want) {
+		t.Errorf("snap argv = %#v, want %#v", got, want)
+	}
+	assertNoPlaceholders(t, rec)
+}
+
+// interface/slot on the blueprint drive the connect step after the install.
+func TestProcessRepositories_SnapAddConnectsInterface(t *testing.T) {
+	sourcesDir, keysDir := repoDirs(t)
+
+	for _, tt := range []struct {
+		name        string
+		slot        string
+		wantConnect []string
+	}{
+		{
+			name:        "named slot",
+			slot:        "core:home",
+			wantConnect: []string{"snap", "connect", "bitwarden:password-manager-service", "core:home"},
+		},
+		{
+			name:        "system slot",
+			slot:        "",
+			wantConnect: []string{"snap", "connect", "bitwarden:password-manager-service"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := providerForTest(t, "snap", sourcesDir, keysDir)
+
+			rec := exectest.New()
+			defer system.SetExecutor(rec)()
+			defer system.SetProvidersForTest(map[string]*types.Provider{"snap": provider})()
+
+			if err := processRepositories([]types.Repository{{
+				Name:           "bitwarden",
+				PackageManager: "snap",
+				Action:         "add",
+				URL:            "https://snapcraft.io/bitwarden",
+				Interface:      "password-manager-service",
+				Slot:           tt.slot,
+			}}, &types.OSInfo{}, &types.InitConfig{}); err != nil {
+				t.Fatalf("processRepositories: %v", err)
+			}
+
+			calls := rec.Find("snap")
+			if len(calls) != 2 {
+				t.Fatalf("recorded %d snap calls, want install + connect: %v", len(calls), rec.Calls)
+			}
+			if got := calls[1].Argv(); !equalStrings(got, tt.wantConnect) {
+				t.Errorf("connect argv = %#v, want %#v", got, tt.wantConnect)
+			}
+			assertNoPlaceholders(t, rec)
+		})
+	}
+}
+
+// The shipped gnome-extensions provider gates its last remove step on
+// ResetSettings, which no blueprint field carried — so every extension remove
+// failed at the reset step.
+func TestProcessRepositories_GnomeExtensionsRemove(t *testing.T) {
+	sourcesDir, keysDir := repoDirs(t)
+
+	for _, tt := range []struct {
+		name      string
+		reset     bool
+		wantCalls int
+	}{
+		{name: "keep settings", reset: false, wantCalls: 2},
+		{name: "reset settings", reset: true, wantCalls: 3},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := providerForTest(t, "gnome-extensions", sourcesDir, keysDir)
+
+			rec := exectest.New()
+			defer system.SetExecutor(rec)()
+			defer system.SetProvidersForTest(map[string]*types.Provider{"gnome-extensions": provider})()
+
+			if err := processRepositories([]types.Repository{{
+				Name:           "dash-to-dock",
+				PackageManager: "gnome-extensions",
+				Action:         "remove",
+				UUID:           "dash-to-dock@micxgx.gmail.com",
+				ResetSettings:  tt.reset,
+			}}, &types.OSInfo{}, &types.InitConfig{}); err != nil {
+				t.Fatalf("processRepositories: %v", err)
+			}
+
+			calls := rec.Find("gnome-extensions")
+			if len(calls) != tt.wantCalls {
+				t.Fatalf("recorded %d calls, want %d: %v", len(calls), tt.wantCalls, rec.Calls)
+			}
+			if tt.reset {
+				want := []string{"gnome-extensions", "reset", "dash-to-dock@micxgx.gmail.com"}
+				if got := calls[2].Argv(); !equalStrings(got, want) {
+					t.Errorf("reset argv = %#v, want %#v", got, want)
+				}
+			}
+			assertNoPlaceholders(t, rec)
+		})
+	}
+}

--- a/internal/system/definitions/providers/snap.toml
+++ b/internal/system/definitions/providers/snap.toml
@@ -47,7 +47,13 @@ condition = "{{ .IsLocalSnap }}"  # For sideloading local snap files
 action = "command"
 exec = "snap"
 args = ["connect", "{{ .Name }}:{{ .Interface }}", "{{ .Slot }}"]
-condition = "{{ .HasInterfaces }}"  # For connecting interfaces if specified
+condition = "{{ and .HasInterfaces .HasSlot }}"  # Connect to a named slot
+
+[[provider.repository.add.steps]]
+action = "command"
+exec = "snap"
+args = ["connect", "{{ .Name }}:{{ .Interface }}"]
+condition = "{{ and .HasInterfaces (not .HasSlot) }}"  # No slot named: snapd picks the system one
 
 [[provider.repository.remove.steps]]
 action = "command"

--- a/internal/types/repository.go
+++ b/internal/types/repository.go
@@ -19,8 +19,11 @@ type Repository struct {
 	ProxyURL       string   `mapstructure:"proxy_url,omitempty" yaml:"proxy_url,omitempty" json:"proxy_url,omitempty" toml:"proxy_url,omitempty"` // Proxy snapd should route through
 	UUID           string   `mapstructure:"uuid,omitempty" yaml:"uuid,omitempty" json:"uuid,omitempty" toml:"uuid,omitempty"`                     // GNOME extension UUID
 	ExtensionID    string   `mapstructure:"extension_id,omitempty" yaml:"extension_id,omitempty" json:"extension_id,omitempty" toml:"extension_id,omitempty"`
-	Interactive    *bool    `mapstructure:"interactive,omitempty" yaml:"interactive,omitempty" json:"interactive,omitempty" toml:"interactive,omitempty"` // Override global interactive mode
-	Import         string   `mapstructure:"import,omitempty" yaml:"import,omitempty" json:"import,omitempty" toml:"import,omitempty"`                     // Import path for external repository definitions
+	Interface      string   `mapstructure:"interface,omitempty" yaml:"interface,omitempty" json:"interface,omitempty" toml:"interface,omitempty"`                     // Snap interface to connect after install (snap connect <name>:<interface> <slot>)
+	Slot           string   `mapstructure:"slot,omitempty" yaml:"slot,omitempty" json:"slot,omitempty" toml:"slot,omitempty"`                                         // Slot the snap interface plugs into
+	ResetSettings  bool     `mapstructure:"reset_settings,omitempty" yaml:"reset_settings,omitempty" json:"reset_settings,omitempty" toml:"reset_settings,omitempty"` // Reset a GNOME extension's settings when removing it
+	Interactive    *bool    `mapstructure:"interactive,omitempty" yaml:"interactive,omitempty" json:"interactive,omitempty" toml:"interactive,omitempty"`             // Override global interactive mode
+	Import         string   `mapstructure:"import,omitempty" yaml:"import,omitempty" json:"import,omitempty" toml:"import,omitempty"`                                 // Import path for external repository definitions
 
 	// Credentials a provider needs to authenticate against a private repository:
 	// chocolatey signs a source in with Username/Password, cargo with Token.


### PR DESCRIPTION
## Summary
Two shipped providers reference predicates rwr could never derive, and an underivable condition is (deliberately) a hard error — so:
- **every snap repository `add`** failed at the `{{ .HasInterfaces }}` connect step, interface or not;
- **every gnome-extensions `remove`** failed at the `{{ .ResetSettings }}` reset step.

## Changes
- `types.Repository` gains `interface`, `slot`, and `reset_settings`.
- Predicates: `HasInterfaces`/`HasSlot` derived from the new fields; `ResetSettings` passed through as step data (operator intent, not derived).
- snap's connect step split in two: a named slot connects to it, no slot lets snapd pick the system one — instead of rendering an empty argv element.

## Tests
Recorder-based over the real embedded providers: snap add without interface (install only — fails on master with the HasInterfaces error), with interface ± slot (exact connect argv), gnome-extensions remove ± reset_settings (2 vs 3 calls, exact reset argv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)