### PR TITLE
fix(templates): keep per-template variables out of the run's globals

### DIFF
--- a/internal/processors/files.go
+++ b/internal/processors/files.go
@@ -258,7 +258,15 @@ func processTemplate(template types.File, blueprintDir string, osInfo *types.OSI
 	log.Debugf("Successfully read template file, content length: %d bytes", len(content))
 
 	log.Debug("Resolving template variables")
+	// Copying the struct still shares the UserDefined map, so writing template
+	// overrides into it mutated initConfig for every later template and
+	// blueprint — a per-template variable permanently clobbered a run-wide one
+	// of the same name. Merge into a fresh map instead.
 	mergedVariables := initConfig.Variables
+	mergedVariables.UserDefined = make(map[string]interface{}, len(initConfig.Variables.UserDefined)+len(template.Variables))
+	for k, v := range initConfig.Variables.UserDefined {
+		mergedVariables.UserDefined[k] = v
+	}
 	for k, v := range template.Variables {
 		mergedVariables.UserDefined[k] = v
 	}

--- a/internal/processors/files_template_vars_test.go
+++ b/internal/processors/files_template_vars_test.go
@@ -1,0 +1,74 @@
+package processors
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// A template's own `variables` are overrides for that one render. They were
+// written into initConfig's shared UserDefined map, so template A's override
+// leaked into template B and permanently clobbered a run-wide variable of the
+// same name.
+func TestProcessFiles_TemplateVariablesDoNotLeak(t *testing.T) {
+	tempDir := t.TempDir()
+	blueprintDir := filepath.Join(tempDir, "blueprints")
+	if err := os.MkdirAll(filepath.Join(blueprintDir, "tpl"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Both templates render the same variable.
+	for _, name := range []string{"a.conf", "b.conf"} {
+		if err := os.WriteFile(filepath.Join(blueprintDir, "tpl", name), []byte("greeting={{ .UserDefined.greeting }}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	config := &types.InitConfig{
+		Init: types.Init{Location: blueprintDir, Format: "yaml"},
+		Variables: types.Variables{
+			Flags:       types.Flags{Debug: true},
+			UserDefined: map[string]interface{}{"greeting": "global"},
+		},
+	}
+
+	// a.conf overrides greeting; b.conf must still see the run-wide value.
+	blueprintData := `
+templates:
+  - name: "a.conf"
+    action: "create"
+    source: "tpl"
+    target: "` + tempDir + `/"
+    variables:
+      greeting: "local"
+  - name: "b.conf"
+    action: "create"
+    source: "tpl"
+    target: "` + tempDir + `/"
+`
+
+	if err := ProcessFiles([]byte(blueprintData), blueprintDir, "yaml", &types.OSInfo{}, config); err != nil {
+		t.Fatalf("ProcessFiles: %v", err)
+	}
+
+	read := func(name string) string {
+		t.Helper()
+		got, err := os.ReadFile(filepath.Join(tempDir, name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		return string(got)
+	}
+
+	if got := read("a.conf"); !strings.Contains(got, "greeting=local") {
+		t.Errorf("a.conf = %q, want its own override %q", got, "local")
+	}
+	if got := read("b.conf"); !strings.Contains(got, "greeting=global") {
+		t.Errorf("b.conf = %q, want the run-wide value %q — a.conf's override leaked", got, "global")
+	}
+	if got := config.Variables.UserDefined["greeting"]; got != "global" {
+		t.Errorf("initConfig.Variables.UserDefined[greeting] = %v, want %q untouched", got, "global")
+	}
+}


### PR DESCRIPTION
## Summary
`mergedVariables := initConfig.Variables` copies the struct but shares the `UserDefined` map, so a template's own `variables:` were written into the run's global state: template A's override leaked into template B and every later blueprint render, permanently clobbering a run-wide variable of the same name.

## Changes
Merge into a fresh map (globals first, then the template's overrides). No behavior change for the template being rendered — only the leak stops.

## Tests
Two templates rendering the same variable, the first with an override: on master, the second template and `initConfig` both see the leaked override; with the fix the override stays scoped to its template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)