### PR TITLE
fix(run): record failures from files, services, repositories and fonts

### DIFF
--- a/internal/processors/failures_coverage_test.go
+++ b/internal/processors/failures_coverage_test.go
@@ -1,0 +1,137 @@
+package processors
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// The ledger contract (failures.go): a processor keeps going when one item
+// fails, records the failure, and All() turns the ledger into the exit code.
+// packages, git, ssh_keys and configuration honored it; files, services,
+// repositories and fonts aborted the whole run on the first bad item instead.
+// These tests pin the contract for the four late joiners: the bad item is
+// recorded, the good item still happens, the processor returns nil.
+
+func TestProcessFiles_BadFileDoesNotStopTheRest(t *testing.T) {
+	resetFailures()
+	defer resetFailures()
+
+	tempDir := t.TempDir()
+	blueprintDir := filepath.Join(tempDir, "blueprints")
+
+	config := &types.InitConfig{
+		Init:      types.Init{Location: blueprintDir, Format: "yaml"},
+		Variables: types.Variables{Flags: types.Flags{Debug: true}},
+	}
+
+	// The first file's source does not exist; the second is a plain create.
+	blueprintData := `
+files:
+  - name: "missing.conf"
+    action: "copy"
+    source: "does-not-exist"
+    target: "` + tempDir + `/"
+  - name: "good.conf"
+    action: "create"
+    content: "key = value"
+    target: "` + tempDir + `/"
+`
+
+	if err := ProcessFiles([]byte(blueprintData), blueprintDir, "yaml", &types.OSInfo{}, config); err != nil {
+		t.Fatalf("ProcessFiles = %v, want nil: item failures belong in the ledger", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tempDir, "good.conf")); err != nil {
+		t.Errorf("the file after the failing one was not processed: %v", err)
+	}
+	if got := failureCount(); got != 1 {
+		t.Errorf("failureCount() = %d, want 1", got)
+	}
+}
+
+func TestProcessServices_BadServiceDoesNotStopTheRest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("asserts the linux/darwin service command path")
+	}
+	resetFailures()
+	defer resetFailures()
+
+	rec := exectest.New()
+	rec.Err = errors.New("boom")
+	defer system.SetExecutor(rec)()
+
+	services := []types.Service{
+		{Name: "first", Action: "enable"},
+		{Name: "second", Action: "enable"},
+	}
+
+	if err := processServices(services, &types.OSInfo{}, &types.InitConfig{}); err != nil {
+		t.Fatalf("processServices = %v, want nil: item failures belong in the ledger", err)
+	}
+
+	if len(rec.Calls) != 2 {
+		t.Errorf("recorded %d calls, want 2 — the second service must still be attempted: %v", len(rec.Calls), rec.Calls)
+	}
+	if got := failureCount(); got != 2 {
+		t.Errorf("failureCount() = %d, want 2", got)
+	}
+}
+
+func TestProcessRepositories_BadRepositoryDoesNotStopTheRest(t *testing.T) {
+	resetFailures()
+	defer resetFailures()
+
+	sourcesDir, keysDir := repoDirs(t)
+	provider := providerForTest(t, "flatpak", sourcesDir, keysDir)
+
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+	defer system.SetProvidersForTest(map[string]*types.Provider{"flatpak": provider})()
+
+	if err := processRepositories([]types.Repository{
+		{Name: "broken", PackageManager: "no-such-manager", Action: "add", URL: "https://example.com"},
+		{Name: "flathub", PackageManager: "flatpak", Action: "add", URL: "https://dl.flathub.org/repo/flathub.flatpakrepo"},
+	}, &types.OSInfo{}, &types.InitConfig{}); err != nil {
+		t.Fatalf("processRepositories = %v, want nil: item failures belong in the ledger", err)
+	}
+
+	if calls := rec.Find("flatpak"); len(calls) == 0 {
+		t.Errorf("the repository after the failing one was not processed: %v", rec.Calls)
+	}
+	if got := failureCount(); got != 1 {
+		t.Errorf("failureCount() = %d, want 1", got)
+	}
+}
+
+func TestProcessFonts_UnreachableReleaseLookupIsALedgerFailure(t *testing.T) {
+	resetFailures()
+	defer resetFailures()
+
+	orig := nerdFontRepoAPI
+	nerdFontRepoAPI = "http://127.0.0.1:0/unreachable"
+	defer func() { nerdFontRepoAPI = orig }()
+
+	blueprintData := `
+fonts:
+  - name: "FiraCode"
+    action: "install"
+`
+
+	config := &types.InitConfig{
+		Variables: types.Variables{Flags: types.Flags{Debug: true}},
+	}
+
+	if err := ProcessFonts([]byte(blueprintData), "", "yaml", &types.OSInfo{}, config); err != nil {
+		t.Fatalf("ProcessFonts = %v, want nil: the failed lookup belongs in the ledger", err)
+	}
+	if got := failureCount(); got != 1 {
+		t.Errorf("failureCount() = %d, want 1", got)
+	}
+}

--- a/internal/processors/files.go
+++ b/internal/processors/files.go
@@ -92,6 +92,8 @@ func resolveAndFilterFileData(blueprintData []byte, blueprintDir string, format 
 	return filteredFiles, filteredDirs, filteredTemplates, nil
 }
 
+// One file failing does not stop the rest: the failure goes to the ledger,
+// which puts it in the run's exit code, and processing continues.
 func processFiles(files []types.File, blueprintDir string, osInfo *types.OSInfo) error {
 	for _, file := range files {
 		if len(file.Names) > 0 {
@@ -99,12 +101,12 @@ func processFiles(files []types.File, blueprintDir string, osInfo *types.OSInfo)
 				fileWithName := file
 				fileWithName.Name = name
 				if err := processFile(fileWithName, blueprintDir, osInfo); err != nil {
-					return fmt.Errorf("error processing file %s: %w", name, err)
+					recordFailure("files", name, err)
 				}
 			}
 		} else {
 			if err := processFile(file, blueprintDir, osInfo); err != nil {
-				return fmt.Errorf("error processing file %s: %w", file.Name, err)
+				recordFailure("files", file.Name, err)
 			}
 		}
 	}
@@ -218,16 +220,14 @@ func processTemplates(templates []types.File, blueprintDir string, osInfo *types
 				fileWithName.Name = name
 				err := processTemplate(fileWithName, blueprintDir, osInfo, initConfig)
 				if err != nil {
-					log.Errorf("Error processing template to file %s: %v", fileWithName.Name, err)
-					return fmt.Errorf("error processing template to file %s: %w", fileWithName.Name, err)
+					recordFailure("templates", fileWithName.Name, err)
 				}
 			}
 		} else {
 			log.Infof("Processing single template: %s", tmpl.Name)
 			err := processTemplate(tmpl, blueprintDir, osInfo, initConfig)
 			if err != nil {
-				log.Errorf("Error processing template to file %s: %v", tmpl.Name, err)
-				return fmt.Errorf("error processing template to file %s: %w", tmpl.Name, err)
+				recordFailure("templates", tmpl.Name, err)
 			}
 		}
 	}
@@ -299,42 +299,49 @@ func processDirectories(directories []types.Directory, blueprintDir string, init
 			log.Infof("[DRY-RUN] Would %s directory: %s (target: %s)", dir.Action, dir.Name, dir.Target)
 			continue
 		}
-		switch dir.Action {
-		case "copy":
-			if err := copyDirectory(dir, blueprintDir, initConfig); err != nil {
-				return fmt.Errorf("error copying directory: %w", err)
-			}
-		case "move":
-			if err := moveDirectory(dir, blueprintDir); err != nil {
-				return fmt.Errorf("error moving directory: %w", err)
-			}
-		case "delete":
-			if err := deleteDirectory(dir); err != nil {
-				return fmt.Errorf("error deleting directory: %w", err)
-			}
-		case "create":
-			if err := createDirectory(dir); err != nil {
-				return fmt.Errorf("error creating directory: %w", err)
-			}
-		case "chmod":
-			if err := chmodDirectory(dir); err != nil {
-				return fmt.Errorf("error changing directory permissions: %w", err)
-			}
-		case "chown":
-			if err := chownDirectory(dir); err != nil {
-				return fmt.Errorf("error changing directory owner: %w", err)
-			}
-		case "chgrp":
-			if err := chgrpDirectory(dir); err != nil {
-				return fmt.Errorf("error changing directory group: %w", err)
-			}
-		case "symlink":
-			if err := symlinkDirectory(dir, blueprintDir); err != nil {
-				return fmt.Errorf("error creating symlink: %w", err)
-			}
-		default:
-			return fmt.Errorf("unsupported action for directory: %s", dir.Action)
+		if err := processDirectory(dir, blueprintDir, initConfig); err != nil {
+			recordFailure("directories", dir.Name, err)
 		}
+	}
+	return nil
+}
+
+func processDirectory(dir types.Directory, blueprintDir string, initConfig *types.InitConfig) error {
+	switch dir.Action {
+	case "copy":
+		if err := copyDirectory(dir, blueprintDir, initConfig); err != nil {
+			return fmt.Errorf("error copying directory: %w", err)
+		}
+	case "move":
+		if err := moveDirectory(dir, blueprintDir); err != nil {
+			return fmt.Errorf("error moving directory: %w", err)
+		}
+	case "delete":
+		if err := deleteDirectory(dir); err != nil {
+			return fmt.Errorf("error deleting directory: %w", err)
+		}
+	case "create":
+		if err := createDirectory(dir); err != nil {
+			return fmt.Errorf("error creating directory: %w", err)
+		}
+	case "chmod":
+		if err := chmodDirectory(dir); err != nil {
+			return fmt.Errorf("error changing directory permissions: %w", err)
+		}
+	case "chown":
+		if err := chownDirectory(dir); err != nil {
+			return fmt.Errorf("error changing directory owner: %w", err)
+		}
+	case "chgrp":
+		if err := chgrpDirectory(dir); err != nil {
+			return fmt.Errorf("error changing directory group: %w", err)
+		}
+	case "symlink":
+		if err := symlinkDirectory(dir, blueprintDir); err != nil {
+			return fmt.Errorf("error creating symlink: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported action for directory: %s", dir.Action)
 	}
 	return nil
 }

--- a/internal/processors/files_idempotency_test.go
+++ b/internal/processors/files_idempotency_test.go
@@ -106,13 +106,22 @@ func TestSymlink_RegularFileInTheWayIsAnError(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// The occupied target is a ledger failure, not an abort: the processor
+	// returns nil so later items still run, and the failure reaches the exit
+	// code through All().
+	resetFailures()
+	defer resetFailures()
+
 	blueprint := "files:\n  - name: vimrc\n    action: symlink\n    source: dotfiles\n    target: " + link + "\n"
-	err := runFilesBlueprint(t, blueprintDir, blueprint)
+	if err := runFilesBlueprint(t, blueprintDir, blueprint); err != nil {
+		t.Fatalf("runFilesBlueprint = %v, want nil: item failures belong in the ledger", err)
+	}
+	err := failureError()
 	if err == nil {
-		t.Fatal("expected an error when a regular file occupies the symlink target")
+		t.Fatal("expected a recorded failure when a regular file occupies the symlink target")
 	}
 	if !strings.Contains(err.Error(), "already exists") {
-		t.Errorf("error should say what is in the way, got: %v", err)
+		t.Errorf("failure should say what is in the way, got: %v", err)
 	}
 
 	content, readErr := os.ReadFile(link)

--- a/internal/processors/files_test.go
+++ b/internal/processors/files_test.go
@@ -423,14 +423,22 @@ files:
     target: "` + tempDir + `"
 `
 
+	// An invalid item is a ledger failure, not an abort: the processor returns
+	// nil so the items after it still run, and All() reads the ledger into the
+	// exit code.
+	resetFailures()
+	defer resetFailures()
+
 	err := ProcessFiles([]byte(blueprintData), blueprintDir, "yaml", osInfo, config)
 
-	if err == nil {
-		t.Error("Expected error for missing content and source")
+	if err != nil {
+		t.Errorf("ProcessFiles = %v, want nil: item failures belong in the ledger", err)
 	}
 
-	if !containsString(err.Error(), "Content or Source must be provided") {
-		t.Errorf("Expected 'Content or Source must be provided' error, got: %v", err)
+	if err := failureError(); err == nil {
+		t.Error("Expected a recorded failure for missing content and source")
+	} else if !containsString(err.Error(), "Content or Source must be provided") {
+		t.Errorf("Expected 'Content or Source must be provided' failure, got: %v", err)
 	}
 }
 

--- a/internal/processors/fonts.go
+++ b/internal/processors/fonts.go
@@ -17,9 +17,8 @@ import (
 	"github.com/ulikunitz/xz"
 )
 
-const (
-	nerdFontRepoAPI = "https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest"
-)
+// A var so a test can point the release lookup at a server it controls.
+var nerdFontRepoAPI = "https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest"
 
 type GithubRelease struct {
 	TagName string `json:"tag_name"`
@@ -30,7 +29,7 @@ type GithubRelease struct {
 }
 
 func getLatestReleaseURL() (string, error) {
-	resp, err := http.Get(nerdFontRepoAPI)
+	resp, err := http.Get(nerdFontRepoAPI) // #nosec G107 -- package-level constant URL, a var only so tests can point it at their own server
 	if err != nil {
 		return "", err
 	}
@@ -81,23 +80,29 @@ func ProcessFonts(blueprintData []byte, blueprintDir string, format string, osIn
 
 	// Resolved after the dry-run and empty-blueprint exits: this is a network call,
 	// and `--dry-run` is expected to work offline.
+	//
+	// GitHub being unreachable fails every font, but not the run: fonts are
+	// cosmetic, and the failures reach the exit code through the ledger.
 	releaseURL, err := getLatestReleaseURL()
 	if err != nil {
-		return fmt.Errorf("error getting latest release URL: %w", err)
+		recordFailure("fonts", "nerd-fonts release lookup", err)
+		return nil
 	}
 
+	// One font failing does not stop the rest: the failure goes to the ledger,
+	// which puts it in the run's exit code, and processing continues.
 	for _, font := range fontsData.Fonts {
 		if len(font.Names) > 0 {
 			for _, name := range font.Names {
 				fontWithName := font
 				fontWithName.Name = name
 				if err := processFont(fontWithName, osInfo, releaseURL); err != nil {
-					return fmt.Errorf("error processing font %s: %w", name, err)
+					recordFailure("fonts", name, err)
 				}
 			}
 		} else if font.Name != "" {
 			if err := processFont(font, osInfo, releaseURL); err != nil {
-				return fmt.Errorf("error processing font %s: %w", font.Name, err)
+				recordFailure("fonts", font.Name, err)
 			}
 		}
 	}

--- a/internal/processors/repository.go
+++ b/internal/processors/repository.go
@@ -58,149 +58,162 @@ func processRepositories(repositories []types.Repository, osInfo *types.OSInfo, 
 		return fmt.Errorf("error initializing providers: %w", err)
 	}
 
-	// Process each repository
+	// One repository failing does not stop the rest: the failure goes to the
+	// ledger, which puts it in the run's exit code, and processing continues.
 	for _, repo := range repositories {
 		log.Infof("Processing repository %s", repo.Name)
 		log.Debugf("Repository definition: %s", repo.LogString())
 
-		// Get provider for this repository
-		provider, exists := system.GetProvider(repo.PackageManager)
-		if !exists {
-			return fmt.Errorf("unsupported package manager: %s", repo.PackageManager)
-		}
-
-		// Get repository config
-		repoConfig := provider.Repository
-
-		// Execute repository action steps
-		var steps []types.ActionStep
-		switch repo.Action {
-		case "add":
-			steps = repoConfig.Add.Steps
-		case "remove":
-			steps = repoConfig.Remove.Steps
-		default:
-			return fmt.Errorf("unsupported repository action: %s", repo.Action)
-		}
-
-		// Execute each step
-		data := repositoryStepData(repo, repoConfig.Paths, provider)
-		for _, rawStep := range steps {
-			// The condition is evaluated before the rest of the step is
-			// rendered: a skipped step is allowed to reference data this
-			// repository does not carry, which is the whole reason it is
-			// conditional.
-			run, err := stepCondition(rawStep.Condition, data)
-			if err != nil {
-				return fmt.Errorf("error evaluating condition for %s repository step of %s: %w", repo.Action, repo.Name, err)
-			}
-			if !run {
-				log.Debugf("Skipping %s step: condition %q is not met", rawStep.Action, rawStep.Condition)
-				continue
-			}
-
-			step, err := renderActionStep(rawStep, data)
-			if err != nil {
-				return fmt.Errorf("error rendering %s repository step for %s: %w", repo.Action, repo.Name, err)
-			}
-
-			var cmd types.Command
-
-			switch step.Action {
-			case "exec", "command": // Support both "exec" and "command" action types
-				cmd = types.Command{
-					Exec:        step.Exec,
-					Args:        step.Args,
-					Elevated:    provider.Elevated,
-					Interactive: helpers.ResolveInteractive(repo.Interactive, initConfig.Variables.Flags.Interactive),
-					// chocolatey's --password and cargo's login token are accepted
-					// only as arguments, so they cannot move to stdin. They can at
-					// least be kept out of the debug and dry-run log lines, which
-					// print the full argv.
-					Secrets: repo.SecretValues(),
-				}
-			case "download":
-				if system.IsDryRun() {
-					log.Infof("[DRY-RUN] Would download file: %s -> %s", step.Source, step.Dest)
-					continue
-				}
-				if err := system.DownloadFile(step.Source, step.Dest, provider.Elevated); err != nil {
-					return fmt.Errorf("error downloading file: %w", err)
-				}
-				continue
-			case "write":
-				if system.IsDryRun() {
-					log.Infof("[DRY-RUN] Would write file: %s", step.Dest)
-					continue
-				}
-				if err := system.WriteToFile(step.Dest, step.Content, provider.Elevated); err != nil {
-					return fmt.Errorf("error writing file: %w", err)
-				}
-				continue
-			case "append":
-				path, err := repositoryFilePath(step.Path, repoConfig.Paths)
-				if err != nil {
-					return fmt.Errorf("error appending to repository file for %s: %w", repo.Name, err)
-				}
-				if system.IsDryRun() {
-					log.Infof("[DRY-RUN] Would append to file: %s", path)
-					continue
-				}
-				if err := system.AppendToFile(path, step.Content, provider.Elevated); err != nil {
-					return fmt.Errorf("error appending to %s: %w", path, err)
-				}
-				continue
-			case "remove_line":
-				path, err := repositoryFilePath(step.Path, repoConfig.Paths)
-				if err != nil {
-					return fmt.Errorf("error removing line from repository file for %s: %w", repo.Name, err)
-				}
-				if system.IsDryRun() {
-					log.Infof("[DRY-RUN] Would remove lines naming %s from file: %s", step.Match, path)
-					continue
-				}
-				if err := system.RemoveLineFromFile(path, step.Match, provider.Elevated); err != nil {
-					return fmt.Errorf("error removing line from %s: %w", path, err)
-				}
-				continue
-			case "remove_section":
-				path, err := repositoryFilePath(step.Path, repoConfig.Paths)
-				if err != nil {
-					return fmt.Errorf("error removing section from repository file for %s: %w", repo.Name, err)
-				}
-				if system.IsDryRun() {
-					log.Infof("[DRY-RUN] Would remove section [%s] from file: %s", step.Section, path)
-					continue
-				}
-				if err := system.RemoveSectionFromFile(path, step.Section, provider.Elevated); err != nil {
-					return fmt.Errorf("error removing section from %s: %w", path, err)
-				}
-				continue
-			case "remove":
-				if err := removeRepositoryPath(step.Path, repoConfig.Paths, provider.Elevated, initConfig.Variables.Flags.Debug); err != nil {
-					return fmt.Errorf("error removing repository path for %s: %w", repo.Name, err)
-				}
-				continue
-			case "copy":
-				if system.IsDryRun() {
-					log.Infof("[DRY-RUN] Would copy file: %s -> %s", step.Source, step.Dest)
-					continue
-				}
-				if err := system.CopyFile(step.Source, step.Dest, provider.Elevated, osInfo); err != nil {
-					return fmt.Errorf("error copying file: %w", err)
-				}
-				continue
-			default:
-				return fmt.Errorf("unsupported repository action step: %s", step.Action)
-			}
-
-			if err := system.RunCommand(cmd, initConfig.Variables.Flags.Debug); err != nil {
-				return fmt.Errorf("error executing repository step: %w", err)
-			}
+		if err := processRepository(repo, osInfo, initConfig); err != nil {
+			recordFailure("repositories", repo.Name, err)
 		}
 	}
 
-	// Run updates for all available providers
+	return runRepositoryUpdates(initConfig)
+}
+
+// processRepository runs one repository's provider action steps.
+func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
+	provider, exists := system.GetProvider(repo.PackageManager)
+	if !exists {
+		return fmt.Errorf("unsupported package manager: %s", repo.PackageManager)
+	}
+
+	// Get repository config
+	repoConfig := provider.Repository
+
+	// Execute repository action steps
+	var steps []types.ActionStep
+	switch repo.Action {
+	case "add":
+		steps = repoConfig.Add.Steps
+	case "remove":
+		steps = repoConfig.Remove.Steps
+	default:
+		return fmt.Errorf("unsupported repository action: %s", repo.Action)
+	}
+
+	// Execute each step
+	data := repositoryStepData(repo, repoConfig.Paths, provider)
+	for _, rawStep := range steps {
+		// The condition is evaluated before the rest of the step is
+		// rendered: a skipped step is allowed to reference data this
+		// repository does not carry, which is the whole reason it is
+		// conditional.
+		run, err := stepCondition(rawStep.Condition, data)
+		if err != nil {
+			return fmt.Errorf("error evaluating condition for %s repository step of %s: %w", repo.Action, repo.Name, err)
+		}
+		if !run {
+			log.Debugf("Skipping %s step: condition %q is not met", rawStep.Action, rawStep.Condition)
+			continue
+		}
+
+		step, err := renderActionStep(rawStep, data)
+		if err != nil {
+			return fmt.Errorf("error rendering %s repository step for %s: %w", repo.Action, repo.Name, err)
+		}
+
+		var cmd types.Command
+
+		switch step.Action {
+		case "exec", "command": // Support both "exec" and "command" action types
+			cmd = types.Command{
+				Exec:        step.Exec,
+				Args:        step.Args,
+				Elevated:    provider.Elevated,
+				Interactive: helpers.ResolveInteractive(repo.Interactive, initConfig.Variables.Flags.Interactive),
+				// chocolatey's --password and cargo's login token are accepted
+				// only as arguments, so they cannot move to stdin. They can at
+				// least be kept out of the debug and dry-run log lines, which
+				// print the full argv.
+				Secrets: repo.SecretValues(),
+			}
+		case "download":
+			if system.IsDryRun() {
+				log.Infof("[DRY-RUN] Would download file: %s -> %s", step.Source, step.Dest)
+				continue
+			}
+			if err := system.DownloadFile(step.Source, step.Dest, provider.Elevated); err != nil {
+				return fmt.Errorf("error downloading file: %w", err)
+			}
+			continue
+		case "write":
+			if system.IsDryRun() {
+				log.Infof("[DRY-RUN] Would write file: %s", step.Dest)
+				continue
+			}
+			if err := system.WriteToFile(step.Dest, step.Content, provider.Elevated); err != nil {
+				return fmt.Errorf("error writing file: %w", err)
+			}
+			continue
+		case "append":
+			path, err := repositoryFilePath(step.Path, repoConfig.Paths)
+			if err != nil {
+				return fmt.Errorf("error appending to repository file for %s: %w", repo.Name, err)
+			}
+			if system.IsDryRun() {
+				log.Infof("[DRY-RUN] Would append to file: %s", path)
+				continue
+			}
+			if err := system.AppendToFile(path, step.Content, provider.Elevated); err != nil {
+				return fmt.Errorf("error appending to %s: %w", path, err)
+			}
+			continue
+		case "remove_line":
+			path, err := repositoryFilePath(step.Path, repoConfig.Paths)
+			if err != nil {
+				return fmt.Errorf("error removing line from repository file for %s: %w", repo.Name, err)
+			}
+			if system.IsDryRun() {
+				log.Infof("[DRY-RUN] Would remove lines naming %s from file: %s", step.Match, path)
+				continue
+			}
+			if err := system.RemoveLineFromFile(path, step.Match, provider.Elevated); err != nil {
+				return fmt.Errorf("error removing line from %s: %w", path, err)
+			}
+			continue
+		case "remove_section":
+			path, err := repositoryFilePath(step.Path, repoConfig.Paths)
+			if err != nil {
+				return fmt.Errorf("error removing section from repository file for %s: %w", repo.Name, err)
+			}
+			if system.IsDryRun() {
+				log.Infof("[DRY-RUN] Would remove section [%s] from file: %s", step.Section, path)
+				continue
+			}
+			if err := system.RemoveSectionFromFile(path, step.Section, provider.Elevated); err != nil {
+				return fmt.Errorf("error removing section from %s: %w", path, err)
+			}
+			continue
+		case "remove":
+			if err := removeRepositoryPath(step.Path, repoConfig.Paths, provider.Elevated, initConfig.Variables.Flags.Debug); err != nil {
+				return fmt.Errorf("error removing repository path for %s: %w", repo.Name, err)
+			}
+			continue
+		case "copy":
+			if system.IsDryRun() {
+				log.Infof("[DRY-RUN] Would copy file: %s -> %s", step.Source, step.Dest)
+				continue
+			}
+			if err := system.CopyFile(step.Source, step.Dest, provider.Elevated, osInfo); err != nil {
+				return fmt.Errorf("error copying file: %w", err)
+			}
+			continue
+		default:
+			return fmt.Errorf("unsupported repository action step: %s", step.Action)
+		}
+
+		if err := system.RunCommand(cmd, initConfig.Variables.Flags.Debug); err != nil {
+			return fmt.Errorf("error executing repository step: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// runRepositoryUpdates refreshes package lists for every available provider.
+func runRepositoryUpdates(initConfig *types.InitConfig) error {
 	available := system.GetAvailableProviders()
 	for name, provider := range available {
 		if provider.Commands.Update == "" {

--- a/internal/processors/repository_test.go
+++ b/internal/processors/repository_test.go
@@ -215,12 +215,12 @@ func TestProcessRepositories_UnknownPlaceholderIsAnError(t *testing.T) {
 		},
 	})()
 
-	err := processRepositories([]types.Repository{{
+	err := processRepository(types.Repository{
 		Name:           "example",
 		PackageManager: "fake",
 		Action:         "add",
 		URL:            "https://example.com/repo",
-	}}, &types.OSInfo{}, &types.InitConfig{})
+	}, &types.OSInfo{}, &types.InitConfig{})
 
 	if err == nil {
 		t.Fatal("processRepositories succeeded, want an error for the unknown placeholder")
@@ -286,11 +286,11 @@ func TestProcessRepositories_RemoveRefusesPathOutsideProviderPaths(t *testing.T)
 	defer system.SetExecutor(rec)()
 	defer system.SetProvidersForTest(map[string]*types.Provider{"apt": provider})()
 
-	err := processRepositories([]types.Repository{{
+	err := processRepository(types.Repository{
 		Name:           "docker",
 		PackageManager: "apt",
 		Action:         "remove",
-	}}, &types.OSInfo{}, &types.InitConfig{})
+	}, &types.OSInfo{}, &types.InitConfig{})
 
 	if err == nil {
 		t.Fatal("processRepositories succeeded, want a refusal for a path outside the provider's paths")
@@ -312,11 +312,11 @@ func TestProcessRepositories_RemoveRefusesRelativePath(t *testing.T) {
 	defer system.SetExecutor(exectest.New())()
 	defer system.SetProvidersForTest(map[string]*types.Provider{"apt": provider})()
 
-	err := processRepositories([]types.Repository{{
+	err := processRepository(types.Repository{
 		Name:           "docker",
 		PackageManager: "apt",
 		Action:         "remove",
-	}}, &types.OSInfo{}, &types.InitConfig{})
+	}, &types.OSInfo{}, &types.InitConfig{})
 
 	if err == nil || !strings.Contains(err.Error(), "not absolute") {
 		t.Fatalf("error = %v, want a refusal naming the relative path", err)
@@ -569,12 +569,12 @@ func TestProcessRepositories_AppendRefusesPathOutsideProviderPaths(t *testing.T)
 	defer system.SetExecutor(exectest.New())()
 	defer system.SetProvidersForTest(map[string]*types.Provider{"pacman": provider})()
 
-	err := processRepositories([]types.Repository{{
+	err := processRepository(types.Repository{
 		Name:           "chaotic-aur",
 		PackageManager: "pacman",
 		Action:         "add",
 		URL:            "https://example.com/repo",
-	}}, &types.OSInfo{}, &types.InitConfig{})
+	}, &types.OSInfo{}, &types.InitConfig{})
 
 	if err == nil || !strings.Contains(err.Error(), "outside the provider's repository paths") {
 		t.Fatalf("error = %v, want a refusal naming the containment check", err)
@@ -750,12 +750,12 @@ func TestProcessRepositories_UnknownConditionPredicateIsAnError(t *testing.T) {
 		},
 	})()
 
-	err := processRepositories([]types.Repository{{
+	err := processRepository(types.Repository{
 		Name:           "example",
 		PackageManager: "fake",
 		Action:         "add",
 		URL:            "https://example.com/repo",
-	}}, &types.OSInfo{}, &types.InitConfig{})
+	}, &types.OSInfo{}, &types.InitConfig{})
 
 	if err == nil {
 		t.Fatal("processRepositories succeeded, want an error for the underivable condition")

--- a/internal/processors/services.go
+++ b/internal/processors/services.go
@@ -48,23 +48,23 @@ func ProcessServices(blueprintData []byte, format string, osInfo *types.OSInfo, 
 	return nil
 }
 
+// One service failing does not stop the rest: the failure goes to the ledger,
+// which puts it in the run's exit code, and processing continues.
 func processServices(services []types.Service, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
 	for _, service := range services {
+		var err error
 		switch runtime.GOOS {
 		case "linux":
-			if err := processLinuxService(service, osInfo, initConfig); err != nil {
-				return err
-			}
+			err = processLinuxService(service, osInfo, initConfig)
 		case "darwin":
-			if err := processMacOSService(service, osInfo, initConfig); err != nil {
-				return err
-			}
+			err = processMacOSService(service, osInfo, initConfig)
 		case "windows":
-			if err := processWindowsService(service, osInfo, initConfig); err != nil {
-				return err
-			}
+			err = processWindowsService(service, osInfo, initConfig)
 		default:
 			return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+		}
+		if err != nil {
+			recordFailure("services", service.Name, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
The failure ledger (#160) covers only 4 of 8 processors. `files`, `services`, `repositories`, and `fonts` still abort the entire run on the first bad item — one font failing to download stops every service after it from being configured, and the abort bypasses the ledger summary.

## Changes
- Per-item errors in all four processors go through `recordFailure` and processing continues; `All()` already turns the ledger into the exit code.
- Structural errors (undecodable blueprint, broken imports, unsupported OS) still abort, matching the packages processor.
- The repository per-item body is extracted to `processRepository`, directory dispatch to `processDirectory`, so the loops can record and continue.
- Fonts: an unreachable release lookup is a ledger failure instead of a run abort.
- Tests asserting per-item error contracts (containment refusals, unknown placeholders/predicates) now call `processRepository` directly — assertions unchanged. Two file tests that asserted the abort now assert the ledger records the failure.

## Tests
Four regression tests (files, services, repositories, fonts), each asserting: the bad item is recorded, **the item after it still runs**, and the processor returns nil. All fail on master. Full `go test -race ./...` and golangci-lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)