### PR TITLE
ci(security): pin actions to commit SHAs, add SECURITY.md

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,10 +24,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ">=1.26.5"
 
@@ -71,18 +71,18 @@ jobs:
   cross-compile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # goreleaser reads git state; a shallow clone breaks its version math.
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ">=1.26.5"
 
       - name: Build every release target
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -94,16 +94,16 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ">=1.26.5"
 
       # Reads .golangci.yml from the repo root, so this runs the same rules as
       # `golangci-lint run` locally — there is no second copy of the config to drift.
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: latest
 
@@ -115,7 +115,7 @@ jobs:
   installers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # shellcheck is preinstalled on the ubuntu runners.
       - name: shellcheck install.sh
@@ -157,10 +157,10 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ">=1.26.5"
 
@@ -234,10 +234,10 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ">=1.26.5"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,12 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ">=1.26.5"
 
@@ -43,7 +43,7 @@ jobs:
       # .goreleaser.yaml's snapshot template and carries the commit sha.
       # Homebrew is skipped: the tap should only ever carry real releases.
       - name: Build artifacts
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: stable
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+rwr provisions machines: it installs packages, writes system configuration,
+manages users and services, and runs elevated commands from blueprint files.
+Security reports are taken seriously — a bug here runs as root on people's
+computers.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.**
+
+Report it privately via
+[GitHub Security Advisories](https://github.com/FynxLabs/rwr/security/advisories/new)
+("Report a vulnerability" on the Security tab). You should receive an initial
+response within a week.
+
+Include what you can: the rwr version (`rwr version`), a minimal blueprint or
+provider definition that demonstrates the problem, and what an attacker gains.
+
+## Scope
+
+Reports we especially care about:
+
+- Anything that lets a blueprint, provider definition, or downloaded content
+  do more than the operator asked for — command injection, path traversal
+  escaping declared boundaries, template injection.
+- Local privilege escalation through rwr's elevated operations or staging.
+- Credential exposure: tokens or keys reaching logs, process listings,
+  subprocess environments, or world-readable files.
+- Integrity of the release pipeline and installers (checksums, signatures).
+
+Out of scope: blueprints doing destructive things they explicitly declare —
+blueprints are trusted operator input by design. The trust boundary is that a
+blueprint may do what the operator could do; it must not be possible for
+*data* a blueprint references (URLs, archives, names) to widen that.
+
+## Supported versions
+
+Only the [latest release](https://github.com/FynxLabs/rwr/releases/latest)
+receives fixes. The `nightly` prerelease is a rolling build of master and is
+not a supported target, though reports against it are welcome — that's where
+fixes land first.

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ]
 }


### PR DESCRIPTION
## Summary
Last two release-hygiene items from the review:

1. **Actions pinned by mutable tag** — `@v7` repoints silently if the tag is compromised, and release.yml runs with `contents: write` plus `HOMEBREW_TAP_DEPLOY_KEY` and `NAUR_DISPATCH_TOKEN` in scope. All actions across the four workflows are now pinned to full commit SHAs (version kept as a comment). The `helpers:pinGitHubActionDigests` renovate preset keeps digests fresh and auto-pins any action added later — including the cosign/syft installers from #184 once it merges.
2. **SECURITY.md** — private disclosure via GitHub Security Advisories, scope, and a statement of the trust boundary (blueprints are trusted operator input; *data* blueprints reference must not widen that). Notable absence for a tool that runs as root on users' machines.

Note: touches the workflow files like #183/#184 — trivial rebases in whatever merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)