### PR TITLE
fix(security): contain repository write steps, validate names, stage keys privately

### DIFF
--- a/internal/processors/repository.go
+++ b/internal/processors/repository.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"text/template"
 
 	"charm.land/log/v2"
@@ -72,8 +73,28 @@ func processRepositories(repositories []types.Repository, osInfo *types.OSInfo, 
 	return runRepositoryUpdates(initConfig)
 }
 
+// validateRepositoryName refuses names that would escape the paths derived
+// from them. repo.Name is blueprint-supplied and is joined into KeyPath,
+// TempKeyPath and provider-templated file names ("{{ .SourcesPath }}/
+// {{ .Name }}.list"), all written with the provider's privileges — root, for
+// every system package manager — so "../../etc/cron.d/x" would land the write
+// outside every declared boundary.
+func validateRepositoryName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("repository name is empty")
+	}
+	if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		return fmt.Errorf("invalid repository name %q: must not contain path separators or %q", name, "..")
+	}
+	return nil
+}
+
 // processRepository runs one repository's provider action steps.
 func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
+	if err := validateRepositoryName(repo.Name); err != nil {
+		return err
+	}
+
 	provider, exists := system.GetProvider(repo.PackageManager)
 	if !exists {
 		return fmt.Errorf("unsupported package manager: %s", repo.PackageManager)
@@ -130,20 +151,28 @@ func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *
 				Secrets: repo.SecretValues(),
 			}
 		case "download":
+			dest, err := repositoryWritePath(step.Dest, repoConfig.Paths)
+			if err != nil {
+				return fmt.Errorf("error downloading for %s: %w", repo.Name, err)
+			}
 			if system.IsDryRun() {
-				log.Infof("[DRY-RUN] Would download file: %s -> %s", step.Source, step.Dest)
+				log.Infof("[DRY-RUN] Would download file: %s -> %s", step.Source, dest)
 				continue
 			}
-			if err := system.DownloadFileWithChecksum(step.Source, step.Dest, provider.Elevated, step.Sha256); err != nil {
+			if err := system.DownloadFileWithChecksum(step.Source, dest, provider.Elevated, step.Sha256); err != nil {
 				return fmt.Errorf("error downloading file: %w", err)
 			}
 			continue
 		case "write":
+			dest, err := repositoryWritePath(step.Dest, repoConfig.Paths)
+			if err != nil {
+				return fmt.Errorf("error writing for %s: %w", repo.Name, err)
+			}
 			if system.IsDryRun() {
-				log.Infof("[DRY-RUN] Would write file: %s", step.Dest)
+				log.Infof("[DRY-RUN] Would write file: %s", dest)
 				continue
 			}
-			if err := system.WriteToFile(step.Dest, step.Content, provider.Elevated); err != nil {
+			if err := system.WriteToFile(dest, step.Content, provider.Elevated); err != nil {
 				return fmt.Errorf("error writing file: %w", err)
 			}
 			continue
@@ -192,11 +221,15 @@ func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *
 			}
 			continue
 		case "copy":
+			dest, err := repositoryWritePath(step.Dest, repoConfig.Paths)
+			if err != nil {
+				return fmt.Errorf("error copying for %s: %w", repo.Name, err)
+			}
 			if system.IsDryRun() {
-				log.Infof("[DRY-RUN] Would copy file: %s -> %s", step.Source, step.Dest)
+				log.Infof("[DRY-RUN] Would copy file: %s -> %s", step.Source, dest)
 				continue
 			}
-			if err := system.CopyFile(step.Source, step.Dest, provider.Elevated, osInfo); err != nil {
+			if err := system.CopyFile(step.Source, dest, provider.Elevated, osInfo); err != nil {
 				return fmt.Errorf("error copying file: %w", err)
 			}
 			continue
@@ -264,7 +297,7 @@ func repositoryStepData(repo types.Repository, paths types.RepositoryPaths, prov
 		"KeysPath":       paths.Keys,
 		"ConfigPath":     paths.Config,
 		"KeyPath":        keyPath,
-		"TempKeyPath":    filepath.Join(os.TempDir(), repo.Name+".gpg"),
+		"TempKeyPath":    filepath.Join(repositoryTempDir(), repo.Name+".gpg"),
 		"KeyID":          repo.KeyID,
 		// The local file a snap or a GNOME extension is installed from. Only
 		// the steps gated on IsLocalFile/IsLocalSnap use it, and those are the
@@ -489,6 +522,66 @@ func removeRepositoryPath(path string, paths types.RepositoryPaths, elevated, de
 
 	log.Infof("Removed repository file: %s", resolved)
 	return nil
+}
+
+// repositoryTempDir is the per-run private directory repository steps stage
+// into ({{ .TempKeyPath }}). It replaces fixed paths under os.TempDir(): a
+// world-known name like /tmp/docker.gpg can be pre-created (or swapped
+// between steps) by any local user, and the very next step imports it as a
+// signing key with root privileges. A 0700 per-run directory is not
+// reachable by other users at all.
+var (
+	repoTempDirOnce sync.Once
+	repoTempDirPath string
+)
+
+func repositoryTempDir() string {
+	repoTempDirOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "rwr-repo-")
+		if err != nil {
+			// Surfaced at use: the write into the unusable directory fails
+			// with a real error naming the path.
+			log.Errorf("could not create the repository staging directory: %v", err)
+			repoTempDirPath = filepath.Join(os.TempDir(), "rwr-repo-unavailable")
+			return
+		}
+		repoTempDirPath = dir
+	})
+	return repoTempDirPath
+}
+
+// repositoryWritePath resolves the destination a download/write/copy step
+// names and refuses anything outside the provider's declared repository paths
+// or the run's private staging directory. These steps run with the provider's
+// privileges — root, for every system package manager — and the destination
+// is a template rendered against blueprint values, so an unchecked dest is a
+// root-privileged write to an arbitrary path. The in-place edit and remove
+// steps have been contained since #163; this closes the same door for the
+// steps that create files.
+func repositoryWritePath(dest string, paths types.RepositoryPaths) (string, error) {
+	if strings.TrimSpace(dest) == "" {
+		return "", fmt.Errorf("step has no dest")
+	}
+
+	resolved := filepath.Clean(system.ExpandPath(dest))
+	if !filepath.IsAbs(resolved) {
+		return "", fmt.Errorf("refusing to write %q: path is not absolute", dest)
+	}
+
+	boundaries := append(repositoryBoundaries(paths), repositoryTempDir())
+	if resolved == repositoryTempDir() {
+		return "", fmt.Errorf("refusing to write %q: it is the staging directory itself", dest)
+	}
+	for _, boundary := range boundaries {
+		if resolved == boundary {
+			return resolved, nil
+		}
+	}
+	if withinAny(resolved, boundaries) {
+		return resolved, nil
+	}
+
+	return "", fmt.Errorf("refusing to write %q: outside the provider's repository paths %v", resolved, boundaries)
 }
 
 // repositoryBoundaries returns the directories a remove step may act inside.

--- a/internal/processors/repository_checksum_test.go
+++ b/internal/processors/repository_checksum_test.go
@@ -28,6 +28,9 @@ func TestProcessRepository_DownloadStepVerifiesSha256(t *testing.T) {
 	}))
 	defer server.Close()
 
+	// The dest's directory is declared as the provider's keys path: download
+	// destinations are contained inside [provider.repository.paths], the same
+	// shape as a real provider writing a keyring.
 	newProvider := func(dest string) *types.Provider {
 		return &types.Provider{
 			Name: "fake",
@@ -36,6 +39,7 @@ func TestProcessRepository_DownloadStepVerifiesSha256(t *testing.T) {
 				Distributions: []string{runtime.GOOS},
 			},
 			Repository: types.RepositoryConfig{
+				Paths: types.RepositoryPaths{Keys: filepath.Dir(dest)},
 				Add: types.RepositoryAction{
 					Steps: []types.ActionStep{{
 						Action: "download",

--- a/internal/processors/repository_containment_test.go
+++ b/internal/processors/repository_containment_test.go
@@ -1,0 +1,103 @@
+package processors
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// download/write/copy steps run with the provider's privileges and their dest
+// is a template rendered against blueprint values. append/remove_line/
+// remove_section/remove have been contained since #163; these are the steps
+// that create files, closed the same way.
+func TestRepositoryWriteStepsAreContained(t *testing.T) {
+	sourcesDir, keysDir := repoDirs(t)
+	victim := filepath.Join(t.TempDir(), "cron.d", "evil")
+
+	newProvider := func(step types.ActionStep) *types.Provider {
+		return &types.Provider{
+			Name: "fake",
+			Detection: types.DetectionConfig{
+				Binary:        "go",
+				Distributions: []string{runtime.GOOS},
+			},
+			Repository: types.RepositoryConfig{
+				Paths: types.RepositoryPaths{Sources: sourcesDir, Keys: keysDir},
+				Add:   types.RepositoryAction{Steps: []types.ActionStep{step}},
+			},
+		}
+	}
+
+	for _, tt := range []struct {
+		name string
+		step types.ActionStep
+	}{
+		{name: "write outside", step: types.ActionStep{Action: "write", Dest: victim, Content: "* * * * * root sh"}},
+		{name: "download outside", step: types.ActionStep{Action: "download", Source: "https://example.com/x", Dest: victim}},
+		{name: "copy outside", step: types.ActionStep{Action: "copy", Source: filepath.Join(sourcesDir, "x"), Dest: victim}},
+		{name: "relative dest", step: types.ActionStep{Action: "write", Dest: "sources.list.d/x.list", Content: "c"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			defer system.SetExecutor(exectest.New())()
+			defer system.SetProvidersForTest(map[string]*types.Provider{"fake": newProvider(tt.step)})()
+
+			err := processRepository(types.Repository{
+				Name:           "example",
+				PackageManager: "fake",
+				Action:         "add",
+				URL:            "https://example.com/repo",
+			}, &types.OSInfo{}, &types.InitConfig{})
+
+			if err == nil || !strings.Contains(err.Error(), "refusing to write") {
+				t.Fatalf("err = %v, want a containment refusal", err)
+			}
+			if _, statErr := os.Stat(victim); statErr == nil {
+				t.Fatalf("%s written despite the refusal", victim)
+			}
+		})
+	}
+
+	// A dest inside the declared paths still works.
+	t.Run("write inside is allowed", func(t *testing.T) {
+		inside := filepath.Join(sourcesDir, "example.list")
+		defer system.SetExecutor(exectest.New())()
+		defer system.SetProvidersForTest(map[string]*types.Provider{
+			"fake": newProvider(types.ActionStep{Action: "write", Dest: inside, Content: "deb https://example.com stable main"}),
+		})()
+
+		if err := processRepository(types.Repository{
+			Name:           "example",
+			PackageManager: "fake",
+			Action:         "add",
+			URL:            "https://example.com/repo",
+		}, &types.OSInfo{}, &types.InitConfig{}); err != nil {
+			t.Fatalf("processRepository: %v", err)
+		}
+		if _, err := os.Stat(inside); err != nil {
+			t.Fatalf("contained write did not land: %v", err)
+		}
+	})
+}
+
+// repo.Name is joined into KeyPath, TempKeyPath and provider-templated file
+// names, all written with the provider's privileges.
+func TestProcessRepository_RefusesTraversalName(t *testing.T) {
+	defer system.SetExecutor(exectest.New())()
+
+	for _, name := range []string{"../../../etc/cron.d/x", "a/b", `a\b`, "..", " "} {
+		err := processRepository(types.Repository{
+			Name:           name,
+			PackageManager: "apt",
+			Action:         "add",
+		}, &types.OSInfo{}, &types.InitConfig{})
+		if err == nil || !strings.Contains(err.Error(), "name") {
+			t.Errorf("name %q: err = %v, want a name refusal", name, err)
+		}
+	}
+}

--- a/internal/processors/repository_test.go
+++ b/internal/processors/repository_test.go
@@ -127,7 +127,10 @@ func TestProcessRepositories_AptAddRendersProviderTemplates(t *testing.T) {
 	}
 
 	keyPath := filepath.Join(keysDir, "docker.gpg")
-	tempKeyPath := filepath.Join(os.TempDir(), "docker.gpg")
+	// The staging path is inside the run's private 0700 directory, not a
+	// world-known name under /tmp any local user could pre-create or swap
+	// between the download and the dearmor that imports it as root.
+	tempKeyPath := filepath.Join(repositoryTempDir(), "docker.gpg")
 
 	// The key is downloaded to the temporary path the dearmor step reads from.
 	if _, err := os.Stat(tempKeyPath); err != nil {


### PR DESCRIPTION
## Summary
Three related gaps in the repository processor's containment story:

1. **download/write/copy steps were uncontained.** The edit/remove steps have been checked against `[provider.repository.paths]` since #163, but the file-creating steps passed their rendered `dest` straight to root-privileged writes. `repositoryWritePath` now applies the same boundary check.
2. **`repo.Name` was never validated**, despite being joined into `KeyPath`, `TempKeyPath`, and provider templates like `{{ .SourcesPath }}/{{ .Name }}.list` — `name: "../../etc/cron.d/x"` escaped every boundary. Same rule as `validateFontName`: no separators, no `..`.
3. **`TempKeyPath` was a fixed, world-known name** (`/tmp/<name>.gpg`) that any local user could pre-create or swap between the download and the `gpg --dearmor`/`rpm --import` that trusts it as root. It now lives in a per-run 0700 staging directory, which is also a containment boundary so apt/dnf download-then-import flows keep working unchanged.

## Tests
Containment table (write/download/copy outside → refused with nothing written; relative dest → refused; inside → lands), traversal-name table, and the existing apt end-to-end test updated to assert the key stages in the private directory.

Note: touches the same `download` case as #180 — whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)