### PR TITLE
fix(security): stage provider installers in a private per-run directory

### DIFF
--- a/internal/processors/packageManager.go
+++ b/internal/processors/packageManager.go
@@ -2,11 +2,36 @@ package processors
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
 
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/types"
 )
+
+// packageManagerTempDir is the per-run private directory install/remove steps
+// stage into via {{ .TempDir }}.
+var (
+	pmTempDirOnce sync.Once
+	pmTempDirPath string
+)
+
+func packageManagerTempDir() string {
+	pmTempDirOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "rwr-pm-")
+		if err != nil {
+			// Surfaced at use: the write into the unusable directory fails
+			// with a real error naming the path.
+			log.Errorf("could not create the package manager staging directory: %v", err)
+			pmTempDirPath = filepath.Join(os.TempDir(), "rwr-pm-unavailable")
+			return
+		}
+		pmTempDirPath = dir
+	})
+	return pmTempDirPath
+}
 
 // ProcessPackageManagers installs package managers and their common dependencies
 // (OpenSSL, build essentials) before installing each requested package manager.
@@ -33,10 +58,14 @@ func ProcessPackageManagers(packageManagers []types.PackageManagerInfo, osInfo *
 	// Process each package manager
 	for _, pm := range packageManagers {
 		log.Debugf("Processing package manager: %s (action: %s)", pm.Name, pm.Action)
-		provider, exists := system.GetProvider(pm.Name)
+		// The definition-level lookup, not GetProvider: GetProvider reports a
+		// provider whose binary is missing as unavailable, and a missing
+		// binary is exactly the state an install starts from. With GetProvider
+		// here, install steps could never run at all — absent binary errored,
+		// present binary skipped as already installed.
+		provider, exists := system.GetProviderDefinition(pm.Name)
 		if !exists {
-			// GetProvider will have already logged detailed error info
-			return fmt.Errorf("package manager %s is not available - check debug logs for details", pm.Name)
+			return fmt.Errorf("no provider definition for package manager %s", pm.Name)
 		}
 
 		// Check if already installed
@@ -57,7 +86,18 @@ func ProcessPackageManagers(packageManagers []types.PackageManagerInfo, osInfo *
 		}
 
 		// Execute each step
-		for _, step := range steps {
+		for _, rawStep := range steps {
+			// Install steps historically staged at fixed, world-known /tmp
+			// names (/tmp/brew-install.sh, a git clone into /tmp/yay). Any
+			// local user can pre-create such a path — or rewrite it between
+			// the download and the elevated step that executes it — which is
+			// root code execution. {{ .TempDir }} renders to a per-run 0700
+			// directory other users cannot reach.
+			step, err := renderActionStep(rawStep, map[string]any{"TempDir": packageManagerTempDir()})
+			if err != nil {
+				return fmt.Errorf("error rendering %s step for %s: %w", pm.Action, pm.Name, err)
+			}
+
 			var cmd types.Command
 
 			switch step.Action {

--- a/internal/processors/package_manager_staging_test.go
+++ b/internal/processors/package_manager_staging_test.go
@@ -1,0 +1,96 @@
+package processors
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// Install steps staged at fixed, world-known /tmp names any local user could
+// pre-create or rewrite between the download and the elevated step executing
+// it. {{ .TempDir }} renders to a per-run 0700 directory instead.
+func TestProcessPackageManagers_InstallStepsStageInPrivateTempDir(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("#!/bin/sh\necho hi\n"))
+	}))
+	defer server.Close()
+
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+	defer system.SetProvidersForTest(map[string]*types.Provider{
+		"fakepm": {
+			Name: "fakepm",
+			Detection: types.DetectionConfig{
+				// Must not exist: an installed binary short-circuits the install.
+				Binary:        "rwr-test-no-such-binary",
+				Distributions: []string{runtime.GOOS},
+			},
+			Install: types.InstallConfig{
+				Steps: []types.ActionStep{
+					{Action: "download", Source: server.URL + "/install.sh", Dest: "{{ .TempDir }}/fakepm-install.sh"},
+					{Action: "command", Exec: "bash", Args: []string{"{{ .TempDir }}/fakepm-install.sh"}},
+				},
+			},
+		},
+	})()
+
+	err := ProcessPackageManagers([]types.PackageManagerInfo{
+		{Name: "fakepm", Action: "install"},
+	}, &types.OSInfo{}, &types.InitConfig{})
+	if err != nil {
+		t.Fatalf("ProcessPackageManagers: %v", err)
+	}
+
+	staged := filepath.Join(packageManagerTempDir(), "fakepm-install.sh")
+	if got, readErr := os.ReadFile(staged); readErr != nil || !strings.Contains(string(got), "echo hi") {
+		t.Fatalf("staged installer = %q (%v), want the downloaded script in the private dir", got, readErr)
+	}
+
+	// The private directory is not reachable by other users.
+	if info, statErr := os.Stat(packageManagerTempDir()); statErr != nil || info.Mode().Perm() != 0o700 {
+		t.Errorf("staging dir mode = %v (%v), want 0700", info.Mode().Perm(), statErr)
+	}
+
+	calls := rec.Find("bash")
+	if len(calls) != 1 {
+		t.Fatalf("recorded %d bash calls, want 1: %v", len(calls), rec.Calls)
+	}
+	if got := calls[0].Args[0]; got != staged {
+		t.Errorf("bash argv[1] = %q, want the rendered staging path %q", got, staged)
+	}
+	for _, arg := range calls[0].Argv() {
+		if strings.Contains(arg, "{{") {
+			t.Errorf("unrendered placeholder reached the command: %v", calls[0])
+		}
+	}
+}
+
+// No shipped install or remove step may name a fixed path under /tmp: a
+// world-known name in a shared directory is pre-creatable by any local user.
+func TestEmbeddedProviders_NoFixedTmpPathsInInstallSteps(t *testing.T) {
+	embedded, err := system.LoadEmbeddedProviders()
+	if err != nil {
+		t.Fatalf("LoadEmbeddedProviders: %v", err)
+	}
+
+	for name, provider := range embedded {
+		for _, steps := range [][]types.ActionStep{provider.Install.Steps, provider.Remove.Steps} {
+			for _, step := range steps {
+				fields := append([]string{step.Source, step.Dest, step.Exec, step.Content}, step.Args...)
+				for _, field := range fields {
+					if strings.Contains(field, "/tmp/") {
+						t.Errorf("provider %s stages at a fixed /tmp path: %q — use {{ .TempDir }}", name, field)
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/system/definitions/providers/aura.toml
+++ b/internal/system/definitions/providers/aura.toml
@@ -44,12 +44,12 @@ args = ["-S", "--needed", "--noconfirm", "base-devel", "git"]
 [[provider.install.steps]]
 action = "command"
 exec = "git"
-args = ["clone", "https://aur.archlinux.org/aura-bin.git", "/tmp/aura"]
+args = ["clone", "https://aur.archlinux.org/aura-bin.git", "{{ .TempDir }}/aura"]
 
 [[provider.install.steps]]
 action = "command"
 exec = "sh"
-args = ["-c", "cd /tmp/aura && makepkg -si --noconfirm"]
+args = ["-c", "cd {{ .TempDir }}/aura && makepkg -si --noconfirm"]
 
 [[provider.remove.steps]]
 action = "command"

--- a/internal/system/definitions/providers/brew.toml
+++ b/internal/system/definitions/providers/brew.toml
@@ -25,38 +25,38 @@ clean = "cleanup -q"
 [provider.install]
 steps = [
   # Download install script
-  { action = "download", source = "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh", dest = "/tmp/brew-install.sh" },
+  { action = "download", source = "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh", dest = "{{ .TempDir }}/brew-install.sh" },
   # Make executable
   { action = "command", exec = "chmod", args = [
     "+x",
-    "/tmp/brew-install.sh",
+    "{{ .TempDir }}/brew-install.sh",
   ] },
   # Run installer
   { action = "command", exec = "bash", args = [
-    "/tmp/brew-install.sh",
+    "{{ .TempDir }}/brew-install.sh",
   ] },
   # Clean up
   { action = "command", exec = "rm", args = [
-    "/tmp/brew-install.sh",
+    "{{ .TempDir }}/brew-install.sh",
   ] },
 ]
 
 [provider.remove]
 steps = [
   # Download uninstall script
-  { action = "download", source = "https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh", dest = "/tmp/brew-uninstall.sh" },
+  { action = "download", source = "https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh", dest = "{{ .TempDir }}/brew-uninstall.sh" },
   # Make executable
   { action = "command", exec = "chmod", args = [
     "+x",
-    "/tmp/brew-uninstall.sh",
+    "{{ .TempDir }}/brew-uninstall.sh",
   ] },
   # Run uninstaller
   { action = "command", exec = "bash", args = [
-    "/tmp/brew-uninstall.sh",
+    "{{ .TempDir }}/brew-uninstall.sh",
   ] },
   # Clean up
   { action = "command", exec = "rm", args = [
-    "/tmp/brew-uninstall.sh",
+    "{{ .TempDir }}/brew-uninstall.sh",
   ] },
 ]
 

--- a/internal/system/definitions/providers/cargo.toml
+++ b/internal/system/definitions/providers/cargo.toml
@@ -34,13 +34,13 @@ args = [
   "-sSf",
   "https://sh.rustup.rs",
   "-o",
-  "/tmp/rustup-init.sh",
+  "{{ .TempDir }}/rustup-init.sh",
 ]
 
 [[provider.install.steps]]
 action = "command"
 exec = "sh"
-args = ["/tmp/rustup-init.sh", "-y"]
+args = ["{{ .TempDir }}/rustup-init.sh", "-y"]
 
 # Install cargo-update
 [[provider.install.steps]]

--- a/internal/system/definitions/providers/nix.toml
+++ b/internal/system/definitions/providers/nix.toml
@@ -44,20 +44,20 @@ steps = [
     "-L",
     "https://nixos.org/nix/install",
     "--output",
-    "/tmp/nix-install",
+    "{{ .TempDir }}/nix-install",
   ] },
   # Make executable
   { action = "command", exec = "chmod", args = [
     "+x",
-    "/tmp/nix-install",
+    "{{ .TempDir }}/nix-install",
   ] },
   # Run installer
   { action = "command", exec = "sh", args = [
-    "/tmp/nix-install",
+    "{{ .TempDir }}/nix-install",
   ] },
   # Clean up
   { action = "command", exec = "rm", args = [
-    "/tmp/nix-install",
+    "{{ .TempDir }}/nix-install",
   ] },
   # Add unstable channel
   { action = "command", exec = "nix-channel", args = [
@@ -78,20 +78,20 @@ steps = [
     "-L",
     "https://nixos.org/nix/uninstall",
     "--output",
-    "/tmp/nix-uninstall",
+    "{{ .TempDir }}/nix-uninstall",
   ] },
   # Make executable
   { action = "command", exec = "chmod", args = [
     "+x",
-    "/tmp/nix-uninstall",
+    "{{ .TempDir }}/nix-uninstall",
   ] },
   # Run uninstaller
   { action = "command", exec = "sh", args = [
-    "/tmp/nix-uninstall",
+    "{{ .TempDir }}/nix-uninstall",
   ] },
   # Clean up
   { action = "command", exec = "rm", args = [
-    "/tmp/nix-uninstall",
+    "{{ .TempDir }}/nix-uninstall",
   ] },
 ]
 

--- a/internal/system/definitions/providers/pamac.toml
+++ b/internal/system/definitions/providers/pamac.toml
@@ -44,12 +44,12 @@ args = ["-S", "--needed", "--noconfirm", "base-devel", "git"]
 [[provider.install.steps]]
 action = "command"
 exec = "git"
-args = ["clone", "https://aur.archlinux.org/pamac-aur.git", "/tmp/pamac"]
+args = ["clone", "https://aur.archlinux.org/pamac-aur.git", "{{ .TempDir }}/pamac"]
 
 [[provider.install.steps]]
 action = "command"
 exec = "sh"
-args = ["-c", "cd /tmp/pamac && makepkg -si --noconfirm"]
+args = ["-c", "cd {{ .TempDir }}/pamac && makepkg -si --noconfirm"]
 
 [[provider.remove.steps]]
 action = "command"

--- a/internal/system/definitions/providers/paru.toml
+++ b/internal/system/definitions/providers/paru.toml
@@ -44,12 +44,12 @@ args = ["-S", "--needed", "--noconfirm", "base-devel", "git"]
 [[provider.install.steps]]
 action = "command"
 exec = "git"
-args = ["clone", "https://aur.archlinux.org/paru.git", "/tmp/paru"]
+args = ["clone", "https://aur.archlinux.org/paru.git", "{{ .TempDir }}/paru"]
 
 [[provider.install.steps]]
 action = "command"
 exec = "sh"
-args = ["-c", "cd /tmp/paru && makepkg -si --noconfirm"]
+args = ["-c", "cd {{ .TempDir }}/paru && makepkg -si --noconfirm"]
 
 [[provider.remove.steps]]
 action = "command"

--- a/internal/system/definitions/providers/trizen.toml
+++ b/internal/system/definitions/providers/trizen.toml
@@ -35,12 +35,12 @@ args = ["-S", "--needed", "--noconfirm", "base-devel", "git"]
 [[provider.install.steps]]
 action = "command"
 exec = "git"
-args = ["clone", "https://aur.archlinux.org/trizen.git", "/tmp/trizen"]
+args = ["clone", "https://aur.archlinux.org/trizen.git", "{{ .TempDir }}/trizen"]
 
 [[provider.install.steps]]
 action = "command"
 exec = "sh"
-args = ["-c", "cd /tmp/trizen && makepkg -si --noconfirm"]
+args = ["-c", "cd {{ .TempDir }}/trizen && makepkg -si --noconfirm"]
 
 [[provider.remove.steps]]
 action = "command"

--- a/internal/system/definitions/providers/yay.toml
+++ b/internal/system/definitions/providers/yay.toml
@@ -35,12 +35,12 @@ args = ["-S", "--needed", "--noconfirm", "base-devel", "git"]
 [[provider.install.steps]]
 action = "command"
 exec = "git"
-args = ["clone", "https://aur.archlinux.org/yay.git", "/tmp/yay"]
+args = ["clone", "https://aur.archlinux.org/yay.git", "{{ .TempDir }}/yay"]
 
 [[provider.install.steps]]
 action = "command"
 exec = "sh"
-args = ["-c", "cd /tmp/yay && makepkg -si --noconfirm"]
+args = ["-c", "cd {{ .TempDir }}/yay && makepkg -si --noconfirm"]
 
 [[provider.remove.steps]]
 action = "command"

--- a/internal/system/files.go
+++ b/internal/system/files.go
@@ -106,8 +106,17 @@ func copyFileContentMode(source, target string, mode os.FileMode) error {
 
 // targetMode returns the mode a write to filePath should end up with: the
 // existing file's mode when there is one, so a rewrite cannot widen it.
+//
+// Only a file the invoking user owns donates its mode. In a shared directory
+// like /tmp anyone can plant the target ahead of time, and inheriting a
+// planted 0666 turns the freshly written file — root-owned, about to be
+// executed by an install step — into one every local user can rewrite.
 func targetMode(filePath string) os.FileMode {
 	if info, err := os.Stat(filePath); err == nil {
+		if !fileOwnedByEUID(info) {
+			log.Warnf("Not inheriting permissions from %s: it is owned by another user; using %04o", filePath, defaultFileMode)
+			return defaultFileMode
+		}
 		return info.Mode().Perm()
 	}
 	return defaultFileMode

--- a/internal/system/files_owner_unix.go
+++ b/internal/system/files_owner_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package system
+
+import (
+	"os"
+	"syscall"
+)
+
+// fileOwnedByEUID reports whether the file belongs to the effective user, so
+// targetMode only inherits permissions from files the invoking user (or root,
+// when elevated) actually owns.
+func fileOwnedByEUID(info os.FileInfo) bool {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return int(st.Uid) == os.Geteuid()
+}

--- a/internal/system/files_owner_windows.go
+++ b/internal/system/files_owner_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package system
+
+import "os"
+
+// fileOwnedByEUID: Windows has no unix ownership; os.FileMode carries no
+// security there either (files report 0666), so mode inheritance is a no-op
+// concern and the check always passes.
+func fileOwnedByEUID(os.FileInfo) bool {
+	return true
+}

--- a/internal/system/files_test.go
+++ b/internal/system/files_test.go
@@ -517,3 +517,35 @@ func TestMoveIntoPlace_CrossFilesystem(t *testing.T) {
 		t.Errorf("mode = %o, want 0640", perm)
 	}
 }
+
+// A pre-existing target donates its mode only when the invoking user owns it:
+// in a shared directory anyone can plant the target ahead of time, and
+// inheriting a planted 0666 leaves the freshly written file world-writable.
+func TestTargetMode_InheritsOnlyFromOwnFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	owned := filepath.Join(dir, "owned")
+	if err := os.WriteFile(owned, []byte("x"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(owned, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if got := targetMode(owned); got != 0o640 {
+		t.Errorf("targetMode(own file) = %04o, want 0640 inherited", got)
+	}
+
+	if got := targetMode(filepath.Join(dir, "absent")); got != defaultFileMode {
+		t.Errorf("targetMode(absent) = %04o, want the default %04o", got, defaultFileMode)
+	}
+
+	// A file owned by another user cannot be created without privileges, so
+	// the refusal branch is exercised at the helper level.
+	info, err := os.Stat(owned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fileOwnedByEUID(info) {
+		t.Error("fileOwnedByEUID(own file) = false, want true")
+	}
+}

--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -274,6 +274,22 @@ func GetProvider(name string) (*types.Provider, bool) {
 	return provider, true
 }
 
+// GetProviderDefinition returns a provider by name without requiring its
+// binary to exist. GetProvider treats a missing binary as "not available",
+// which is right everywhere except the install flow — whose entire purpose is
+// that the binary is not there yet.
+func GetProviderDefinition(name string) (*types.Provider, bool) {
+	if err := InitProviders(); err != nil {
+		log.Errorf("GetProviderDefinition: Error initializing providers: %v", err)
+		return nil, false
+	}
+
+	providersMu.Lock()
+	defer providersMu.Unlock()
+	provider, exists := providers[name]
+	return provider, exists
+}
+
 // GetProvidersPath returns the absolute path to the provider definitions directory,
 // searching the executable's directory and common installation paths.
 //


### PR DESCRIPTION
## Summary
The local-root-escalation finding from the review: provider install steps stage at **fixed, world-known /tmp names** (`/tmp/brew-install.sh`, `/tmp/nix-install`, `git clone` into `/tmp/yay`, …). Any local user can pre-create the path — or swap the file between the download and the elevated step that executes it. `targetMode()` made it worse: a planted 0666 target donated its mode, producing a root-owned world-writable script.

## Changes
- Install/remove steps are now template-rendered (same `renderActionStep` as repository steps) with `{{ .TempDir }}` resolving to a per-run `0700` staging directory; all 8 providers with fixed `/tmp` paths (brew, nix, cargo, yay, paru, trizen, aura, pamac) moved onto it. The AUR clone-into-pre-owned-dir attack dies with it — the directory is fresh and unreachable by other users.
- `targetMode()` inherits permissions only from a file the effective user owns (`fileOwnedByEUID`, unix build tag; Windows unaffected — no unix modes there).
- **Bonus reachability fix:** `ProcessPackageManagers` used `GetProvider`, which treats a missing binary as "unavailable" — so install steps could literally never run (absent binary → error, present binary → "already installed" skip). It now uses a definition-level lookup, `GetProviderDefinition`.

## Tests
- End-to-end: fake provider downloads its installer via `{{ .TempDir }}` and runs it — asserts the file lands in the 0700 private dir and the rendered path (no placeholders) reaches the argv. Only passes because of the reachability fix — install steps were undrivable before.
- `TestEmbeddedProviders_NoFixedTmpPathsInInstallSteps` — a guard over every shipped provider; fails on master against all 8.
- `targetMode` inheritance tests (own-file inherits, absent uses default, ownership helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)