### PR TITLE
fix(processors): make service deletes and GitHub key uploads converge on rerun

### DIFF
--- a/internal/processors/services.go
+++ b/internal/processors/services.go
@@ -100,6 +100,12 @@ func deleteServiceFile(service types.Service) error {
 			return nil
 		}
 		if err := os.Remove(service.File); err != nil {
+			// A file an earlier run already deleted is the state the blueprint
+			// asked for, so a rerun converges instead of failing.
+			if os.IsNotExist(err) {
+				log.Infof("Service file already absent: %s", service.File)
+				return nil
+			}
 			return fmt.Errorf("error deleting service file: %v", err)
 		}
 	} else {
@@ -208,6 +214,11 @@ func deleteLaunchDaemon(service types.Service) error {
 			return nil
 		}
 		if err := os.Remove(service.File); err != nil {
+			// Already deleted by an earlier run: the asked-for state, not an error.
+			if os.IsNotExist(err) {
+				log.Infof("Launch daemon already absent: %s", service.File)
+				return nil
+			}
 			return fmt.Errorf("error deleting launch daemon: %v", err)
 		}
 	} else {
@@ -301,6 +312,15 @@ func createWindowsService(service types.Service, osInfo *types.OSInfo, initConfi
 		return fmt.Errorf("either content or source must be provided for create action")
 	}
 
+	// `sc create` fails when the service already exists, so a rerun on a
+	// converged system errored. `sc query` succeeding means it is already
+	// registered; the service file above was still refreshed. The probe is
+	// skipped in dry-run, where every command "succeeds" without running.
+	if !system.IsDryRun() && windowsServiceExists(service.Name, initConfig) {
+		log.Infof("Windows service already exists: %s", service.Name)
+		return nil
+	}
+
 	createCmd := types.Command{
 		Exec:     "sc",
 		Args:     []string{"create", service.Name, "binPath=", service.Target},
@@ -313,20 +333,39 @@ func createWindowsService(service types.Service, osInfo *types.OSInfo, initConfi
 	return nil
 }
 
-func deleteWindowsService(service types.Service, initConfig *types.InitConfig) error {
-	deleteCmd := types.Command{
+// windowsServiceExists probes the service manager; `sc query` exits non-zero
+// for a service that is not registered.
+func windowsServiceExists(name string, initConfig *types.InitConfig) bool {
+	queryCmd := types.Command{
 		Exec:     "sc",
-		Args:     []string{"delete", service.Name},
+		Args:     []string{"query", name},
 		Elevated: true,
 	}
-	if err := system.RunCommand(deleteCmd, initConfig.Variables.Flags.Debug); err != nil {
-		return fmt.Errorf("error deleting Windows service: %v", err)
+	return system.RunCommand(queryCmd, initConfig.Variables.Flags.Debug) == nil
+}
+
+func deleteWindowsService(service types.Service, initConfig *types.InitConfig) error {
+	// `sc delete` fails for a service that is not registered, so a rerun on a
+	// converged system errored. Absent already is the asked-for state. The
+	// probe is skipped in dry-run, where every command "succeeds" without
+	// running.
+	if system.IsDryRun() || windowsServiceExists(service.Name, initConfig) {
+		deleteCmd := types.Command{
+			Exec:     "sc",
+			Args:     []string{"delete", service.Name},
+			Elevated: true,
+		}
+		if err := system.RunCommand(deleteCmd, initConfig.Variables.Flags.Debug); err != nil {
+			return fmt.Errorf("error deleting Windows service: %v", err)
+		}
+	} else {
+		log.Infof("Windows service already absent: %s", service.Name)
 	}
 
 	if service.File != "" {
 		if system.IsDryRun() {
 			log.Infof("[DRY-RUN] Would delete service file: %s", service.File)
-		} else if err := os.Remove(service.File); err != nil {
+		} else if err := os.Remove(service.File); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("error deleting service file: %v", err)
 		}
 	}

--- a/internal/processors/services_idempotency_test.go
+++ b/internal/processors/services_idempotency_test.go
@@ -1,0 +1,117 @@
+package processors
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// A delete already carried out on an earlier run is the state the blueprint
+// asked for: reruns converge instead of failing.
+
+func TestDeleteServiceFile_RerunConverges(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "foo.service")
+	if err := os.WriteFile(file, []byte("[Unit]"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	service := types.Service{Name: "foo", File: file}
+
+	if err := deleteServiceFile(service); err != nil {
+		t.Fatalf("first delete: %v", err)
+	}
+	if err := deleteServiceFile(service); err != nil {
+		t.Fatalf("second delete must converge, got: %v", err)
+	}
+}
+
+func TestDeleteLaunchDaemon_RerunConverges(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "com.foo.plist")
+	if err := os.WriteFile(file, []byte("<plist/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	service := types.Service{Name: "foo", File: file}
+
+	if err := deleteLaunchDaemon(service); err != nil {
+		t.Fatalf("first delete: %v", err)
+	}
+	if err := deleteLaunchDaemon(service); err != nil {
+		t.Fatalf("second delete must converge, got: %v", err)
+	}
+}
+
+// sc delete fails for an unregistered service, so the delete is gated on an
+// `sc query` probe: absent already means converged, not failed.
+func TestDeleteWindowsService_AbsentServiceConverges(t *testing.T) {
+	rec := exectest.New()
+	rec.Err = errors.New("service does not exist")
+	defer system.SetExecutor(rec)()
+
+	err := deleteWindowsService(types.Service{Name: "foo"}, &types.InitConfig{})
+	if err != nil {
+		t.Fatalf("deleting an absent service must converge, got: %v", err)
+	}
+	// The probe ran; sc delete did not.
+	if len(rec.Calls) != 1 || rec.Calls[0].Args[0] != "query" {
+		t.Fatalf("recorded %v, want a single sc query probe", rec.Calls)
+	}
+}
+
+func TestDeleteWindowsService_ExistingServiceIsDeleted(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	err := deleteWindowsService(types.Service{Name: "foo"}, &types.InitConfig{})
+	if err != nil {
+		t.Fatalf("deleteWindowsService: %v", err)
+	}
+	if len(rec.Calls) != 2 || rec.Calls[1].Args[0] != "delete" {
+		t.Fatalf("recorded %v, want sc query then sc delete", rec.Calls)
+	}
+}
+
+// sc create fails when the service already exists: the probe succeeding means
+// converged, and the create is skipped.
+func TestCreateWindowsService_ExistingServiceConverges(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	target := filepath.Join(t.TempDir(), "foo.exe")
+	err := createWindowsService(types.Service{
+		Name:    "foo",
+		Content: "bin",
+		Target:  target,
+	}, &types.OSInfo{}, &types.InitConfig{})
+	if err != nil {
+		t.Fatalf("createWindowsService on an existing service must converge, got: %v", err)
+	}
+	if len(rec.Calls) != 1 || rec.Calls[0].Args[0] != "query" {
+		t.Fatalf("recorded %v, want only the sc query probe", rec.Calls)
+	}
+}
+
+func TestCreateWindowsService_MissingServiceIsCreated(t *testing.T) {
+	rec := exectest.New()
+	rec.Err = errors.New("service does not exist")
+	defer system.SetExecutor(rec)()
+
+	target := filepath.Join(t.TempDir(), "foo.exe")
+	err := createWindowsService(types.Service{
+		Name:    "foo",
+		Content: "bin",
+		Target:  target,
+	}, &types.OSInfo{}, &types.InitConfig{})
+
+	// The recorder fails every call, so sc create errors — what matters is
+	// that it was attempted after the probe said the service is absent.
+	if err == nil {
+		t.Fatal("expected the failing sc create to surface")
+	}
+	if len(rec.Calls) != 2 || rec.Calls[1].Args[0] != "create" {
+		t.Fatalf("recorded %v, want sc query then sc create", rec.Calls)
+	}
+}

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -446,6 +446,9 @@ func getGitHubToken(initConfig *types.InitConfig) (string, string, error) {
 	return prompts.PromptForGitHubAuth(initConfig, AuthenticateWithGitHub)
 }
 
+// A var so a test can point the key upload at a server it controls.
+var githubKeysAPI = "https://api.github.com/user/keys"
+
 func copySSHKeyToGitHub(sshKey types.SSHKey, initConfig *types.InitConfig) error {
 	sshKey = withSSHKeyDefaults(sshKey)
 
@@ -504,7 +507,7 @@ func copySSHKeyToGitHub(sshKey types.SSHKey, initConfig *types.InitConfig) error
 	}
 
 	// Create HTTP request
-	req, err := http.NewRequest("POST", "https://api.github.com/user/keys", bytes.NewBuffer(jsonData))
+	req, err := http.NewRequest("POST", githubKeysAPI, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return fmt.Errorf("error creating request: %v", err)
 	}
@@ -545,8 +548,12 @@ func copySSHKeyToGitHub(sshKey types.SSHKey, initConfig *types.InitConfig) error
 			// Check if it's a duplicate key error
 			if len(ghErr.Errors) > 0 {
 				for _, e := range ghErr.Errors {
+					// The key being on the account already is the state
+					// copy_to_github asks for, so a rerun on a converged
+					// system succeeds instead of failing the whole run.
 					if e.Field == "key" && strings.Contains(strings.ToLower(e.Message), "already in use") {
-						return fmt.Errorf("validation failed: this SSH key already exists in your GitHub account")
+						log.Infof("SSH public key already on GitHub: %s", title)
+						return nil
 					}
 				}
 			}

--- a/internal/processors/ssh_key_test.go
+++ b/internal/processors/ssh_key_test.go
@@ -221,14 +221,35 @@ func TestCopySSHKeyToGitHub_Success(t *testing.T) {
 	// This test documents the expected behavior
 }
 
-// TestCopySSHKeyToGitHub_Errors tests error scenarios.
+// TestCopySSHKeyToGitHub_Errors drives the real upload against a local server.
+// The duplicate-key 422 is the converged state — the key already being on the
+// account is what copy_to_github asks for — so it succeeds; every other
+// failure still errors.
 func TestCopySSHKeyToGitHub_Errors(t *testing.T) {
+	duplicate := githubError{
+		Message: "Validation Failed",
+		Errors: []struct {
+			Resource string `json:"resource"`
+			Code     string `json:"code"`
+			Field    string `json:"field"`
+			Message  string `json:"message"`
+		}{
+			{Resource: "PublicKey", Field: "key", Message: "key is already in use"},
+		},
+	}
+
 	tests := []struct {
 		name          string
 		statusCode    int
 		responseBody  interface{}
 		expectedError string
 	}{
+		{
+			name:          "201 Created",
+			statusCode:    201,
+			responseBody:  map[string]string{"key": "ok"},
+			expectedError: "",
+		},
 		{
 			name:          "401 Unauthorized",
 			statusCode:    401,
@@ -242,47 +263,50 @@ func TestCopySSHKeyToGitHub_Errors(t *testing.T) {
 			expectedError: "forbidden: GitHub token requires 'write:public_key' scope",
 		},
 		{
-			name:       "422 Duplicate Key",
-			statusCode: 422,
-			responseBody: githubError{
-				Message: "Validation Failed",
-				Errors: []struct {
-					Resource string `json:"resource"`
-					Code     string `json:"code"`
-					Field    string `json:"field"`
-					Message  string `json:"message"`
-				}{
-					{
-						Resource: "PublicKey",
-						Field:    "key",
-						Message:  "key is already in use",
-					},
-				},
-			},
-			expectedError: "validation failed: this SSH key already exists in your GitHub account",
+			name:          "422 Duplicate Key converges",
+			statusCode:    422,
+			responseBody:  duplicate,
+			expectedError: "",
+		},
+		{
+			name:          "422 other validation failure",
+			statusCode:    422,
+			responseBody:  githubError{Message: "key is invalid"},
+			expectedError: "validation failed: key is invalid",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create temporary SSH key files
 			tmpDir := t.TempDir()
-			privKeyPath := filepath.Join(tmpDir, "test_key")
-			pubKeyPath := privKeyPath + ".pub"
-
+			pubKeyPath := filepath.Join(tmpDir, "test_key.pub")
 			testPubKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ test@example.com"
-			err := os.WriteFile(pubKeyPath, []byte(testPubKey), 0600)
-			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(pubKeyPath, []byte(testPubKey), 0600))
 
-			// Create mock GitHub API server that returns error
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tt.statusCode)
-				json.NewEncoder(w).Encode(tt.responseBody)
+				json.NewEncoder(w).Encode(tt.responseBody) //nolint:errcheck
 			}))
 			defer server.Close()
 
-			// Note: In production, we'd need to make the API URL configurable
-			// This test documents the expected error handling
+			orig := githubKeysAPI
+			githubKeysAPI = server.URL
+			defer func() { githubKeysAPI = orig }()
+
+			err := copySSHKeyToGitHub(types.SSHKey{
+				Name:        "test_key",
+				Path:        tmpDir,
+				GithubTitle: "test-title",
+			}, &types.InitConfig{
+				Variables: types.Variables{Flags: types.Flags{GHAPIToken: "ghp_test"}},
+			})
+
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Three remaining violations of the reruns-converge contract from #163:

1. **Service file deletes** (`deleteServiceFile`, `deleteLaunchDaemon`, `deleteWindowsService`'s file removal) errored on the second run — no `IsNotExist` exemption, unlike `deleteFile` which got one in #163.
2. **Windows `sc create`/`sc delete`** fail for an already-registered/already-absent service. Both are now gated on an `sc query` probe (skipped in dry-run, where every command "succeeds" and the probe would lie).
3. **`copy_to_github`**: a duplicate key gets a 422 from GitHub, which was mapped to an error — so every rerun on a converged system exited non-zero. The duplicate is the desired state and now succeeds; other 422s still error.

## Tests
- Rerun-converges tests for all three delete paths and both `sc` probes (recorder-based, exact argv).
- The GitHub keys API URL becomes a var, and `TestCopySSHKeyToGitHub_Errors` now actually drives `copySSHKeyToGitHub` against httptest — the old version built a server and asserted nothing ("documents the expected error handling"). Covers 201, 401, 403, duplicate-422 (converges), and other-422 (errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)