### PR TITLE
ci(release): sign checksums with keyless cosign, publish SPDX SBOMs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,9 @@ on:
 
 permissions:
   contents: write
+  # Keyless cosign signing exchanges the job's OIDC token for a short-lived
+  # certificate; no signing key is stored anywhere.
+  id-token: write
 
 concurrency:
   # Merges can land faster than a build takes. Keep only the newest, so the
@@ -38,6 +41,14 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: ">=1.26.5"
+
+      # cosign signs checksums.txt, syft writes the SBOMs — both invoked by
+      # goreleaser (signs: / sboms: in .goreleaser.yaml). The nightly gets the
+      # same treatment as a release: people install it.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
 
       # --snapshot builds without publishing, so the version comes from
       # .goreleaser.yaml's snapshot template and carries the commit sha.
@@ -84,7 +95,8 @@ jobs:
             find dist -maxdepth 1 -type f \
               \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.deb' \
                  -o -name '*.rpm' -o -name '*.apk' -o -name '*.pkg.tar.zst' \
-                 -o -name 'checksums.txt' \) | sort
+                 -o -name 'checksums.txt' -o -name 'checksums.txt.sig' \
+                 -o -name 'checksums.txt.pem' -o -name '*.sbom.json' \) | sort
           )
 
           if [ "${#artifacts[@]}" -eq 0 ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       - "v*"
 permissions:
   contents: write
+  # Keyless cosign signing exchanges the job's OIDC token for a short-lived
+  # certificate; no signing key is stored anywhere.
+  id-token: write
 
 jobs:
   goreleaser:
@@ -25,6 +28,13 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: ">=1.26.5"
+
+      # cosign signs checksums.txt, syft writes the SBOMs — both invoked by
+      # goreleaser (signs: / sboms: in .goreleaser.yaml).
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,6 +67,36 @@ universal_binaries:
 checksum:
   name_template: "checksums.txt"
 
+# An SPDX SBOM per archive, so what went into a build is inspectable without
+# rebuilding it. Requires syft on the PATH (installed in the workflows).
+sboms:
+  - artifacts: archive
+
+# Keyless cosign signature over checksums.txt. The installers verify artifacts
+# against the checksums file, but that file was served from the same release it
+# protects — integrity without authenticity. Signing the checksums file
+# transitively covers every artifact it lists.
+#
+# Keyless: the signature is bound to this repository's GitHub Actions OIDC
+# identity (no key to store or leak), verifiable with:
+#
+#   cosign verify-blob checksums.txt \
+#     --signature checksums.txt.sig --certificate checksums.txt.pem \
+#     --certificate-identity-regexp 'github.com/FynxLabs/rwr' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    signature: "${artifact}.sig"
+    args:
+      - sign-blob
+      - --output-certificate=${certificate}
+      - --output-signature=${signature}
+      - ${artifact}
+      - --yes
+    artifacts: checksum
+    output: true
+
 changelog:
   sort: asc
   use: github


### PR DESCRIPTION
## Summary
That "cosign not found, skipping" line in release logs was goreleaser noting an *unconfigured* optional — no signing existed at all. `checksums.txt` gave integrity but not authenticity: it's served from the same release as the artifacts it protects.

## Changes
- `signs:` in .goreleaser.yaml — keyless cosign over `checksums.txt` (bound to this repo's Actions OIDC identity, no stored key; signing the checksums file transitively covers every artifact it lists). Verify with:
  ```
  cosign verify-blob checksums.txt --signature checksums.txt.sig --certificate checksums.txt.pem --certificate-identity-regexp 'github.com/FynxLabs/rwr' --certificate-oidc-issuer https://token.actions.githubusercontent.com
  ```
- `sboms:` — SPDX SBOM per archive via syft.
- release.yml + nightly.yml: `id-token: write`, cosign/syft installers. The nightly is signed too — people install it — and its upload filter now includes `.sig`/`.pem`/`.sbom.json`.

## Verification
`goreleaser check` passes. The first nightly after merge exercises the full path end-to-end. Follow-up (not here): teach install.sh/install.ps1 to verify the signature when cosign is present.

Note: touches release.yml like #183 (different lines — trivial rebase for whichever merges second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)