### PR TITLE
docs(openspec): change proposals + spec deltas for TUI, CUE providers, CUE blueprints, blueprint manifest, format registry

### DIFF
--- a/openspec/changes/add-blueprint-manifest/proposal.md
+++ b/openspec/changes/add-blueprint-manifest/proposal.md
@@ -1,0 +1,46 @@
+# Change: Multi-configuration blueprint repos (root manifest + smart selection)
+
+Depends on: `add-format-registry`, `add-tui` (selection renders as a TUI frame).
+
+## Why
+
+A single blueprint repo commonly carries several machines' worth of config —
+e.g. TheFynx/rwr-blueprints has Arch/, Archcraft/, Common/, macOS/,
+OpenMandriva/, PopOS/, Windows/ at root. Today rwr has no notion of this: the
+operator must point `--init-file` at the right subdirectory by hand, and there
+is no way to publish one repo URL that works on any of your machines.
+
+## What Changes
+
+- A `manifest.{yaml,yml,json,toml}` file at blueprint-repo root (`.cue` once
+  `add-cue-blueprints` lands), listing named configurations. Each entry:
+  - `name` — e.g. `arch-desktop`
+  - `init` — path to that configuration's init file, relative to repo root
+  - matchers: `os` (linux/darwin/windows), `distro`, `family` (arch/debian/…),
+    optional `arch`
+  - optional `default: true`
+- Init resolution learns to accept a repo root (local dir or git URL): clone via
+  the existing `GetBlueprints` machinery, find `manifest.*` at root, filter
+  entries against `system.DetectOS()` (runs before init — ordering already works).
+- Selection:
+  - zero matches → error listing every entry and its matchers
+  - exactly one match → use it, log which
+  - multiple matches → TUI selection frame before resolve stage 1
+    (stage 1 needs only `SetPaths` + `DetectOS`, so this composes with the TUI
+    resolve pipeline); non-TTY runs require `--config-name`
+- `--config-name <entry>` selects explicitly and always wins; scripts and CI
+  never prompt.
+- Shared content (`Common/`) needs no new mechanism: entries' init files reach
+  it via existing relative imports.
+
+## Breakage
+
+Nothing breaks. Repos without a manifest behave exactly as today. The manifest
+path only activates when `--init-file` points at a location whose root has a
+`manifest.*` and no init file.
+
+## Impact
+
+- Affected specs: `initialization`, `cli`.
+- Blueprint manifests are untrusted input like blueprints: `init` paths must
+  resolve inside the repo (no `..` escape), matchers are data only.

--- a/openspec/changes/add-blueprint-manifest/specs/cli/spec.md
+++ b/openspec/changes/add-blueprint-manifest/specs/cli/spec.md
@@ -1,0 +1,25 @@
+# CLI — Deltas
+
+## ADDED Requirements
+
+### Requirement: --config-name selects a manifest entry explicitly
+
+`--config-name <name>` SHALL select the named manifest entry, bypassing
+matching and prompting, and SHALL error if the name does not exist. In a
+non-TTY run with multiple matches and no `--config-name`, the system SHALL
+error listing the candidates rather than prompt.
+
+Why: scripts and CI must never block on a prompt.
+
+#### Scenario: Non-TTY with multiple matches
+
+- **GIVEN** a manifest with two matching entries and stdout not a terminal
+- **WHEN** `rwr all` runs without `--config-name`
+- **THEN** the run exits nonzero listing `arch-desktop` and `arch-server`
+
+#### Scenario: Explicit selection wins
+
+- **GIVEN** `--config-name arch-server` on a host that would auto-match
+  `arch-desktop`
+- **WHEN** `rwr all` runs
+- **THEN** `arch-server` is used

--- a/openspec/changes/add-blueprint-manifest/specs/initialization/spec.md
+++ b/openspec/changes/add-blueprint-manifest/specs/initialization/spec.md
@@ -1,0 +1,55 @@
+# Initialization — Deltas
+
+## ADDED Requirements
+
+### Requirement: A repo-root manifest declares multiple configurations
+
+When the init location (local dir or cloned git repo) contains no init file
+but a `manifest.*` at its root, the system SHALL read the manifest: a list of
+named configurations, each with an `init` path relative to the repo root and
+optional matchers `os`, `distro`, `family`, `arch`, plus optional `default`.
+The manifest SHALL decode strictly through the format registry.
+
+Why: one blueprint repo commonly serves several machines (Arch/, macOS/,
+Windows/…); today the operator must hand-point at the right subdirectory.
+
+#### Scenario: Repo URL as init option
+
+- **GIVEN** `--init-file` pointing at a git repo whose root has `manifest.yaml`
+- **WHEN** `rwr all` runs
+- **THEN** the repo is cloned via the existing blueprint git machinery and the
+  manifest is read
+
+### Requirement: Configuration selection matches detected OS
+
+Manifest entries SHALL be filtered against detected OS info. Zero matches
+SHALL error listing every entry and its matchers. Exactly one match SHALL be
+used without prompting, logging which. Multiple matches SHALL present a TUI
+selection frame before resolve stage 1.
+
+#### Scenario: Single match auto-selected
+
+- **GIVEN** an Arch host and a manifest whose only `family: arch` entry is
+  `arch-desktop`
+- **WHEN** `rwr all` runs
+- **THEN** `arch-desktop` is used with no prompt and the choice is logged
+
+#### Scenario: Multiple matches prompt
+
+- **GIVEN** an Arch host and entries `arch-desktop` and `arch-server` both
+  matching
+- **WHEN** `rwr all` runs on a TTY
+- **THEN** a selection frame lists both, matched entries first
+
+### Requirement: Manifest paths cannot escape the repo
+
+An entry's `init` path SHALL resolve inside the repo root; a path escaping it
+SHALL be rejected before any file is read.
+
+Why: blueprints (and their manifests) are untrusted input.
+
+#### Scenario: Traversal rejected
+
+- **GIVEN** an entry with `init: ../../etc/init.yaml`
+- **WHEN** the manifest is validated
+- **THEN** the entry is rejected with an error naming the path

--- a/openspec/changes/add-blueprint-manifest/tasks.md
+++ b/openspec/changes/add-blueprint-manifest/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+- [ ] 1. Manifest types + strict decode via the format registry; reject `init`
+      paths escaping the repo root (test with `../` fails without the check).
+- [ ] 2. Init resolution: detect manifest at root when no init file present;
+      test repo-root and git-URL forms.
+- [ ] 3. Matcher filtering against `types.OSInfo` (os/distro/family/arch);
+      table tests: zero, one, many matches.
+- [ ] 4. `--config-name` flag; non-TTY with multiple matches errors and lists
+      candidates (test fails without).
+- [ ] 5. TUI selection frame (post `add-tui`): entry list with matched entries
+      first, renders before resolve stage 1.
+- [ ] 6. Example manifest under `examples/`; validate covers manifest files.

--- a/openspec/changes/add-coverage-reporting/proposal.md
+++ b/openspec/changes/add-coverage-reporting/proposal.md
@@ -1,0 +1,27 @@
+# Change: Code coverage reporting and thresholds
+
+(Was issue #102.)
+
+## Why
+
+Tests exist (70+ test files) but coverage is not measured or enforced; a
+regression in test coverage is invisible in review.
+
+## What Changes
+
+- `mise` tasks: `test:coverage` (exists), add `test:coverage:html` and
+  `test:coverage:summary`.
+- A coverage gate script with a global threshold (starting point 70%,
+  calibrated to actual current coverage before enforcement so CI doesn't go
+  red on day one).
+- CI runs the gate on the ubuntu test job.
+- README coverage badge.
+
+## Breakage
+
+Nothing breaks. CI gains a gate; the threshold is set at-or-below current
+measured coverage initially and ratcheted deliberately.
+
+## Impact
+
+- Affected specs: none (tooling only).

--- a/openspec/changes/add-coverage-reporting/tasks.md
+++ b/openspec/changes/add-coverage-reporting/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [ ] 1. Measure current per-package coverage; record baseline in the change.
+- [ ] 2. Add `test:coverage:html` / `test:coverage:summary` mise tasks.
+- [ ] 3. Gate script comparing total coverage to threshold; threshold set from
+      the baseline.
+- [ ] 4. Wire the gate into the ubuntu CI test job; verify it fails on a
+      simulated coverage drop (delete a test locally) and passes on master.
+- [ ] 5. README badge.

--- a/openspec/changes/add-cue-blueprints/proposal.md
+++ b/openspec/changes/add-cue-blueprints/proposal.md
@@ -1,0 +1,46 @@
+# Change: CUE as a supported blueprint format
+
+Depends on: `add-format-registry`. Related: `add-cue-providers` (independent —
+that change is build-time only; this one is runtime).
+
+## Why
+
+Blueprints today are YAML, JSON, or TOML — all shape-unchecked at authoring
+time; errors surface at run time on the target machine. CUE gives blueprint
+authors types, constraints, and composition (shared fragments unified across
+machines), and rwr already publishes strict schemas per blueprint type that
+CUE can encode.
+
+## What Changes
+
+- `.cue` joins the known extensions in the format registry: init files,
+  bootstrap files, blueprints, imports, and (once it exists) the manifest.
+- **Runtime dependency on `cuelang.org/go`** (decision): the user's `.cue` is
+  evaluated in-process and exported to concrete JSON, which feeds the existing
+  strict-decode path (`DecodeBlueprintInto`). CUE evaluation errors are
+  surfaced as diagnostics with file/line.
+  - Rejected alternative: shelling out to a `cue` binary. rwr's job is
+    bootstrapping machines that don't have tools yet; requiring `cue` on the
+    target defeats it. Cost of the dep is binary size (~+10–15 MB), accepted.
+- Init-file path: CUE is evaluated → exported to JSON → handed to the existing
+  viper decode (mirroring today's TOML→YAML pre-conversion).
+- `rwr validate` runs CUE evaluation as part of stage 1 resolve; a CUE value
+  that doesn't unify is a validation error, same surface as schema errors.
+- `examples/` gains a fourth format column for every blueprint type per the
+  compatibility contract; validated in CI like the other three.
+- Optional (follow-up-friendly): ship rwr's blueprint schemas as importable
+  CUE definitions so authors can write `packages: #Packages & {...}`.
+
+## Breakage
+
+Nothing breaks. Existing formats are untouched; `.cue` is additive. A tree may
+mix `.cue` with other formats (per-file format derivation from
+`add-format-registry`).
+
+## Impact
+
+- Affected specs: `blueprint-processing`, `initialization`,
+  `blueprint-validation`, `blueprint-schema-versioning`.
+- CUE blueprints are still untrusted input: evaluation must run with no
+  filesystem/network access outside the blueprint tree (CUE `@embed`/module
+  resolution disabled or rooted at the tree).

--- a/openspec/changes/add-cue-blueprints/specs/blueprint-processing/spec.md
+++ b/openspec/changes/add-cue-blueprints/specs/blueprint-processing/spec.md
@@ -1,0 +1,41 @@
+# Blueprint Processing — Deltas
+
+## MODIFIED Requirements
+
+### Requirement: CUE is a supported blueprint format
+
+`.cue` SHALL be a registered blueprint format alongside YAML, JSON, and TOML,
+valid for blueprints, imports, init files, bootstrap files, and the manifest.
+A `.cue` file SHALL be evaluated in-process (`cuelang.org/go`), exported to
+concrete values, and decoded through the existing strict path — semantics
+identical to the equivalent YAML.
+
+Why: CUE gives authors types, constraints, and composition at authoring time;
+errors surface before a run touches the machine. Evaluation is in-process
+because rwr bootstraps machines that do not have a `cue` binary.
+
+#### Scenario: CUE blueprint equals its YAML twin
+
+- **GIVEN** `packages.cue` and `packages.yaml` declaring the same packages
+- **WHEN** both are decoded
+- **THEN** the resulting blueprint values are identical
+
+#### Scenario: Non-concrete value is an error
+
+- **GIVEN** a `.cue` blueprint with an unresolved field (`version: string`)
+- **WHEN** it is evaluated
+- **THEN** decoding fails with the field name and file/line
+
+### Requirement: CUE evaluation is sandboxed to the blueprint tree
+
+CUE evaluation SHALL NOT resolve modules, imports, or embeds from the
+network or from filesystem paths outside the blueprint tree.
+
+Why: blueprints are untrusted input; evaluation must not become a way to read
+arbitrary files or phone home.
+
+#### Scenario: Escape rejected
+
+- **GIVEN** a `.cue` file importing a path outside the blueprint tree
+- **WHEN** it is evaluated
+- **THEN** evaluation fails with a containment error

--- a/openspec/changes/add-cue-blueprints/specs/blueprint-validation/spec.md
+++ b/openspec/changes/add-cue-blueprints/specs/blueprint-validation/spec.md
@@ -1,0 +1,27 @@
+# Blueprint Validation — Deltas
+
+## MODIFIED Requirements
+
+### Requirement: CUE errors are validate diagnostics
+
+`rwr validate` SHALL evaluate `.cue` blueprints and report evaluation and
+unification failures as diagnostics with file and line, on the same surface
+as schema errors for the other formats.
+
+#### Scenario: Constraint violation reported
+
+- **GIVEN** a `.cue` blueprint violating one of its own constraints
+- **WHEN** `rwr validate` runs
+- **THEN** the diagnostic names the file, line, and failed constraint, and
+  validation exits nonzero
+
+### Requirement: Examples cover CUE
+
+`examples/` SHALL cover every blueprint type in CUE as a fourth format column,
+validated in CI, per the compatibility contract.
+
+#### Scenario: CI validates CUE examples
+
+- **GIVEN** the examples tree
+- **WHEN** CI runs
+- **THEN** every `.cue` example validates like its YAML/JSON/TOML siblings

--- a/openspec/changes/add-cue-blueprints/tasks.md
+++ b/openspec/changes/add-cue-blueprints/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+- [ ] 1. Add `cuelang.org/go`; `.cue` registered in the format registry; CUE →
+      concrete JSON evaluation feeding `unmarshalBlueprint`. Test: a `.cue`
+      packages blueprint decodes identically to its YAML twin (fails without).
+- [ ] 2. Evaluation sandboxing: no module/network/filesystem resolution outside
+      the blueprint tree. Test with an import escaping the tree (fails without
+      the guard).
+- [ ] 3. Init + bootstrap files in `.cue` (evaluate → JSON → viper path).
+- [ ] 4. Diagnostics: CUE errors carry file/line into validate output.
+- [ ] 5. `examples/`: fourth format column for every blueprint type; CI
+      validates them.
+- [ ] 6. Docs: blueprint format page + authoring example with a shared fragment.

--- a/openspec/changes/add-cue-providers/design.md
+++ b/openspec/changes/add-cue-providers/design.md
@@ -1,0 +1,107 @@
+# Design: CUE provider definitions
+
+Status: proposed
+Scope: provider definitions only. CUE as a *blueprint* language is a follow-up
+with its own design once this lands (`add-cue-blueprints`).
+
+## Why
+
+The 25 provider TOMLs (~1,800 lines) are the most duplicated and least checked
+code in the repository:
+
+- **Duplication.** yay, paru, trizen, aura and pamac are near-identical: same
+  pacman-family commands, same detection files, same clone-and-makepkg install
+  shape, differing in a name and a URL. Every family-wide fix (the `/tmp`
+  staging move, the `--needed` flag) is five edits that must not drift.
+- **Weak validation.** TOML decoding accepts any shape; the checks live in
+  `internal/validate/providers.go` as hand-rolled Go that has already drifted
+  from the processors once (the `condition`/`path` fields, the fictional
+  actions). A wrong field name is silent until runtime.
+- **No shared vocabulary.** Nothing says "a provider MUST declare detection
+  and commands", or "a repository add step that names a condition must use a
+  derivable predicate". Those contracts exist only in reviewers' heads.
+
+CUE fixes all three natively: schemas are unification (a provider that lacks a
+required field fails to *export*, at build time), and family templates are
+plain values a definition unifies with (`yay: #ArchAURHelper & {name: "yay"}`).
+
+## Decisions
+
+1. **CUE is a build-time tool, not a runtime dependency.** `cuelang.org/go`
+   never ships in the binary. The pipeline is:
+
+   ```
+   providers/cue/*.cue  --cue export-->  internal/system/definitions/providers/*.json  --go:embed-->  binary
+   ```
+
+   The exported JSON decodes into the existing `types.Provider` structs; the
+   loading code changes from a TOML decoder to a JSON decoder and nothing
+   downstream notices. Filesystem provider *overrides* stay TOML (or gain
+   JSON) — operators should not need CUE installed to override a provider.
+
+2. **Schema mirrors `types.Provider` exactly, and a test enforces it.** A Go
+   test round-trips every exported provider through strict decoding into
+   `types.Provider` with no unknown keys, so the CUE schema and the Go structs
+   cannot drift apart silently — the same guarantee `embedded_test.go` gives
+   today, but at the schema level.
+
+3. **Family templates for the proven clusters only.**
+   - `#PacmanFamily`: commands + detection files + repository paths shared by
+     pacman and the AUR helpers.
+   - `#ArchAURHelper`: `#PacmanFamily` + the clone-and-makepkg install steps,
+     parameterized by AUR package name (collapses 5 files to ~5 lines each).
+   - `#DebianFamily`: apt/apt-get share detection and repository shape.
+
+   Everything else stays a standalone definition — inventing hierarchies for
+   single members obscures more than it saves.
+
+4. **Contracts move into the schema.** What `validate/providers.go` checks by
+   hand becomes unification:
+   - required: `name`, `detection.binary`, `commands.install`
+   - `elevated` defaults to false, must be explicit `true` for system managers
+   - step actions constrained to the enum the processors implement
+   - a `condition` may reference only the predicate names rwr derives
+     (kept as a CUE `or` list that a Go test asserts equals the keys of
+     `repositoryPredicates` — one source of truth, checked both ways)
+   - install/remove steps may not contain literal `/tmp/` paths
+     (the `{{ .TempDir }}` rule, today a Go test, becomes a schema regexp)
+
+5. **CI validates and checks freshness; the export is committed.** A
+   `cue-providers` job runs `cue vet` + `cue export` and fails if the
+   committed JSON differs from the fresh export (same pattern as gofmt).
+   Committed output keeps `go build` working with no CUE toolchain installed —
+   contributors touching providers need CUE (via mise), everyone else doesn't.
+
+## What gets deleted
+
+- The 25 TOML files under `internal/system/definitions/providers/`.
+- Most of `internal/validate/providers.go` (schema does it); what stays is the
+  filesystem-override validation, which still sees TOML.
+- The hardcoded action list assertions in `embedded_test.go` (schema enum).
+
+## Expected size
+
+Corpus 1,845 → ~1,100 lines (5 AUR files collapse to ~25 lines total, shared
+commands/paths lift into families). Plus ~150 lines of schema, ~60 of CI, ~80
+of export-freshness tooling.
+
+## Sequencing (3 PRs)
+
+1. **Schema + pipeline**: `providers/cue/schema.cue`, export tooling
+   (`mise run providers:export`), CI job, loader reads committed JSON —
+   with the TOMLs still the source, converted mechanically 1:1 (no family
+   templates yet). Proves the pipeline with zero semantic change; the
+   round-trip test is the gate.
+2. **Families**: introduce `#PacmanFamily` / `#ArchAURHelper` /
+   `#DebianFamily`, collapse the members onto them. Exported JSON must be
+   byte-identical to PR 1's — the diff *is* the review.
+3. **Contracts**: move the validate/providers.go checks into the schema,
+   delete the superseded Go, add the predicate-name cross-check test.
+
+## Resolved questions
+
+- Filesystem overrides: accept both `.toml` and `.json`; JSON is what the
+  export produces, so power users can copy one out and edit it.
+- `mise install` pins `cue` from PR 1 (CI needs it from day one).
+- Source lives at `providers/cue/` (repo root): it is source, not an embedded
+  asset.

--- a/openspec/changes/add-cue-providers/proposal.md
+++ b/openspec/changes/add-cue-providers/proposal.md
@@ -1,0 +1,54 @@
+# Change: CUE provider definitions
+
+Scope: provider definitions only. CUE as a *blueprint* format is
+`add-cue-blueprints`, a separate change.
+
+## Why
+
+The 25 provider TOMLs (~1,845 lines) are the most duplicated and least checked
+code in the repository:
+
+- **Duplication.** yay, paru, trizen, aura and pamac are near-identical: same
+  pacman-family commands, same detection files, same clone-and-makepkg install
+  shape. Every family-wide fix (the `/tmp` staging move, `--needed`) is five
+  edits that must not drift.
+- **Weak validation.** TOML decoding accepts any shape; the checks live in
+  `internal/validate/providers.go` as hand-rolled Go that has already drifted
+  from the processors once. A wrong field name is silent until runtime.
+- **No shared vocabulary.** Contracts like "a provider MUST declare detection
+  and commands" exist only in reviewers' heads.
+
+CUE fixes all three natively: schemas are unification (a provider lacking a
+required field fails to *export*, at build time), and family templates are
+plain values a definition unifies with.
+
+Full design in `design.md`. Key decisions:
+
+1. CUE is build-time only; `cuelang.org/go` never ships in the binary.
+   `providers/cue/*.cue` → `cue export` → committed JSON → `go:embed`.
+   Filesystem overrides stay TOML (and gain JSON).
+2. Schema mirrors `types.Provider` exactly; a strict round-trip test enforces it.
+3. Family templates for proven clusters only: `#PacmanFamily`,
+   `#ArchAURHelper`, `#DebianFamily`.
+4. Contracts move into the schema (required fields, action enum, condition
+   predicate names cross-checked against `repositoryPredicates`, no literal
+   `/tmp/` paths).
+5. CI runs `cue vet` + export-freshness check; committed JSON keeps `go build`
+   working without a CUE toolchain.
+
+Resolved open questions: overrides accept TOML **and** JSON; `cue` pinned in
+mise from PR 1; source lives at `providers/cue/` (repo root — it is source,
+not an embedded asset).
+
+## Breakage
+
+Nothing breaks for existing blueprints or filesystem provider overrides. The
+exported JSON must decode into the same `types.Provider` values the TOMLs
+produce today (round-trip test is the gate).
+
+## Impact
+
+- Affected specs: `provider-detection`, `blueprint-validation`, `distribution`.
+- Deleted: the 25 provider TOMLs, most of `validate/providers.go`, the
+  hardcoded action-list assertions in `embedded_test.go`.
+- Expected corpus: 1,845 → ~1,100 lines, plus ~150 schema / ~60 CI / ~80 tooling.

--- a/openspec/changes/add-cue-providers/specs/blueprint-validation/spec.md
+++ b/openspec/changes/add-cue-providers/specs/blueprint-validation/spec.md
@@ -1,0 +1,29 @@
+# Blueprint Validation — Deltas
+
+## MODIFIED Requirements
+
+### Requirement: Embedded provider contracts live in the CUE schema
+
+The contracts currently checked by `internal/validate/providers.go` for
+embedded providers SHALL be expressed in the CUE schema: required `name`,
+`detection.binary`, `commands.install`; step `action` constrained to the enum
+the processors implement; `condition` restricted to derivable predicate names;
+no literal `/tmp/` paths in steps. Go validation SHALL remain only for
+filesystem overrides.
+
+Why: the hand-rolled Go checks have already drifted from the processors once
+(fictional actions, stale fields); a schema the export gate enforces cannot
+drift silently.
+
+#### Scenario: Invalid action rejected at export
+
+- **GIVEN** a CUE provider step with `action: "instal"`
+- **WHEN** the export runs
+- **THEN** it fails listing the allowed actions
+
+#### Scenario: Predicate list cannot drift
+
+- **GIVEN** the CUE `or` list of condition predicates and Go's
+  `repositoryPredicates` keys
+- **WHEN** the cross-check test runs
+- **THEN** it fails if the two sets differ in either direction

--- a/openspec/changes/add-cue-providers/specs/provider-detection/spec.md
+++ b/openspec/changes/add-cue-providers/specs/provider-detection/spec.md
@@ -1,0 +1,51 @@
+# Provider Detection — Deltas
+
+## MODIFIED Requirements
+
+### Requirement: Embedded provider definitions are exported from CUE
+
+Embedded provider definitions SHALL be authored in CUE under `providers/cue/`
+and exported at build time to committed JSON under
+`internal/system/definitions/providers/`. The binary SHALL embed and decode
+the JSON; `cuelang.org/go` SHALL NOT be linked into the binary.
+
+Why: the 25 TOMLs duplicate whole command blocks across families and are
+shape-unchecked; CUE unification rejects an invalid provider at export time
+instead of at runtime on a user's machine.
+
+#### Scenario: Provider missing a required field fails at build
+
+- **GIVEN** a CUE provider definition lacking `commands.install`
+- **WHEN** `mise run providers:export` runs
+- **THEN** the export fails naming the provider and field
+- **AND** no JSON is produced
+
+#### Scenario: Exported providers decode identically
+
+- **GIVEN** the committed JSON exports
+- **WHEN** each is strictly decoded into `types.Provider`
+- **THEN** no unknown keys are present and values equal the pre-migration
+  TOML-derived values (round-trip test)
+
+### Requirement: Filesystem overrides do not require CUE
+
+Filesystem provider overrides SHALL be accepted as `.toml` or `.json`.
+Operators SHALL NOT need a CUE toolchain to override a provider.
+
+#### Scenario: JSON override
+
+- **GIVEN** `~/.config/rwr/providers/pacman.json` copied from the exported JSON
+- **WHEN** providers initialize
+- **THEN** the override replaces the embedded pacman definition, same as a
+  TOML override does today
+
+### Requirement: Committed exports stay fresh
+
+CI SHALL fail when the committed JSON differs from a fresh `cue export` of the
+CUE sources, and SHALL run `cue vet` over them.
+
+#### Scenario: Stale export
+
+- **GIVEN** a PR edits `providers/cue/yay.cue` without re-exporting
+- **WHEN** CI runs
+- **THEN** the `cue-providers` job fails with the diff

--- a/openspec/changes/add-cue-providers/tasks.md
+++ b/openspec/changes/add-cue-providers/tasks.md
@@ -1,0 +1,17 @@
+# Tasks
+
+Three PRs, each independently green.
+
+- [ ] 1. **Schema + pipeline**: `providers/cue/schema.cue`, mechanical 1:1
+      conversion of the 25 TOMLs, `mise run providers:export`, pinned `cue` in
+      mise, CI job (`cue vet` + freshness diff), loader reads committed JSON.
+      Gate: strict round-trip test — every exported provider decodes into
+      `types.Provider` with no unknown keys and equals the TOML-derived value
+      (fails on any semantic drift).
+- [ ] 2. **Families**: `#PacmanFamily`, `#ArchAURHelper`, `#DebianFamily`;
+      collapse members. Gate: exported JSON byte-identical to PR 1's.
+- [ ] 3. **Contracts**: move `validate/providers.go` checks into the schema;
+      delete superseded Go; predicate-name cross-check test (CUE `or` list ==
+      keys of `repositoryPredicates`, asserted from Go — fails if either side
+      drifts). Filesystem overrides accept `.toml` and `.json`; override
+      validation stays in Go.

--- a/openspec/changes/add-format-registry/proposal.md
+++ b/openspec/changes/add-format-registry/proposal.md
@@ -1,0 +1,53 @@
+# Change: Centralize blueprint format handling (format registry)
+
+## Why
+
+Format *decoding* is centralized (`internal/helpers/blueprints.go` `unmarshalBlueprint`),
+but format *derivation* — which extensions exist and which decoder a file gets — is
+hardcoded in ~15 places. Worse, the codebase holds two contradictory models:
+
+- `internal/processors/blueprints.go:187,221` and `internal/processors/profiles.go:53`
+  assume the whole tree is one format via `initConfig.Init.Format`.
+- `internal/processors/all.go:148` and the validate package derive format per file
+  from its extension. `all.go:148` (`filepath.Ext(file)[1:]`) panics on an
+  extensionless file.
+
+Every hardcoded site is a place a new format (CUE) must be added by hand, and the
+two models disagree today for a tree that mixes formats. This change is a
+prerequisite for `add-cue-blueprints` and `add-blueprint-manifest`.
+
+Known hardcoded/derived sites: `cmd/root.go:114-119`, `cmd/root.go:130`,
+`cmd/validate.go:74`, `internal/types/constants.go:21-29`,
+`internal/processors/all.go:22,148`, `internal/processors/initialize.go:100,186`,
+`internal/processors/bootstrap.go:46,51`, `internal/processors/blueprints.go:187,221`,
+`internal/processors/profiles.go:53,65,68`, `internal/helpers/resolve_imports.go:70`,
+`internal/validate/blueprints.go:48,64,92,99,122,212,231`,
+`internal/validate/helpers.go:113,117,122`.
+
+Also fixed here: `--init-file` is bound to viper key `rwr.init-file`
+(`cmd/root.go:206`) but read from `repository.init-file` (`cmd/root.go:105`), so
+the config-file form of the setting and the flag disagree.
+
+## What Changes
+
+- One registry in `internal/helpers` (or `internal/types`) owning: known
+  extensions, extension → format resolution, candidate init/bootstrap filename
+  generation, and decoder dispatch. All sites above call it.
+- Format is derived **per file** everywhere. `Init.Format` becomes a fallback/
+  default for extensionless cases only (or is deprecated); the tree-uniform
+  assumption in `blueprints.go`/`profiles.go` is removed.
+- Extensionless and unknown-extension files produce a diagnostic, not a panic.
+- The init-file path also flows through the registry for discovery (viper decode
+  can remain for now; `add-cue-blueprints` revisits it).
+- Fix the `rwr.init-file` / `repository.init-file` viper binding mismatch.
+
+## Breakage
+
+Nothing breaks for existing blueprints. A tree that mixes formats — previously
+undefined behavior (half the code honored it, half didn't) — becomes supported.
+`examples/` must still pass unchanged.
+
+## Impact
+
+- Affected specs: `blueprint-processing`, `initialization`, `blueprint-validation`, `cli`.
+- Unblocks: `add-cue-blueprints`, `add-blueprint-manifest`.

--- a/openspec/changes/add-format-registry/specs/blueprint-processing/spec.md
+++ b/openspec/changes/add-format-registry/specs/blueprint-processing/spec.md
@@ -1,0 +1,36 @@
+# Blueprint Processing — Deltas
+
+## ADDED Requirements
+
+### Requirement: Format registry is the single source of blueprint format knowledge
+
+The system SHALL resolve a blueprint file's format from its extension through a
+single registry. No other code SHALL enumerate blueprint extensions or map an
+extension to a decoder.
+
+Why: format knowledge is duplicated across ~15 sites today; each new format is
+N hand edits, and the copies have already diverged (see next requirement).
+
+#### Scenario: Unknown extension yields a diagnostic, not a panic
+
+- **GIVEN** a blueprint directory containing `packages.xml`
+- **WHEN** the run order is processed
+- **THEN** the file is reported as an unsupported format with its path
+- **AND** the run does not panic (today `all.go:148` panics on an extensionless file)
+
+### Requirement: Format is derived per file
+
+The system SHALL determine each blueprint file's format from that file's
+extension. `Init.Format` SHALL NOT cause a file with a recognized extension to
+be decoded as another format.
+
+Why: half the codebase assumes a tree-uniform format via `Init.Format`, half
+derives per file; a mixed tree behaves differently depending on which code path
+touches it.
+
+#### Scenario: Mixed-format tree
+
+- **GIVEN** a blueprint tree containing `packages.yaml` and `files.toml`
+- **WHEN** `rwr all` processes the tree
+- **THEN** each file is decoded according to its own extension
+- **AND** profile discovery and file ordering see both files

--- a/openspec/changes/add-format-registry/specs/initialization/spec.md
+++ b/openspec/changes/add-format-registry/specs/initialization/spec.md
@@ -1,0 +1,30 @@
+# Initialization — Deltas
+
+## MODIFIED Requirements
+
+### Requirement: Init file discovery uses the format registry
+
+Init and bootstrap file discovery SHALL derive candidate filenames
+(`init.<ext>`, `bootstrap.<ext>`) from the format registry rather than
+hardcoded lists.
+
+#### Scenario: New format is discoverable without touching discovery code
+
+- **GIVEN** a format is added to the registry
+- **WHEN** a directory contains `init.<newext>`
+- **THEN** init discovery finds it with no change to `cmd/` or `processors/`
+
+### Requirement: --init-file flag and config key agree
+
+The `--init-file` flag SHALL be bound to the same configuration key it is read
+from. Setting the value via config file SHALL behave identically to the flag.
+
+Why: today the flag binds to `rwr.init-file` but resolution reads
+`repository.init-file`, so the documented config key silently ignores the flag
+binding.
+
+#### Scenario: Config key resolves like the flag
+
+- **GIVEN** a config file setting the init-file key to `/tmp/x/init.yaml`
+- **WHEN** `rwr all` runs without `--init-file`
+- **THEN** `/tmp/x/init.yaml` is used, same as if passed via `--init-file`

--- a/openspec/changes/add-format-registry/tasks.md
+++ b/openspec/changes/add-format-registry/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+- [ ] 1. Add format registry: extensions set, `FormatForPath(path) (Format, error)`,
+      `CandidateFilenames(base) []string`, decoder dispatch. Unit tests, including
+      extensionless and unknown extensions (fails today via `all.go:148` panic).
+- [ ] 2. Replace the hardcoded extension lists in `cmd/`, `internal/processors/`,
+      `internal/helpers/`, `internal/validate/` with registry calls.
+- [ ] 3. Remove tree-uniform `Init.Format` assumption in
+      `processors/blueprints.go` and `processors/profiles.go`; add a test with a
+      mixed-format tree (fails without the change).
+- [ ] 4. Fix `rwr.init-file` vs `repository.init-file` binding; test that
+      `--init-file` and the config key resolve identically (fails today).
+- [ ] 5. `mise run ci` green; `examples/` unchanged and passing.

--- a/openspec/changes/add-tui/design.md
+++ b/openspec/changes/add-tui/design.md
@@ -1,0 +1,584 @@
+# rwr TUI Implementation Plan
+
+Target repo: `github.com/fynxlabs/rwr` (master)
+
+Replaces the current streaming-log output with a Bubble Tea dashboard. Non-TTY behavior is unchanged.
+
+---
+
+## 1. Terminology
+
+| Term | Meaning |
+|---|---|
+| Processor | The 10 blueprint types plus pre-steps (blueprints, init, bootstrap). One strip block each. |
+| Provider | Package manager from `internal/system/definitions/providers/*.toml`. Renders as a lane inside a processor panel. |
+| Resource | A single item: one package, one file, one service, one font. Recorded always, rendered only in the summary. |
+
+Do not use "step" or "engine" in user-facing strings. Help bar uses `j/k move`, not `j/k processor`.
+
+---
+
+## 2. Dependencies
+
+Already in `go.sum` via `charm.land/huh/v2`. Promote to direct in `go.mod`:
+
+- `charm.land/bubbletea/v2` v2.0.2
+- `charm.land/bubbles/v2` v2.0.0
+- `charm.land/lipgloss/v2` v2.0.1
+- `github.com/catppuccin/go` v0.3.0
+- `github.com/charmbracelet/colorprofile` v0.4.3
+
+New:
+
+- `github.com/charmbracelet/harmonica`
+- `github.com/lrstanley/bubblezone`
+
+Bubble Tea v2 changed message types. Key events are `KeyPressMsg`/`KeyReleaseMsg`; mouse events are split into click, motion, wheel, and release messages rather than a single `MouseMsg`. Verify against v2.0.2 source. Most examples online are v1 and will not compile.
+
+Components to use rather than hand-roll: `viewport`, `progress`, `spinner`, `stopwatch`, `help`, `key`, `textinput`. Only the strip and the panel height animation are custom.
+
+---
+
+## 3. Prerequisites
+
+Three changes outside the TUI. All are on the critical path.
+
+### 3.1 Resolve phase and `Plan`
+
+Hoist file reading, template resolution, and unmarshalling out of the execution loop in `internal/processors/all.go` into a resolve phase producing one struct.
+
+```go
+type Plan struct {
+    Init      *types.InitConfig
+    Order     []string                  // from GetBlueprintRunOrder
+    Files     map[string][]ResolvedFile // from GetBlueprintFileOrder, plus resolved content
+    Providers []ProviderState
+    Resources []Resource
+    Diags     []Diagnostic
+}
+```
+
+Two stages, because provider detection has a dependency the rest does not:
+
+| Stage | Runs | Produces |
+|---|---|---|
+| 1 | before init, needs only `SetPaths` + `DetectOS` | parse, imports, schema, template resolution, diagnostics |
+| 2 | after init and bootstrap complete | provider states, resource enumeration, lane counts |
+
+Bootstrap can install the package manager later blueprints depend on. Detecting providers before bootstrap produces wrong lanes.
+
+Consumers of `Plan`: `rwr validate` (stage 1 only), the TUI, the executor. Do not add an output-format flag to validate and call it from the run path. That resolves twice.
+
+### 3.2 Error accumulation in `All()`
+
+`internal/processors/all.go` currently returns on the first processor error. Push-through mode does not exist yet.
+
+- Fatal in both modes, abort immediately: blueprint fetch, blueprint location missing, package manager install, run order unresolvable. Everything before the processor loop.
+- Recoverable, collected: anything returned by the ten `Process*` calls.
+
+```go
+if err != nil {
+    if interactive {
+        return fmt.Errorf("error processing %s: %w", processor, err)
+    }
+    stepErrs = append(stepErrs, StepError{Processor: processor, Err: err})
+}
+```
+
+Exit nonzero if `stepErrs` is non-empty.
+
+### 3.3 Output routing in `internal/system/commands.go`
+
+Two branches, handled differently.
+
+Interactive branch currently sets `command.Stdin/Stdout/Stderr = os.Std*`. This is deliberate. Capturing stderr swallows sudo's password prompt and hangs the run. Do not pipe it.
+
+```go
+if cmd.Interactive {
+    done := make(chan error, 1)
+    reporter.Emit(TerminalReq{Processor: currentProcessor, Cmd: command, Done: done})
+    return <-done
+}
+```
+
+TUI handles `TerminalReq` with `tea.ExecProcess`, which restores cooked mode, hands over the real tty, and repaints on exit. `LogReporter` implements it as the current direct wiring, so headless output is byte-identical to today.
+
+This path must work in non-interactive runs too. `helpers.ResolveInteractive` lets a single blueprint item set `interactive: true` inside an otherwise non-interactive run. Do not gate handoff on the global flag.
+
+Non-interactive branch, in `setOutputStreams`, replacing `cmd.Stdout = os.Stdout` under debug:
+
+```go
+cmd.Stdout = &lineWriter{proc: currentProcessor, src: SrcStdout}
+cmd.Stderr = io.MultiWriter(&stderr, &lineWriter{proc: currentProcessor, src: SrcStderr})
+```
+
+`lineWriter` buffers to newline and emits one record per line. Keep the existing `stderr bytes.Buffer` so the error path still has full text. Per-blueprint `logName` files keep working via `io.MultiWriter`.
+
+---
+
+## 4. Event bus
+
+Goal: `All()` and the ten processors do not know a TUI exists.
+
+```go
+type Reporter interface{ Emit(Event) }
+
+type ProcStarted   struct{ Processor string; Files int; Providers []string }
+type ProcFinished  struct{ Processor string; Err error; Dur time.Duration }
+type ProcSkipped   struct{ Processor, Reason string }
+type LaneUpdate    struct{ Processor, Provider string; Done, Total int; Status Status }
+type ResourceDone  struct{ Resource Resource }
+type TerminalReq   struct{ Processor string; Cmd *exec.Cmd; Done chan error }
+type RunFinished   struct{ Errs []StepError }
+```
+
+Two implementations, chosen in `cmd/`:
+
+- `TUIReporter` wraps `p.Send`
+- `LogReporter` reproduces current streaming output exactly
+
+### Log capture without touching the processors
+
+`charmbracelet/log` implements `slog.Handler`. Install a custom handler at startup that stamps each record with a package-level atomic `currentProcessor` and appends to the store. Every existing `log.Infof("Processing packages")` across all ten processor files flows into the buffer correctly attributed, with zero edits to those files. Same pattern as the existing `dryRunMode` and `current` executor package state.
+
+Explicit events are then needed in only two places: the `All()` loop, and `runCommand`.
+
+---
+
+## 5. Data model
+
+```go
+type LogRecord struct {
+    Seq       uint64
+    Time      time.Time
+    Level     log.Level
+    Processor string
+    Provider  string
+    Msg       string
+    Attrs     []slog.Attr
+    Src       Source // SrcLog | SrcStdout | SrcStderr
+}
+
+type Resource struct {
+    Processor string
+    Provider  string        // empty for files, services, git, scripts
+    Name      string        // "neovim", "~/.config/nvim/"
+    Action    string        // install, copy, enable, clone
+    Status    Status        // ok, failed, skipped, unknown, planned, present
+    Detail    string
+    Dur       time.Duration
+}
+
+type Diagnostic struct {
+    Severity  Severity // Error | Warning
+    Processor string
+    File      string
+    Line      int
+    Msg       string
+}
+```
+
+`unknown` is required. rwr shells out and several providers do not report per-package results reliably. Do not force those into ok or failed.
+
+Each `Process*` function emits one `ResourceDone` per item. Ten files touched, mechanical.
+
+### Buffer
+
+- One append-only store with monotonic `Seq`, capped ring
+- `--tui-buffer` sizes it, default 50k lines
+- Every record also writes to a run log file unconditionally at debug level, regardless of display level
+- Run log: `os.CreateTemp("", "rwr-<timestamp>-*.log")`, mode 0600. `--log-file` overrides. Path printed on exit
+- When scrolling past the top of the ring, show a boundary row pointing at the file. Do not silently truncate
+
+Eviction gotcha: views hold `Seq` values, not array indices. Track `oldest` and drop stale head entries lazily on read. Storing positions will panic or scramble output once the ring wraps.
+
+### Views
+
+```go
+type View struct {
+    Processor string   // "" = all
+    idx       []uint64 // Seqs matching, appended as records arrive
+    offset    int      // scroll position, remembered
+    follow    bool
+}
+```
+
+Records stored once. Filtering is O(1) at render, not a scan. Each view keeps its own scroll position and follow state.
+
+Level, stdout, and search filters are global, applied on top of whichever view is active.
+
+---
+
+## 6. Model and states
+
+```go
+type State int
+const (
+    Resolving State = iota
+    Running
+    Suspended  // terminal handed to child
+    Prompting  // interactive error halt
+    Summary
+)
+
+type Model struct {
+    plan   *Plan
+    procs  []Proc
+    cursor int
+    live   int
+    pinned bool
+    store  *Store
+    views  map[string]*View
+    scope  string
+    level  log.Level
+    stdout bool
+    state  State
+    errs   []StepError
+}
+```
+
+Processor states: `pending`, `running`, `done`, `degraded`, `failed`, `skipped`.
+
+`degraded` covers a processor where some providers succeeded and others failed. Maps to the `warning` token, no theme changes needed.
+
+Processor state derives from the worst lane state. Do not set it directly.
+
+Pinning: selection follows execution until the user presses `j`/`k` or scrolls. First manual input pins. Once pinned, execution continues and the checklist updates but the viewport does not move. Status line shows where live is. `g` unpins and snaps back.
+
+---
+
+## 7. Layout
+
+Five regions, top to bottom:
+
+1. Header: `rwr`, blueprint source, host, failure counters, elapsed clock
+2. Strip: one block per processor, colored by state, one line total
+3. Collapsed completed processors
+4. Active panel with provider lanes and log viewport
+5. Pending chips, then help bar
+
+### Collapse rules
+
+- Successful processors compress onto a single shared line: `✓ blueprints · init · repositories · files · services · git  41.2s`
+- Failed and degraded processors always keep a full row, with the reason in place of a duration
+- Selecting or clicking the compressed line expands it into individual rows
+- Pending compresses to one chip row. Expanding grows inline and shrinks the panel. Never an overlay, it would cover live output
+- Expansion is a manual toggle, does not auto-collapse when the next processor starts
+
+### Vertical space priority
+
+When height is constrained, sacrifice in this order, last first:
+
+1. Header and strip. Fixed, never sacrificed
+2. Failed and degraded rows. Never compressed, never scrolled out
+3. Active panel, minimum three log lines
+4. Help bar, collapses to `? help`
+5. Compressed success line
+6. Pending chips
+
+If failures alone exceed available height, that list becomes the scrollable region and the panel shrinks to minimum. Failures win over live output.
+
+### Provider lanes
+
+Inside the active panel, one row per provider with its own glyph, counts, progress bar, and duration. Panel border takes the worst lane state.
+
+Denominators are declared resources, not operations. Glob copies, URL sources, and dependency resolution all expand at execution time. Installing 112 declared packages may touch 400. Show `37/112` and let the log carry the rest. Do not imply the count is total work.
+
+### Compact mode
+
+Triggers below ~60 columns or ~14 rows. Either threshold trips it.
+
+Stays inside the TUI so filters and search survive. A raw stream would lose errors-only, which is what matters most on a small pane.
+
+Renders: one pinned status line (running processor, progress, failure counts), the log stream, one help line. No strip, no lanes, no panel borders, no collapsed list.
+
+Switch live on `WindowSizeMsg`. Both layouts render from the same model, so resizing a tmux pane mid-run promotes or demotes with no state lost.
+
+---
+
+## 8. Frames
+
+### Resolving
+
+Progress list: init file, fetch, blueprint files, templates, providers, resources. First four are stage 1, last two are stage 2.
+
+Hold the frame behind a ~150ms delay. If resolve finishes first, go straight to the main view. A loading screen that appears for three frames is worse than none.
+
+Footer: `nothing has been modified yet`, `q` cancels.
+
+### Running
+
+The five regions above.
+
+### Summary
+
+Replaces the active panel when the run ends.
+
+- Tabs per processor, plus a `failures` tab first and selected by default
+- Rows are `Resource` records: glyph, provider, name, detail, duration
+- Footer totals: applied, skipped, failed, unknown
+- Run log path with `Y` to copy
+- `enter` on a row jumps to that resource's lines in the run log. The summary is an index into the log, not a dead end
+- `tab` cycles tabs, `/` searches within the current tab
+
+### Dry run
+
+Same frame as Summary. Dry run completes in under a second, so there is no live phase to design.
+
+Differences only:
+
+- `DRY RUN` badge in the header
+- Strip blocks render hollow rather than filled
+- Status vocabulary: `+` would apply, `=` already present, `?` cannot resolve
+- Footer counts: would apply, already present, unresolved
+- `c` filters to changes only, hiding already-present rows. Most runs on an existing machine are mostly no-ops
+
+Dry run is not necessarily clean. Unreachable file sources, dead font URLs, missing provider binaries, and unresolvable template variables are all detectable without touching the system. Render as amber `?`, not red. It is a plan problem, not a failure.
+
+### Validate
+
+Summary frame with a diagnostics tab instead of failures, and `Diagnostic` rows instead of `Resource` rows. Same tabs, same search, `enter` opens the offending file and line.
+
+---
+
+## 9. Error handling
+
+| | Interactive (default) | `--interactive=false` |
+|---|---|---|
+| On processor error | halt, jump viewport to it, errors-only auto-applied | mark row, record, continue |
+| Prompt | `r` retry lane, `R` retry processor, `s` skip lane, `q` abort | none |
+| Viewport | jumps and unpins | does not move |
+| End | resolved or aborted | Summary frame, nonzero exit |
+
+Retry defaults to the failed provider lane. Retrying the whole processor means reinstalling 112 packages to recover from one cargo failure. `R` exists for a deliberate clean redo.
+
+`r`, `R`, and `s` only render in `Prompting`. They cost nothing in the normal help bar.
+
+### Failure persistence
+
+Four surfaces, none of which scroll:
+
+1. Strip block turns red and stays red for the rest of the run
+2. Collapsed row keeps its glyph and swaps duration for the error summary
+3. Header counter `✗ 2 · ⚠ 1`, always present
+4. Panel border takes the worst lane state
+
+---
+
+## 10. Theming
+
+Eleven roles. A theme file defines colors and glyphs together.
+
+| Role | Used for |
+|---|---|
+| `bg` `text` `subtext` | base surfaces and copy |
+| `muted` `dim` | pending, skipped, rules, timestamps |
+| `accent` | running, panel border, spinner, progress fill |
+| `success` | completed |
+| `danger` | failed, error lines |
+| `warning` | degraded, warn lines, unknown |
+| `info` | info-level markers |
+| `stdout` `stderr` | raw command output, distinct from rwr's own logs |
+
+Color by state, not by processor. Coloring 13 processors individually requires more distinguishable accents than most themes expose.
+
+Default theme `rwr`, built from Go brand colors: `#00ADD8` accent, `#00A29C` success, `#CE3262` danger, `#FDDD00` warning, `#5DC9E2` info.
+
+Ship embedded: `rwr`, catppuccin's four flavors (free from `catppuccin/go`), nord, gruvbox, dracula, tokyonight, rose-pine, solarized. User themes as TOML in the config dir, same schema, so a user can copy a built-in and edit it. Matches the existing providers pattern.
+
+Resolution order: `--theme`, `config.yaml`, `$RWR_THEME`, default. `NO_COLOR` overrides all of it.
+
+**Do not paint a background.** Inherit the terminal's and use theme colors for foreground and borders only. Light-theme and transparent-terminal users otherwise get a broken-looking frame.
+
+Degradation via `colorprofile`: truecolor gets hex, 256 quantizes, 16 falls back to ANSI names, no-color drops to glyphs and dim/bold. Test with `NO_COLOR=1` and `TERM=xterm`.
+
+### Glyphs
+
+Part of the theme, not a separate mechanism. ASCII set is a base theme others inherit.
+
+| Role | Unicode | ASCII |
+|---|---|---|
+| done | `✓` | `+` |
+| failed | `✗` | `x` |
+| degraded | `⚠` | `!` |
+| unknown | `?` | `?` |
+| pending | `○` | `.` |
+| skipped | `–` | `-` |
+| strip filled / empty | `▰` `▱` | `#` `.` |
+| progress full / empty | `█` `█` | `#` `-` |
+| spinner | braille | `\|` `/` `-` `\` |
+
+`lipgloss.ASCIIBorder()` handles panel frames, `spinner.Line` is the ASCII spinner, progress takes custom full and empty runes.
+
+Detection:
+
+- `LANG` or `LC_ALL` containing UTF-8 implies unicode is safe
+- On Windows, `WT_SESSION` present means Windows Terminal, unicode is fine. Absent means conhost, use ASCII
+- `--ascii` and `--unicode` force either way
+
+---
+
+## 11. Keybinds
+
+| Key | Action |
+|---|---|
+| `j` `k` | move selection, sets pinned |
+| `g` | unpin, snap to live |
+| `a` | toggle scope between selected processor and all |
+| `d` | cycle level: info, debug, warn |
+| `e` | errors only |
+| `o` | toggle stdout/stderr lines |
+| `E` | jump to first failure, apply errors-only |
+| `/` | search |
+| `n` `N` | cycle matches |
+| `f` | toggle follow |
+| `m` | toggle mouse reporting |
+| `y` | yank visible viewport |
+| `Y` | copy run log path |
+| `tab` | cycle summary tabs |
+| `c` | changes only, dry run |
+| `?` | full help |
+| `q` | quit, or abort at a halt |
+| `r` `R` `s` | retry lane, retry processor, skip. Prompting only |
+
+Search scopes to the current view: selected processor plus active level and stdout filters. Matches highlight in place, `esc` clears. Widening scope is what `a` already does.
+
+---
+
+## 12. Mouse
+
+BubbleZone marks regions, `zone.Get(id).InBounds(msg)` in `Update`. Call `zone.Scan` on the final rendered output in top-level `View()`.
+
+| Zone | Click |
+|---|---|
+| Strip block | select that processor |
+| Collapsed done row | select and expand |
+| Pending chip row | expand pending list |
+| `info` / `live` / `stdout` in panel footer | cycle level, toggle follow, toggle raw output |
+| Help bar pills | fire that action |
+| Viewport | wheel scrolls, sets pinned |
+
+Strip blocks are 1 cell. Render each as 2 cells plus separator for a 3-cell target.
+
+Hover matters more than click. The strip is 13 unlabeled blocks. Brighten the hovered block and print its name to the right. Without it the strip is unusable by mouse.
+
+Guard re-render on `hoveredZone != lastHovered`. Motion events fire on every cell crossed.
+
+### Text selection
+
+Mouse tracking takes over drag-select. On a log-heavy TUI this is the first thing a user reaches for.
+
+- Most terminals bypass tracking on shift-drag. Document in `?` help
+- `m` toggles mouse reporting off entirely
+- `y` and `Y` provide a real copy path. Bubble Tea v2 pushes to system clipboard over OSC52, and `atotto/clipboard` is already in the dep tree
+- Mouse reporting must come down and go back up around terminal handoff. `tea.ExecProcess` restores terminal state, but verify the mouse specifically
+
+---
+
+## 13. Animation
+
+| What | Driver | Stops |
+|---|---|---|
+| Progress fill | `progress.SetPercent` spring | settled |
+| Spinner | `spinner.Tick` | processor finishes |
+| Elapsed | `stopwatch` | run ends |
+| Panel height on processor change | harmonica spring + `tea.Tick` | spring settles, then cancel the tick |
+| Strip block state flip | 3-frame brightness pulse | immediately |
+
+Kill the panel tick the moment the spring is within a cell of target and snap. Ticking at 60fps indefinitely costs real CPU on a laptop mid-install.
+
+---
+
+## 14. Activation
+
+Primary check: `term.IsTerminal(os.Stdout.Fd())`. `golang.org/x/term` is already a direct dep.
+
+Fall back to `LogReporter` on any of:
+
+- `--no-tui`
+- `CI` set. Some runners allocate a pty and would otherwise get escape sequences in a build log
+- `TERM=dumb`
+- not a TTY
+
+`rwr all > install.log` already fails the TTY check and behaves as today.
+
+### Single-processor runs
+
+`rwr run packages` uses the same TUI with one strip block. Collapsed success list is always empty, pending chips never render, and the panel takes the freed vertical space. Result is a full-height lane view with a large viewport. Summary still works with fewer tabs.
+
+---
+
+## 15. Notifications
+
+One notification, at run completion, in both interactive and non-interactive modes. Nothing else.
+
+- Use OSC 9. Escape sequences travel over SSH, so provisioning a remote box notifies the machine you are sitting at. `notify-send` and `osascript` notify the remote box, which nobody sees. Also dependency-free, where libnotify may be missing on a system rwr is mid-build
+- Only fire if the run exceeded ~30s
+- Only fire when the terminal is unfocused. Bubble Tea reports focus and blur
+- Gate the sequence on a recognized terminal. Unknown OSC sequences are usually swallowed, but some older terminals print the payload as literal text into the log view
+- Never when not a TTY
+- `--no-notify` disables. No bell by default
+
+Payload carries counts: `rwr finished · 2 failed`.
+
+---
+
+## 16. Validation gating
+
+Every run does stage 1 resolve as a precaution. Gating needs severity or the first person with a slightly odd blueprint cannot run at all.
+
+- Errors gate by default
+- Warnings surface as `⚠ n` in the header and do not stop anything
+- `--strict` promotes warnings to gating
+- `--skip-validate` escape hatch
+
+---
+
+## 17. Suggested sequencing
+
+1. `Plan` struct and stage 1 resolve. Wire `rwr validate` to it. No TUI yet, verify parity with current validate output
+2. Reporter interface and `LogReporter`. Wire into `All()` and `commands.go`. Output must be byte-identical to today. This is the safety net
+3. Store, views, slog handler. Verify records land with correct processor attribution
+4. Stage 2 resolve, provider grouping, lane counts
+5. Error accumulation in `All()`
+6. Static TUI: header, strip, collapsed list, panel, help bar. No animation, no mouse
+7. Terminal handoff via `tea.ExecProcess`. Test sudo prompts hard, this is the common path since interactive defaults true
+8. Filters, search, pinning
+9. Summary and dry-run frames
+10. Theming and glyph fallback
+11. Mouse and hover
+12. Animation
+13. Compact mode and resize
+14. Notifications
+
+Steps 1 through 5 are prerequisites and carry most of the risk. Steps 6 onward are additive.
+
+---
+
+## 18. Test checklist
+
+- `rwr all > file.log`, output matches current master byte for byte
+- `CI=true rwr all`, no escape sequences
+- `NO_COLOR=1`, readable, meaning carried by glyphs
+- `TERM=xterm`, 16-color degradation
+- `TERM=dumb`, falls back to LogReporter
+- Windows conhost, ASCII glyphs
+- Windows Terminal, unicode
+- sudo prompt in a `files` blueprint, handoff and repaint
+- `interactive: true` on one package inside `--interactive=false`, handoff still works
+- Ring wrap during a long debug run, no panic, boundary row renders
+- Resize below and above both thresholds mid-run
+- Processor failure at position 1 and at position 13, both stay visible at end
+- Provider partial failure, processor renders degraded not failed
+- Dry run against a system where everything is already installed
+- Light-background terminal, no painted background
+- Terminal with transparency, frame does not fill
+
+---
+
+## 19. Out of scope
+
+- Resource-level granularity in the live view. Live stays at processor and provider. Resources are recorded and rendered only in Summary
+- Concurrent processor execution. `All()` is sequential and this design assumes it
+- Interactive plan approval before apply. Dry run and validate cover the need
+- Scrollbar dragging in the viewport

--- a/openspec/changes/add-tui/proposal.md
+++ b/openspec/changes/add-tui/proposal.md
@@ -1,0 +1,49 @@
+# Change: Bubble Tea TUI for interactive runs
+
+## Why
+
+`rwr all` streams logs; on a real provisioning run (13 processors, hundreds of
+resources, sudo prompts mid-stream) there is no view of overall progress, no
+persistent failure surface, and errors scroll away. A TTY-only dashboard fixes
+this; non-TTY behavior stays byte-identical.
+
+## What Changes
+
+Full design in `design.md`. Summary:
+
+- Resolve phase producing a `Plan` (two stages; stage 2 after bootstrap because
+  bootstrap can install the package manager later blueprints depend on).
+  `rwr validate` consumes stage 1.
+- Error accumulation in `All()`: fatal pre-loop errors abort; processor errors
+  are collected in non-interactive mode, halt-and-prompt in interactive mode.
+  Exit nonzero if any collected.
+- `Reporter` event bus; `TUIReporter` and `LogReporter` (byte-identical to
+  today's output). Log capture via a `slog.Handler` stamping a package-level
+  `currentProcessor` — zero edits to the ten processor files.
+- Interactive command handoff via `TerminalReq` + `tea.ExecProcess`; stderr of
+  interactive commands is never piped (sudo prompt). Works for per-item
+  `interactive: true` inside non-interactive runs.
+- Ring-buffered log store with per-processor views, run log file always written.
+- Frames: Resolving, Running (header/strip/collapsed/panel/help), Summary,
+  Dry-run, Validate. Compact mode below ~60 cols / ~14 rows.
+- Theming (11 roles, embedded themes, TOML user themes, `NO_COLOR`/colorprofile
+  degradation, ASCII glyph fallback), mouse via bubblezone, animation via
+  harmonica, OSC 9 completion notification.
+- Activation: TTY check; `--no-tui`, `CI`, `TERM=dumb` fall back to
+  `LogReporter`.
+
+Also folds `internal/system/prompt.go` `PromptUserChoice` (raw stdin) into the
+reporter/handoff path — a second stdin consumer would fight the TUI.
+
+## Breakage
+
+Nothing breaks. `rwr all > file.log`, `CI=true`, and `TERM=dumb` produce
+today's output byte-for-byte (this is a gated test). Blueprint semantics are
+untouched.
+
+## Impact
+
+- Affected specs: `cli`, `blueprint-processing`, `command-execution`.
+- New direct deps: bubbletea/v2, bubbles/v2, lipgloss/v2, catppuccin/go,
+  colorprofile (already in go.sum via huh), harmonica, bubblezone.
+- Unblocks: `add-blueprint-manifest` selection frame.

--- a/openspec/changes/add-tui/specs/blueprint-processing/spec.md
+++ b/openspec/changes/add-tui/specs/blueprint-processing/spec.md
@@ -1,0 +1,40 @@
+# Blueprint Processing — Deltas
+
+## ADDED Requirements
+
+### Requirement: Two-stage resolve produces a Plan before execution
+
+The system SHALL resolve blueprints into a `Plan` before executing: stage 1
+(parse, imports, schema, templates, diagnostics) requires only paths + OS
+detection; stage 2 (provider states, resource enumeration) SHALL run only
+after init and bootstrap complete.
+
+Why: bootstrap can install the package manager later blueprints depend on;
+detecting providers earlier produces wrong results.
+
+#### Scenario: validate uses stage 1 only
+
+- **GIVEN** `rwr validate`
+- **WHEN** it runs
+- **THEN** it consumes stage 1 output and performs no provider detection
+
+## MODIFIED Requirements
+
+### Requirement: Processor errors accumulate in non-interactive runs
+
+In non-interactive mode, an error from a processor SHALL be recorded and the
+run SHALL continue with the remaining processors; the exit code SHALL be
+nonzero if any error was recorded. Pre-loop failures (blueprint fetch, missing
+location, package-manager install, unresolvable run order) SHALL abort in both
+modes. Interactive mode SHALL halt at the failing processor.
+
+Why: a provisioning run that dies at processor 2 of 13 leaves the machine in a
+worse state than one that applies everything it can and reports what failed.
+Logging a failure and exiting 0 is a bug (repo invariant).
+
+#### Scenario: Non-interactive continues past a failure
+
+- **GIVEN** `--interactive=false` and a failing `packages` processor
+- **WHEN** `rwr all` runs
+- **THEN** the remaining processors execute
+- **AND** the exit code is nonzero and the failure appears in the summary

--- a/openspec/changes/add-tui/specs/cli/spec.md
+++ b/openspec/changes/add-tui/specs/cli/spec.md
@@ -1,0 +1,40 @@
+# CLI — Deltas
+
+## ADDED Requirements
+
+### Requirement: TUI activates only on a real TTY
+
+`rwr all` and `rwr run` SHALL render the TUI only when stdout is a terminal
+and none of `--no-tui`, `CI`, or `TERM=dumb` apply. In every other case output
+SHALL be byte-identical to the pre-TUI streaming logs.
+
+Why: escape sequences in a CI build log or a redirected file are corruption,
+not UI.
+
+#### Scenario: Redirected output unchanged
+
+- **GIVEN** `rwr all > install.log`
+- **WHEN** the run completes
+- **THEN** `install.log` matches the pre-TUI output byte for byte
+
+#### Scenario: CI runner with a pty
+
+- **GIVEN** `CI=true` on a runner that allocates a pty
+- **WHEN** `rwr all` runs
+- **THEN** no escape sequences are emitted
+
+### Requirement: Run summary and run log
+
+A TUI run SHALL record every log line to a run log file (mode 0600, path
+printed on exit, `--log-file` overrides) and SHALL end with a summary of
+resources by status: applied, skipped, failed, unknown.
+
+Why: `unknown` is required — several providers do not report per-package
+results reliably; forcing them into ok/failed fabricates data.
+
+#### Scenario: Failure visible at end
+
+- **GIVEN** a 13-processor run where processor 1 failed
+- **WHEN** the run reaches the summary
+- **THEN** the failure is on screen without scrolling, and the exit code is
+  nonzero

--- a/openspec/changes/add-tui/specs/command-execution/spec.md
+++ b/openspec/changes/add-tui/specs/command-execution/spec.md
@@ -1,0 +1,42 @@
+# Command Execution — Deltas
+
+## MODIFIED Requirements
+
+### Requirement: Interactive commands get the real terminal
+
+A command with `Interactive` set SHALL receive the real tty (stdin, stdout,
+stderr). Under the TUI this SHALL happen via terminal handoff
+(`tea.ExecProcess`): the TUI suspends, the child owns the terminal, the TUI
+repaints on exit. The handoff SHALL apply to per-item `interactive: true`
+inside an otherwise non-interactive run.
+
+Why: piping stderr swallows sudo's password prompt and hangs the run; gating
+handoff on the global flag breaks `ResolveInteractive`'s per-item override.
+
+#### Scenario: sudo prompt under the TUI
+
+- **GIVEN** a `files` blueprint requiring elevation
+- **WHEN** sudo prompts for a password mid-run
+- **THEN** the prompt appears on the real terminal, the user answers, and the
+  TUI repaints
+
+#### Scenario: Per-item interactive in a non-interactive run
+
+- **GIVEN** `--interactive=false` and one package with `interactive: true`
+- **WHEN** that package installs
+- **THEN** the terminal is handed off for that command only
+
+## ADDED Requirements
+
+### Requirement: Non-interactive command output is attributed per line
+
+Stdout and stderr of non-interactive commands SHALL be captured line-wise,
+attributed to the running processor, and marked by source (stdout/stderr).
+The full stderr text SHALL remain available to the error path, and
+per-blueprint `logName` files SHALL keep working.
+
+#### Scenario: Attribution in the store
+
+- **GIVEN** a package manager writing progress to stdout during `packages`
+- **WHEN** the lines are captured
+- **THEN** each record carries processor `packages` and source `stdout`

--- a/openspec/changes/add-tui/tasks.md
+++ b/openspec/changes/add-tui/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+Steps 1–5 are prerequisites and carry the risk; 6+ are additive.
+
+- [ ] 1. `Plan` struct + stage 1 resolve; wire `rwr validate` to it. Parity test
+      against current validate output (fails if outputs diverge).
+- [ ] 2. `Reporter` interface + `LogReporter` wired into `All()` and
+      `commands.go`. Byte-identical-output test vs master (the safety net).
+- [ ] 3. Store, views, slog handler; test processor attribution of records.
+- [ ] 4. Stage 2 resolve: provider grouping, lane counts.
+- [ ] 5. Error accumulation in `All()`; test: non-interactive run with one
+      failing processor continues, exits nonzero (fails today — first error
+      aborts).
+- [ ] 6. Static TUI: header, strip, collapsed list, panel, help bar.
+- [ ] 7. Terminal handoff (`tea.ExecProcess`); test sudo prompt and per-item
+      `interactive: true` under `--interactive=false`.
+- [ ] 8. Filters, search, pinning.
+- [ ] 9. Summary + dry-run frames.
+- [ ] 10. Theming + glyph fallback (`NO_COLOR=1`, `TERM=xterm`, conhost ASCII).
+- [ ] 11. Mouse + hover (bubblezone).
+- [ ] 12. Animation (harmonica; kill ticks when springs settle).
+- [ ] 13. Compact mode + live resize.
+- [ ] 14. OSC 9 notification (unfocused, >30s, recognized terminal only).
+- [ ] 15. Full test checklist from design.md §18.

--- a/openspec/changes/refactor-cmd-config/proposal.md
+++ b/openspec/changes/refactor-cmd-config/proposal.md
@@ -1,0 +1,29 @@
+# Change: Replace cmd package globals with a config struct
+
+(Was issue #104.)
+
+## Why
+
+`cmd/root.go` holds 17 package-level mutable variables (`ghApiToken`, `debug`,
+`profiles`, `initConfig`, `osInfo`, …). They make unit testing the cmd package
+nearly impossible (no isolated state, no reset between tests), risk races in
+parallel tests, and hide ownership/lifecycle.
+
+## What Changes
+
+- An `AppConfig` struct owning all current globals (auth, execution flags,
+  paths, active `InitConfig`/`OSInfo`/profiles), constructed in
+  `PersistentPreRunE` and passed to `initializeSystemInfo` and the command
+  implementations.
+- Cobra flags bind to struct fields; no package-level mutable state remains in
+  `cmd` beyond the cobra command tree itself.
+
+## Breakage
+
+Nothing breaks. Flags, config keys, and behavior are unchanged; this is an
+internal restructuring.
+
+## Impact
+
+- Affected specs: `cli` (no requirement changes — internal only).
+- Makes cmd-level tests with isolated config instances possible.

--- a/openspec/changes/refactor-cmd-config/tasks.md
+++ b/openspec/changes/refactor-cmd-config/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [ ] 1. `AppConfig` struct + constructor with defaults (`Interactive: true`,
+      `LogLevel: "info"`).
+- [ ] 2. Bind all cobra flags to struct fields; move the 17 globals in
+      `cmd/root.go` into it; thread through `initializeSystemInfo` and
+      subcommands.
+- [ ] 3. Test constructing two isolated `AppConfig` instances and running
+      command setup against each without cross-talk (impossible today —
+      fails without the refactor).
+- [ ] 4. `mise run ci` green; behavior of every flag unchanged.


### PR DESCRIPTION
Adds five OpenSpec changes under `openspec/changes/`, each with proposal, tasks, and SHALL-statement spec deltas with scenarios (designs included where they exist):

- **add-format-registry** — centralize format derivation (~15 hardcoded sites, two contradictory format models, `all.go:148` panic, `rwr.init-file`/`repository.init-file` binding mismatch). Prereq for the two below. → #192
- **add-cue-providers** — provider definitions in CUE, exported at build time to committed embedded JSON; family templates; contracts move into the schema. → #193
- **add-tui** — Bubble Tea v2 dashboard; Plan/two-stage resolve, Reporter bus, error accumulation, terminal handoff; non-TTY output stays byte-identical. → #194
- **add-blueprint-manifest** — root `manifest.*` for multi-OS blueprint repos, OS-matched smart selection as a TUI frame, `--config-name`. Depends on format registry + TUI. → #195
- **add-cue-blueprints** — `.cue` as a fourth blueprint format via runtime `cuelang.org/go`, sandboxed evaluation. Depends on format registry. → #196

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkZzCSG9ZUErWkhAZmHXsY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkZzCSG9ZUErWkhAZmHXsY)_