### PR TITLE
fix(providers): stop rejecting every provider definition on Windows

### DIFF
--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -365,11 +365,26 @@ func LoadProviders(definitionsPath string) error {
 // world-writable files are skipped rather than rejected outright: one bad file in
 // a directory should not cost the user every other provider in it.
 func isProviderFileTrusted(path string) bool {
+	return isProviderFileTrustedOn(runtime.GOOS, path)
+}
+
+// isProviderFileTrustedOn is isProviderFileTrusted with the platform as data,
+// so both branches are testable from any platform.
+func isProviderFileTrustedOn(goos, path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
 		log.Warnf("LoadProviders: Skipping provider %s: %v", path, err)
 		return false
 	}
+
+	// Windows has no unix permission bits: Go synthesizes 0666 for any file
+	// that is not read-only, so the writability check below would reject every
+	// normal provider file — and its chmod advice is not runnable there. File
+	// security on Windows is ACLs, which os.FileMode cannot express.
+	if goos == "windows" {
+		return true
+	}
+
 	if mode := info.Mode(); mode&0o022 != 0 {
 		log.Warnf("LoadProviders: Skipping provider %s: it is group- or world-writable (mode %04o); "+
 			"provider files run commands as root, so tighten it with chmod go-w", path, mode.Perm())

--- a/internal/system/providers_trust_test.go
+++ b/internal/system/providers_trust_test.go
@@ -1,0 +1,47 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// On unix, group/world-writable definitions are skipped; a 0644 one loads.
+// On Windows, Go synthesizes mode 0666 for every writable file, so the same
+// check rejected every provider definition a Windows user could ever write —
+// the platform gets no mode check at all rather than one that always fails.
+func TestIsProviderFileTrustedOn(t *testing.T) {
+	dir := t.TempDir()
+
+	private := filepath.Join(dir, "private.toml")
+	if err := os.WriteFile(private, []byte("[provider]\nname='x'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loose := filepath.Join(dir, "loose.toml")
+	if err := os.WriteFile(loose, []byte("[provider]\nname='x'\n"), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	// WriteFile's mode passes through the umask; make the mode explicit.
+	if err := os.Chmod(loose, 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		name string
+		goos string
+		path string
+		want bool
+	}{
+		{name: "linux private file loads", goos: "linux", path: private, want: true},
+		{name: "linux world-writable file skipped", goos: "linux", path: loose, want: false},
+		// The same 0666 mode Windows reports for every normal file.
+		{name: "windows 0666 file loads", goos: "windows", path: loose, want: true},
+		{name: "windows missing file skipped", goos: "windows", path: filepath.Join(dir, "nope.toml"), want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isProviderFileTrustedOn(tt.goos, tt.path); got != tt.want {
+				t.Errorf("isProviderFileTrustedOn(%q, %q) = %v, want %v", tt.goos, tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
`isProviderFileTrusted` skips group/world-writable definitions — correct on unix, but Go reports mode 0666 for every writable file on Windows, so the check rejected **every** provider file a Windows user could write, with `chmod go-w` advice that doesn't exist there.

## Changes
The platform check moves to `isProviderFileTrustedOn(goos, path)` (testable from any platform); Windows skips the mode test entirely — its file security is ACLs, which `os.FileMode` can't express. Unix behavior unchanged.

## Tests
Table test covering both platforms; the windows-0666 case fails on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)