### PR TITLE
feat(install): add --nightly and --tag to both installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ against the release's `checksums.txt` and refuses to install on a mismatch.
 `install.sh` installs to `/usr/local/bin`; `install.ps1` installs to
 `%ProgramFiles%\rwr` and adds it to the machine `PATH`.
 
+To install the rolling [nightly prerelease](https://github.com/FynxLabs/rwr/releases/tag/nightly)
+(an unvetted build of master) or pin a specific version, pass a flag through:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/FynxLabs/rwr/refs/heads/master/install.sh | sudo bash -s -- --nightly
+```
+
+`--tag v0.5.1` pins a release by tag. On Windows the same options are
+`-Nightly` and `-Tag v0.5.1` (download the script to a file to pass
+parameters, or wrap the one-liner in `& ([scriptblock]::Create(...))`).
+
 > [!NOTE]
 > Always review scripts before running them with elevated privileges. The install scripts are available for inspection in the RWR repository.
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,21 @@
 #Requires -Version 5.1
+# By default the latest stable release is installed. GitHub's /releases/latest
+# endpoint never returns prereleases, so the rolling `nightly` build (and any
+# pinned tag) is reached through /releases/tags/<tag> instead — same response
+# shape, same assets, same checksums.txt.
+param(
+    [switch]$Nightly,
+    [string]$Tag
+)
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+if ($Nightly -and $Tag) {
+    Write-Host "-Nightly and -Tag are two ways to pick one release; use one or the other."
+    exit 1
+}
+if ($Nightly) { $Tag = 'nightly' }
 
 $REPO = "FynxLabs/rwr"
 $BINARY_PATH = "$env:ProgramFiles\rwr"
@@ -36,11 +51,22 @@ switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
 
 Write-Host "Installing RWR for $OS $ARCH"
 
+if ($Tag) {
+    $release_api = "https://api.github.com/repos/$REPO/releases/tags/$Tag"
+    $release_desc = "release $Tag"
+    if ($Tag -eq 'nightly') {
+        Write-Host "Installing the nightly prerelease: an unvetted build of whatever master last was."
+    }
+} else {
+    $release_api = "https://api.github.com/repos/$REPO/releases/latest"
+    $release_desc = "latest release"
+}
+
 $headers = @{ 'User-Agent' = 'rwr-installer' }
 try {
-    $latest_release = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest" -Headers $headers
+    $latest_release = Invoke-RestMethod -Uri $release_api -Headers $headers
 } catch {
-    Write-Host "Failed to query the latest release: $_"
+    Write-Host "Failed to query the ${release_desc}: $_"
     exit 1
 }
 
@@ -50,7 +76,7 @@ $download_url = $latest_release.assets |
     Select-Object -First 1 -ExpandProperty browser_download_url
 
 if (-not $download_url) {
-    Write-Host "Could not find $asset_name in the latest release. Exiting."
+    Write-Host "Could not find $asset_name in the $release_desc. Exiting."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,38 @@ fail() {
     exit 1
 }
 
+# By default the latest stable release is installed. GitHub's /releases/latest
+# endpoint never returns prereleases, so the rolling `nightly` build (and any
+# pinned tag) is reached through /releases/tags/<tag> instead — same response
+# shape, same assets, same checksums.txt.
+RELEASE_TAG=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --nightly)
+            RELEASE_TAG="nightly"
+            ;;
+        --tag)
+            [ $# -ge 2 ] || fail "--tag needs a value, e.g. --tag v0.5.1 or --tag nightly."
+            RELEASE_TAG="$2"
+            shift
+            ;;
+        --tag=*)
+            RELEASE_TAG="${1#--tag=}"
+            [ -n "$RELEASE_TAG" ] || fail "--tag needs a value, e.g. --tag v0.5.1 or --tag nightly."
+            ;;
+        -h|--help)
+            echo "Usage: install.sh [--nightly | --tag <tag>]"
+            echo "  --nightly     install the rolling prerelease built from master"
+            echo "  --tag <tag>   install a specific release tag (e.g. v0.5.1)"
+            exit 0
+            ;;
+        *)
+            fail "Unknown option: $1. Supported options: --nightly, --tag <tag>."
+            ;;
+    esac
+    shift
+done
+
 OS=$(uname -s)
 case "$OS" in
     Linux*)     OS="Linux";;
@@ -81,10 +113,21 @@ cleanup() {
 }
 trap cleanup EXIT
 
+if [ -n "$RELEASE_TAG" ]; then
+    RELEASE_API="https://api.github.com/repos/$REPO/releases/tags/$RELEASE_TAG"
+    RELEASE_DESC="release $RELEASE_TAG"
+    if [ "$RELEASE_TAG" = "nightly" ]; then
+        echo "Installing the nightly prerelease: an unvetted build of whatever master last was."
+    fi
+else
+    RELEASE_API="https://api.github.com/repos/$REPO/releases/latest"
+    RELEASE_DESC="latest release"
+fi
+
 echo "Installing RWR for $OS $ARCH"
 
-if ! latest_release=$(curl -fsSL -H "User-Agent: $USER_AGENT" "https://api.github.com/repos/$REPO/releases/latest"); then
-    fail "Failed to query the latest release from the GitHub API. The API may be unreachable or rate limiting this host (unauthenticated requests are limited per IP). Try again later."
+if ! latest_release=$(curl -fsSL -H "User-Agent: $USER_AGENT" "$RELEASE_API"); then
+    fail "Failed to query the $RELEASE_DESC from the GitHub API. The tag may not exist, the API may be unreachable, or it is rate limiting this host (unauthenticated requests are limited per IP)."
 fi
 
 asset_urls=$(printf '%s' "$latest_release" |
@@ -104,12 +147,12 @@ url_for_asset() {
 
 download_url=$(url_for_asset "$ASSET")
 if [ -z "$download_url" ]; then
-    fail "The latest release does not contain $ASSET, so there is no build for $OS $ARCH. Exiting."
+    fail "The $RELEASE_DESC does not contain $ASSET, so there is no build for $OS $ARCH. Exiting."
 fi
 
 checksums_url=$(url_for_asset "$CHECKSUMS")
 if [ -z "$checksums_url" ]; then
-    fail "The latest release does not publish $CHECKSUMS, so the download cannot be verified. Exiting."
+    fail "The $RELEASE_DESC does not publish $CHECKSUMS, so the download cannot be verified. Exiting."
 fi
 
 echo "Downloading $ASSET"


### PR DESCRIPTION
## Summary
The installers query GitHub's `/releases/latest`, which deliberately excludes prereleases — so the rolling `nightly` build was unreachable through them. A tagged release is available at `/releases/tags/<tag>` with the identical response shape and its own `checksums.txt`, so selecting one is just a different URL; checksum verification is unchanged and applies to every tag.

## Usage
```bash
curl -sSL https://raw.githubusercontent.com/FynxLabs/rwr/refs/heads/master/install.sh | sudo bash -s -- --nightly
```
`--tag v0.5.1` pins a version. Windows: `-Nightly` / `-Tag v0.5.1`. Nightly installs print a one-line "unvetted build of master" warning. README documents both.

## Verification
shellcheck clean; `--help`, missing `--tag` value, and unknown-option paths exercised locally. install.ps1 param block is validated by the CI parse gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)