### PR TITLE
feat(install): --init runs rwr against your blueprints after installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ curl -sSL https://raw.githubusercontent.com/FynxLabs/rwr/refs/heads/master/insta
 `-Nightly` and `-Tag v0.5.1` (download the script to a file to pass
 parameters, or wrap the one-liner in `& ([scriptblock]::Create(...))`).
 
+### One-shot machine setup
+
+`--init` installs rwr and immediately provisions the machine from your
+blueprints — the whole new-machine setup in one line:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/FynxLabs/rwr/refs/heads/master/install.sh | bash -s -- --init yourname/your-blueprints
+```
+
+The init source takes any form `rwr -i` accepts: `owner/repo`,
+`owner/repo@ref`, an `https://` URL, or a local path. Provisioning runs as
+you (rwr elevates itself only where a blueprint asks for it); when there is
+no terminal to prompt on, it runs non-interactively. On Windows:
+`-Init yourname/your-blueprints`.
+
 > [!NOTE]
 > Always review scripts before running them with elevated privileges. The install scripts are available for inspection in the RWR repository.
 

--- a/install.ps1
+++ b/install.ps1
@@ -5,7 +5,10 @@
 # shape, same assets, same checksums.txt.
 param(
     [switch]$Nightly,
-    [string]$Tag
+    [string]$Tag,
+    # After installing, run `rwr all` with this init source — owner/repo[@ref],
+    # an https URL, or a local path.
+    [string]$Init
 )
 
 Set-StrictMode -Version Latest
@@ -158,4 +161,10 @@ try {
     Write-Host "Open a new terminal for the PATH change to take effect."
 } finally {
     Remove-Item -Path $tmp_dir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if ($Init) {
+    Write-Host "Running rwr with init source: $Init"
+    & (Join-Path $BINARY_PATH "rwr.exe") all --init-file $Init
+    exit $LASTEXITCODE
 }

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ fail() {
 # pinned tag) is reached through /releases/tags/<tag> instead — same response
 # shape, same assets, same checksums.txt.
 RELEASE_TAG=""
+INIT_REF=""
 while [ $# -gt 0 ]; do
     case "$1" in
         --nightly)
@@ -32,14 +33,25 @@ while [ $# -gt 0 ]; do
             RELEASE_TAG="${1#--tag=}"
             [ -n "$RELEASE_TAG" ] || fail "--tag needs a value, e.g. --tag v0.5.1 or --tag nightly."
             ;;
+        --init)
+            [ $# -ge 2 ] || fail "--init needs a value, e.g. --init owner/repo or --init https://.../init.yaml"
+            INIT_REF="$2"
+            shift
+            ;;
+        --init=*)
+            INIT_REF="${1#--init=}"
+            [ -n "$INIT_REF" ] || fail "--init needs a value, e.g. --init owner/repo or --init https://.../init.yaml"
+            ;;
         -h|--help)
-            echo "Usage: install.sh [--nightly | --tag <tag>]"
+            echo "Usage: install.sh [--nightly | --tag <tag>] [--init <ref>]"
             echo "  --nightly     install the rolling prerelease built from master"
             echo "  --tag <tag>   install a specific release tag (e.g. v0.5.1)"
+            echo "  --init <ref>  after installing, run 'rwr all' with this init source"
+            echo "                (owner/repo[@ref], an https URL, or a local path)"
             exit 0
             ;;
         *)
-            fail "Unknown option: $1. Supported options: --nightly, --tag <tag>."
+            fail "Unknown option: $1. Supported options: --nightly, --tag <tag>, --init <ref>."
             ;;
     esac
     shift
@@ -216,3 +228,26 @@ for doc in README.adoc README.md README; do
 done
 
 echo "rwr has been installed to $BINARY_PATH for $OS $ARCH."
+
+if [ -n "$INIT_REF" ]; then
+    echo "Running rwr with init source: $INIT_REF"
+
+    # Provisioning must run as the person whose machine this is, not as root:
+    # blueprints write dotfiles, user services and per-user config. Under
+    # `curl | sudo bash` the script is root but SUDO_USER names the real user.
+    RWR_RUN=("$BINARY_PATH/rwr")
+    if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+        echo "Installer is running as root; running rwr as $SUDO_USER (it elevates itself where blueprints ask for it)."
+        RWR_RUN=(sudo -u "$SUDO_USER" "$BINARY_PATH/rwr")
+    fi
+
+    # Under `curl ... | bash` stdin is the script itself, already consumed.
+    # rwr prompts interactively by default, so give it the terminal when there
+    # is one; otherwise run non-interactively rather than dying on EOF.
+    if [ -e /dev/tty ] && { : </dev/tty; } 2>/dev/null; then
+        "${RWR_RUN[@]}" all --init-file "$INIT_REF" </dev/tty
+    else
+        echo "No terminal available; running non-interactively."
+        "${RWR_RUN[@]}" all --interactive=false --init-file "$INIT_REF"
+    fi
+fi


### PR DESCRIPTION
## Summary
Second half of the one-shot bootstrap (pairs with #188):

```bash
curl -sSL https://raw.githubusercontent.com/FynxLabs/rwr/refs/heads/master/install.sh | bash -s -- --init yourname/your-blueprints
```

installs rwr and immediately provisions the machine. `--init` takes any form `rwr -i` accepts — `owner/repo[@ref]` shorthand (from #188), https URL, or local path.

## Details that matter
- **Runs as the right user**: under `curl | sudo bash` the script is root, but provisioning writes dotfiles and per-user config — so rwr runs as `SUDO_USER` and elevates itself only where blueprints ask for it.
- **Terminal handling**: piped stdin is the already-consumed script, so rwr gets `/dev/tty` when one exists; with no terminal it runs `--interactive=false` instead of dying on EOF at the first prompt.
- Windows: `-Init` on install.ps1, same semantics.

## Verification
shellcheck clean; `--help`, missing-value, and unknown-option paths exercised. README documents the one-liner. Works independently of #188 (`--init` with a URL or path), but shorthands need it — merge #188 first for the full experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)