### PR TITLE
fix(security): refuse plain-http downloads, verify declared sha256 digests

### DIFF
--- a/internal/processors/fonts.go
+++ b/internal/processors/fonts.go
@@ -215,7 +215,10 @@ func getFontURL(font types.Font, releaseURL string) string {
 }
 
 func downloadFontTarball(url, filepath string) error {
-	resp, err := http.Get(url) // #nosec G107 -- URL is operator-supplied (init/blueprint source); scheme restricted in PR6
+	if err := system.ValidateDownloadURL(url); err != nil {
+		return err
+	}
+	resp, err := http.Get(url) // #nosec G107 -- scheme restricted by ValidateDownloadURL above
 	if err != nil {
 		return err
 	}

--- a/internal/processors/repository.go
+++ b/internal/processors/repository.go
@@ -134,7 +134,7 @@ func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *
 				log.Infof("[DRY-RUN] Would download file: %s -> %s", step.Source, step.Dest)
 				continue
 			}
-			if err := system.DownloadFile(step.Source, step.Dest, provider.Elevated); err != nil {
+			if err := system.DownloadFileWithChecksum(step.Source, step.Dest, provider.Elevated, step.Sha256); err != nil {
 				return fmt.Errorf("error downloading file: %w", err)
 			}
 			continue
@@ -539,7 +539,7 @@ func withinAny(path string, boundaries []string) bool {
 func renderActionStep(step types.ActionStep, data map[string]any) (types.ActionStep, error) {
 	rendered := step
 
-	for _, field := range []*string{&rendered.Source, &rendered.Dest, &rendered.Exec, &rendered.Content, &rendered.Path, &rendered.Match, &rendered.Section} {
+	for _, field := range []*string{&rendered.Source, &rendered.Dest, &rendered.Exec, &rendered.Content, &rendered.Path, &rendered.Match, &rendered.Section, &rendered.Sha256} {
 		value, err := renderStepField(*field, data)
 		if err != nil {
 			return types.ActionStep{}, err

--- a/internal/processors/repository_checksum_test.go
+++ b/internal/processors/repository_checksum_test.go
@@ -1,0 +1,90 @@
+package processors
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// A download step's sha256 is a template like every other field, so a provider
+// can pin the fetched content to the digest the blueprint declares.
+func TestProcessRepository_DownloadStepVerifiesSha256(t *testing.T) {
+	content := []byte("signing key bytes")
+	sum := sha256.Sum256(content)
+	good := hex.EncodeToString(sum[:])
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	newProvider := func(dest string) *types.Provider {
+		return &types.Provider{
+			Name: "fake",
+			Detection: types.DetectionConfig{
+				Binary:        "go",
+				Distributions: []string{runtime.GOOS},
+			},
+			Repository: types.RepositoryConfig{
+				Add: types.RepositoryAction{
+					Steps: []types.ActionStep{{
+						Action: "download",
+						Source: "{{ .URL }}",
+						Dest:   dest,
+						Sha256: "{{ .SHA256 }}",
+					}},
+				},
+			},
+		}
+	}
+
+	t.Run("declared digest matches", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "key.gpg")
+		defer system.SetExecutor(exectest.New())()
+		defer system.SetProvidersForTest(map[string]*types.Provider{"fake": newProvider(dest)})()
+
+		err := processRepository(types.Repository{
+			Name:           "example",
+			PackageManager: "fake",
+			Action:         "add",
+			URL:            server.URL,
+			SHA256:         good,
+		}, &types.OSInfo{}, &types.InitConfig{})
+		if err != nil {
+			t.Fatalf("processRepository: %v", err)
+		}
+		if got, readErr := os.ReadFile(dest); readErr != nil || string(got) != string(content) {
+			t.Fatalf("dest = %q (%v), want the downloaded content", got, readErr)
+		}
+	})
+
+	t.Run("declared digest mismatch refuses", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "key.gpg")
+		defer system.SetExecutor(exectest.New())()
+		defer system.SetProvidersForTest(map[string]*types.Provider{"fake": newProvider(dest)})()
+
+		err := processRepository(types.Repository{
+			Name:           "example",
+			PackageManager: "fake",
+			Action:         "add",
+			URL:            server.URL,
+			SHA256:         strings.Repeat("0", 64),
+		}, &types.OSInfo{}, &types.InitConfig{})
+		if err == nil || !strings.Contains(err.Error(), "sha256 mismatch") {
+			t.Fatalf("err = %v, want a sha256 mismatch refusal", err)
+		}
+		if _, statErr := os.Stat(dest); statErr == nil {
+			t.Fatal("dest written despite the mismatch")
+		}
+	})
+}

--- a/internal/system/download_integrity_test.go
+++ b/internal/system/download_integrity_test.go
@@ -1,0 +1,98 @@
+package system
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Everything rwr downloads is installed with the operator's privileges —
+// package-signing keys included — so plain http from a real host is refused.
+// Loopback stays allowed for local mirrors and these tests.
+func TestValidateDownloadURL(t *testing.T) {
+	for _, tt := range []struct {
+		url string
+		ok  bool
+	}{
+		{"https://example.com/key.gpg", true},
+		{"http://localhost:8080/x", true},
+		{"http://127.0.0.1:9999/x", true},
+		{"http://[::1]/x", true},
+		{"http://example.com/key.gpg", false},
+		{"http://10.0.0.5/x", false},
+		{"ftp://example.com/x", false},
+		{"file:///etc/passwd", false},
+		{"://not a url", false},
+	} {
+		err := ValidateDownloadURL(tt.url)
+		if tt.ok && err != nil {
+			t.Errorf("ValidateDownloadURL(%q) = %v, want nil", tt.url, err)
+		}
+		if !tt.ok && err == nil {
+			t.Errorf("ValidateDownloadURL(%q) = nil, want refusal", tt.url)
+		}
+	}
+}
+
+// The refusal happens before any request is made: a plain-http URL to a dead
+// host errors on the scheme, not the network.
+func TestDownloadFile_RefusesPlainHTTP(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "out")
+	err := DownloadFile("http://example.invalid/key.gpg", target, false)
+	if err == nil || !strings.Contains(err.Error(), "plain http") {
+		t.Fatalf("err = %v, want a plain-http refusal", err)
+	}
+	if _, statErr := os.Stat(target); statErr == nil {
+		t.Fatal("target file exists despite the refusal")
+	}
+}
+
+func TestDownloadFileWithChecksum(t *testing.T) {
+	content := []byte("the artifact")
+	sum := sha256.Sum256(content)
+	good := hex.EncodeToString(sum[:])
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	t.Run("matching digest installs", func(t *testing.T) {
+		target := filepath.Join(t.TempDir(), "out")
+		if err := DownloadFileWithChecksum(server.URL, target, false, good); err != nil {
+			t.Fatalf("DownloadFileWithChecksum: %v", err)
+		}
+		got, err := os.ReadFile(target)
+		if err != nil || string(got) != string(content) {
+			t.Fatalf("target = %q (%v), want the artifact", got, err)
+		}
+	})
+
+	t.Run("digest case is ignored", func(t *testing.T) {
+		target := filepath.Join(t.TempDir(), "out")
+		if err := DownloadFileWithChecksum(server.URL, target, false, strings.ToUpper(good)); err != nil {
+			t.Fatalf("DownloadFileWithChecksum: %v", err)
+		}
+	})
+
+	t.Run("mismatch discards the download", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "out")
+		err := DownloadFileWithChecksum(server.URL, target, false, strings.Repeat("0", 64))
+		if err == nil || !strings.Contains(err.Error(), "sha256 mismatch") {
+			t.Fatalf("err = %v, want a sha256 mismatch", err)
+		}
+		entries, readErr := os.ReadDir(dir)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("directory not empty after refused install: %v", entries)
+		}
+	})
+}

--- a/internal/system/files.go
+++ b/internal/system/files.go
@@ -1,10 +1,14 @@
 package system
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -132,9 +136,59 @@ func removeStaged(name string) {
 	}
 }
 
+// ValidateDownloadURL refuses URLs rwr must not fetch from: everything it
+// downloads (package-signing keys included) is installed with the operator's
+// privileges, and a plain-http fetch lets anyone on the path substitute the
+// content. https is required; http is allowed only for loopback hosts, so
+// local mirrors and tests keep working.
+func ValidateDownloadURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid download URL %q: %v", raw, err)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		host := u.Hostname()
+		if host == "localhost" {
+			return nil
+		}
+		if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+			return nil
+		}
+		return fmt.Errorf("refusing to download %s over plain http: the content cannot be trusted in transit; use https", raw)
+	default:
+		return fmt.Errorf("refusing to download %s: unsupported scheme %q", raw, u.Scheme)
+	}
+}
+
+// verifyFileSHA256 compares the file's digest against the expected hex string.
+func verifyFileSHA256(path, wantHex string) error {
+	f, err := os.Open(path) // #nosec G304 -- staging file created by this package
+	if err != nil {
+		return fmt.Errorf("error opening downloaded file for verification: %v", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("error hashing downloaded file: %v", err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, strings.TrimSpace(wantHex)) {
+		return fmt.Errorf("sha256 mismatch: expected %s, got %s", wantHex, got)
+	}
+	return nil
+}
+
 func downloadFileContent(url, filePath string) error {
+	if err := ValidateDownloadURL(url); err != nil {
+		return err
+	}
+
 	// Send an HTTP GET request to the URL
-	response, err := http.Get(url) // #nosec G107 -- URL is operator-supplied (init/blueprint source); scheme restricted in PR6
+	response, err := http.Get(url) // #nosec G107 -- scheme restricted by ValidateDownloadURL above
 	if err != nil {
 		return fmt.Errorf("error downloading file: %v", err)
 	}
@@ -187,6 +241,13 @@ func moveFileWithElevatedPrivileges(source, target string) error {
 // DownloadFile downloads a file from the given URL to filePath.
 // If elevated is true, the file is moved to the target using sudo.
 func DownloadFile(url, filePath string, elevated bool) error {
+	return DownloadFileWithChecksum(url, filePath, elevated, "")
+}
+
+// DownloadFileWithChecksum is DownloadFile with an optional expected sha256
+// hex digest: when non-empty, the download is verified before it is moved
+// into place and discarded on a mismatch.
+func DownloadFileWithChecksum(url, filePath string, elevated bool, sha256Hex string) error {
 
 	log.Debugf("Downloading file from %s to %s", url, filePath)
 	mode := targetMode(filePath)
@@ -203,6 +264,13 @@ func DownloadFile(url, filePath string, elevated bool) error {
 	if err := downloadFileContent(url, tempFile.Name()); err != nil {
 		removeStaged(tempFile.Name())
 		return err
+	}
+
+	if sha256Hex != "" {
+		if err := verifyFileSHA256(tempFile.Name(), sha256Hex); err != nil {
+			removeStaged(tempFile.Name())
+			return fmt.Errorf("refusing to install %s: %w", url, err)
+		}
 	}
 
 	return moveIntoPlace(tempFile.Name(), filePath, mode, elevated)

--- a/internal/types/providers.go
+++ b/internal/types/providers.go
@@ -75,10 +75,15 @@ type ActionStep struct {
 	Path string `toml:"path,omitempty"`
 	// Match is the line a "remove_line" step takes out of Path, Section the
 	// ini-style section a "remove_section" step takes out of it.
-	Match   string   `toml:"match,omitempty"`
-	Section string   `toml:"section,omitempty"`
-	Source  string   `toml:"source,omitempty"`
-	Dest    string   `toml:"dest,omitempty"`
+	Match   string `toml:"match,omitempty"`
+	Section string `toml:"section,omitempty"`
+	Source  string `toml:"source,omitempty"`
+	Dest    string `toml:"dest,omitempty"`
+	// Sha256, when set on a "download" step, is the hex digest the fetched
+	// content must match — the download is discarded on a mismatch. It is a
+	// template like every other step field, so a provider can take it from the
+	// blueprint with `sha256 = "{{ .SHA256 }}"`.
+	Sha256  string   `toml:"sha256,omitempty"`
 	Exec    string   `toml:"exec,omitempty"`
 	Args    []string `toml:"args,omitempty"`
 	Content string   `toml:"content,omitempty"`


### PR DESCRIPTION
## Summary
Nothing rwr downloads was integrity-checked, and `http://` was accepted everywhere except the init file and git clones. Worst case: a `key_url: http://…` (or a MITM of it) substitutes an apt/rpm **signing key**, after which every package from that repo installs as root with a "valid" signature. The blueprint `sha256` field existed but was never verified.

## Changes
- `ValidateDownloadURL`: https required; http allowed only for loopback (local mirrors, httptest). Gates `downloadFileContent` — covering every `DownloadFile` caller (repository steps, package-manager installers, file URL sources) — and the font tarball fetch.
- `ActionStep` gains a templated `sha256`; a download step carrying one (e.g. `sha256 = "{{ .SHA256 }}"`) is verified before the staged file moves into place, and discarded on mismatch.
- `DownloadFileWithChecksum` added; `DownloadFile` unchanged for callers.

## Behavior change
Blueprints downloading from plain-http hosts now fail with an explicit refusal naming the URL. That's the point — but it is a compatibility break for anyone relying on an http mirror.

## Tests
Scheme table (https/loopback/remote-http/ftp/file), refusal-before-network, digest match/mismatch/case-insensitivity with staging cleanup asserted, and an end-to-end repository download step pinning `{{ .SHA256 }}` from the blueprint (match installs, mismatch refuses and writes nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)