### PR TITLE
ci(release): only cut releases from v* tags, with the tested toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: RWR - Release
 
+# Only version tags cut a release. "*" meant any tag — a typo, an experiment,
+# a manually pushed `nightly` — published to GitHub, the Homebrew tap and the
+# naur dispatch. Release tags here have always been v-prefixed (v0.5.1).
 on:
   push:
     tags:
-      - "*"
+      - "v*"
 permissions:
   contents: write
 
@@ -15,10 +18,13 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      # The same constraint go.yml tests with (and mise.toml pins locally for
+      # GO-2026-5856). `stable` here meant release binaries could be built by a
+      # toolchain no CI run had ever tested.
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: stable
+          go-version: ">=1.26.5"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:


### PR DESCRIPTION
## Summary
Two release-workflow hardening items from the review:

1. `tags: "*"` → `tags: "v*"` — any pushed tag (a typo, an experiment, a manual `nightly`) cut a full release, published to the Homebrew tap, and fired the naur dispatch. Release tags have always been v-prefixed.
2. `go-version: stable` → `">=1.26.5"` — release binaries could be built with a toolchain no CI run ever tested. Now matches go.yml/nightly.yml (and mise.toml's pin for GO-2026-5856).

🤖 Generated with [Claude Code](https://claude.com/claude-code)