### PR TITLE
fix(release): sign with the cosign bundle format

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,6 +88,48 @@ jobs:
           version: "~> v2"
           args: build --snapshot --clean
 
+  # cross-compile only exercises `goreleaser build`; the signs:/sboms:/nfpms:
+  # blocks only ever ran inside a real tag push or the master prerelease, which
+  # is how the cosign 3.x sign-blob CLI change could break every release and
+  # nightly before anything caught it. This runs the full release pipeline as a
+  # snapshot — including the cosign signing step — before merge. Keyless signing
+  # needs an OIDC token, which fork PRs do not get, so those are skipped (they
+  # still run cross-compile).
+  release-snapshot:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # goreleaser reads git state; a shallow clone breaks its version math.
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: ">=1.26.5"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Same pin as release.yml/nightly.yml: this job exists to prove the
+          # exact binary the release will use can still sign.
+          cosign-release: "v3.1.2"
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
+
+      - name: Release snapshot (no publish)
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean --skip=homebrew
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # golangci-lint gates every commit locally, through mise (`mise run lint`) and
   # the hk pre-commit hook — but only for contributors who ran `mise install`.
   # Anyone else got no lint at all, and neither did any pull request.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,6 +47,11 @@ jobs:
       # same treatment as a release: people install it.
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin the binary, not just the action: an unpinned install tracks
+          # cosign's latest, whose sign-blob CLI has broken the signs: block
+          # before (the 3.x bundle-format switch). Renovate keeps this current.
+          cosign-release: "v3.1.2"
       - name: Install syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
@@ -95,8 +100,8 @@ jobs:
             find dist -maxdepth 1 -type f \
               \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.deb' \
                  -o -name '*.rpm' -o -name '*.apk' -o -name '*.pkg.tar.zst' \
-                 -o -name 'checksums.txt' -o -name 'checksums.txt.sig' \
-                 -o -name 'checksums.txt.pem' -o -name '*.sbom.json' \) | sort
+                 -o -name 'checksums.txt' -o -name 'checksums.txt.sigstore.json' \
+                 -o -name '*.sbom.json' \) | sort
           )
 
           if [ "${#artifacts[@]}" -eq 0 ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ jobs:
       # goreleaser (signs: / sboms: in .goreleaser.yaml).
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin the binary, not just the action: an unpinned install tracks
+          # cosign's latest, whose sign-blob CLI has broken the signs: block
+          # before (the 3.x bundle-format switch). Renovate keeps this current.
+          cosign-release: "v3.1.2"
       - name: Install syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
       - name: Run GoReleaser

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -81,17 +81,20 @@ sboms:
 # identity (no key to store or leak), verifiable with:
 #
 #   cosign verify-blob checksums.txt \
-#     --signature checksums.txt.sig --certificate checksums.txt.pem \
-#     --certificate-identity-regexp 'github.com/FynxLabs/rwr' \
+#     --bundle checksums.txt.sigstore.json \
+#     --certificate-identity-regexp '^https://github\.com/FynxLabs/rwr/' \
 #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+#
+# cosign 3.x signs in the sigstore bundle format (signature + certificate in one
+# .sigstore.json file). Its sign-blob ignores --output-signature/--output-certificate
+# and requires --bundle — the old two-file form made every signing step die with
+# "create bundle file: open : no such file or directory".
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
-    signature: "${artifact}.sig"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
-      - --output-certificate=${certificate}
-      - --output-signature=${signature}
+      - --bundle=${signature}
       - ${artifact}
       - --yes
     artifacts: checksum

--- a/install.ps1
+++ b/install.ps1
@@ -117,7 +117,7 @@ try {
     # (checksums.txt.sigstore.json, a sigstore bundle). Verifying it upgrades the
     # checksum comparison from integrity to authenticity. Opportunistic: cosign
     # is rarely installed on Windows, so a missing cosign or missing bundle only
-    # warns — the install then rests on checksum integrity alone, and a
+    # warns - the install then rests on checksum integrity alone, and a
     # substituted checksums.txt would not be detected. When cosign is present
     # and a bundle is published, a bad signature is a hard stop.
     $bundle_url = $latest_release.assets |

--- a/install.ps1
+++ b/install.ps1
@@ -113,6 +113,38 @@ try {
         exit 1
     }
 
+    # Releases carry a keyless cosign signature over checksums.txt
+    # (checksums.txt.sigstore.json, a sigstore bundle). Verifying it upgrades the
+    # checksum comparison from integrity to authenticity. Opportunistic: cosign
+    # is rarely installed on Windows, so a missing cosign or missing bundle only
+    # warns — the install then rests on checksum integrity alone, and a
+    # substituted checksums.txt would not be detected. When cosign is present
+    # and a bundle is published, a bad signature is a hard stop.
+    $bundle_url = $latest_release.assets |
+        Where-Object { $_.name -eq "checksums.txt.sigstore.json" } |
+        Select-Object -First 1 -ExpandProperty browser_download_url
+    $cosign = Get-Command cosign -ErrorAction SilentlyContinue
+
+    if ($cosign -and $bundle_url) {
+        $tmp_bundle = Join-Path $tmp_dir "checksums.txt.sigstore.json"
+        Invoke-WebRequest -Uri $bundle_url -OutFile $tmp_bundle -Headers $headers -UseBasicParsing
+        & $cosign.Source verify-blob $tmp_sums `
+            --bundle $tmp_bundle `
+            --certificate-identity-regexp '^https://github\.com/FynxLabs/rwr/' `
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "cosign signature verification FAILED for checksums.txt. The release may have been tampered with. Refusing to install."
+            exit 1
+        }
+        Write-Host "Signature verified (cosign)"
+    }
+    elseif ($bundle_url) {
+        Write-Host "Note: this release is signed; install cosign to verify signatures. Proceeding on checksum integrity only."
+    }
+    else {
+        Write-Host "Note: this release publishes no signature for checksums.txt. Proceeding on checksum integrity only."
+    }
+
     $actual = (Get-FileHash -Path $tmp_file -Algorithm SHA256).Hash
     if ($actual -ne $expected.ToUpper()) {
         Write-Host "Checksum mismatch for ${asset_name}:"

--- a/install.sh
+++ b/install.sh
@@ -166,12 +166,57 @@ fi
 
 # Releases carry a keyless cosign signature over checksums.txt, bound to this
 # repository's GitHub Actions identity. Verifying it upgrades the checksum
-# comparison from integrity to authenticity. Opportunistic: cosign is not a
-# requirement to install, but when it is present and the release publishes a
-# signature, a bad signature is a hard stop.
+# comparison from integrity to authenticity.
+#
+# Current releases publish a sigstore bundle (checksums.txt.sigstore.json,
+# signature + certificate in one file); releases up to v0.5.1 published the
+# older two-file form (checksums.txt.sig + checksums.txt.pem) — both verify.
+#
+# The identity match is anchored: "github.com/$REPO" as a bare substring also
+# matched evil.github.com/FynxLabs/rwr.anything hosted by an attacker's issuer
+# subdomain. Keyless GitHub Actions identities are always
+# https://github.com/<owner>/<repo>/<workflow path>@<ref>.
+COSIGN_IDENTITY_RE='^https://github\.com/FynxLabs/rwr/'
+COSIGN_ISSUER="https://token.actions.githubusercontent.com"
+
+# By default a missing signature or missing cosign only warns: an attacker with
+# write access to release assets could delete the signature and let the install
+# proceed on their own checksums.txt, so the warning is loud. Set
+# RWR_REQUIRE_SIGNATURE=1 to make either condition a hard stop.
+REQUIRE_SIG="${RWR_REQUIRE_SIGNATURE:-0}"
+
+warn_or_fail_unverified() {
+    if [ "$REQUIRE_SIG" = "1" ]; then
+        fail "RWR_REQUIRE_SIGNATURE=1: $1 Refusing to install."
+    fi
+    echo "" >&2
+    echo "WARNING: $1" >&2
+    echo "WARNING: proceeding on checksum integrity only — the checksums file itself is unauthenticated." >&2
+    echo "WARNING: set RWR_REQUIRE_SIGNATURE=1 to refuse unverified installs." >&2
+    echo "" >&2
+}
+
+bundle_url=$(url_for_asset "$CHECKSUMS.sigstore.json")
 sig_url=$(url_for_asset "$CHECKSUMS.sig")
 cert_url=$(url_for_asset "$CHECKSUMS.pem")
-if command -v cosign >/dev/null 2>&1 && [ -n "$sig_url" ] && [ -n "$cert_url" ]; then
+
+if [ -z "$bundle_url" ] && { [ -z "$sig_url" ] || [ -z "$cert_url" ]; }; then
+    warn_or_fail_unverified "this release publishes no signature for $CHECKSUMS, so its authenticity cannot be verified."
+elif ! command -v cosign >/dev/null 2>&1; then
+    warn_or_fail_unverified "this release is signed, but cosign is not installed so the signature cannot be verified."
+elif [ -n "$bundle_url" ]; then
+    if ! curl -fsSL -H "User-Agent: $USER_AGENT" -o "$TMP_DIR/$CHECKSUMS.sigstore.json" "$bundle_url"; then
+        fail "The release publishes a signature bundle for $CHECKSUMS but it could not be downloaded. Refusing to install."
+    fi
+    if ! cosign verify-blob "$TMP_DIR/$CHECKSUMS" \
+        --bundle "$TMP_DIR/$CHECKSUMS.sigstore.json" \
+        --certificate-identity-regexp "$COSIGN_IDENTITY_RE" \
+        --certificate-oidc-issuer "$COSIGN_ISSUER" >/dev/null 2>&1; then
+        fail "cosign signature verification FAILED for $CHECKSUMS. The release may have been tampered with. Refusing to install."
+    fi
+    echo "Signature verified (cosign)"
+elif [ -n "$sig_url" ] && [ -n "$cert_url" ]; then
+    # Pre-bundle release (v0.5.1 and earlier).
     if ! curl -fsSL -H "User-Agent: $USER_AGENT" -o "$TMP_DIR/$CHECKSUMS.sig" "$sig_url" ||
        ! curl -fsSL -H "User-Agent: $USER_AGENT" -o "$TMP_DIR/$CHECKSUMS.pem" "$cert_url"; then
         fail "The release publishes a signature for $CHECKSUMS but it could not be downloaded. Refusing to install."
@@ -179,13 +224,11 @@ if command -v cosign >/dev/null 2>&1 && [ -n "$sig_url" ] && [ -n "$cert_url" ];
     if ! cosign verify-blob "$TMP_DIR/$CHECKSUMS" \
         --signature "$TMP_DIR/$CHECKSUMS.sig" \
         --certificate "$TMP_DIR/$CHECKSUMS.pem" \
-        --certificate-identity-regexp "github.com/$REPO" \
-        --certificate-oidc-issuer https://token.actions.githubusercontent.com >/dev/null 2>&1; then
+        --certificate-identity-regexp "$COSIGN_IDENTITY_RE" \
+        --certificate-oidc-issuer "$COSIGN_ISSUER" >/dev/null 2>&1; then
         fail "cosign signature verification FAILED for $CHECKSUMS. The release may have been tampered with. Refusing to install."
     fi
     echo "Signature verified (cosign)"
-elif [ -n "$sig_url" ]; then
-    echo "Note: this release is signed; install cosign to verify signatures."
 fi
 
 # goreleaser writes "<sha256>  <file name>" lines. Compare $2 exactly so a


### PR DESCRIPTION
## Why

Every `v*` tag and nightly currently fails at the signing step. cosign 3.x (installed by cosign-installer v4) signs in the sigstore bundle format: `--output-signature`/`--output-certificate` are deprecated **and ignored**, and `sign-blob` dies writing the bundle to the never-passed `--bundle` path:

```
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
```

Confirmed in the nightly run history ([run 30762009614](https://github.com/FynxLabs/rwr/actions/runs/30762009614)) — the release pipeline has been red since the cosign 3.x rollout.

## What

- **`.goreleaser.yaml`**: sign to `${artifact}.sigstore.json` via `--bundle`; drop the two-file `.sig`/`.pem` form. Verify comment updated.
- **`nightly.yml`**: publish `checksums.txt.sigstore.json` instead of the `.sig`/`.pem` assets that no longer exist (otherwise the nightly would sign but never upload the signature).
- **`release.yml`/`nightly.yml`**: pin `cosign-release: v3.1.2` so the signing CLI only changes when Renovate proposes it, not silently on the runner.
- **`install.sh`** (folds in planned PR-5):
  - verify with `cosign verify-blob --bundle`; legacy `.sig`/`.pem` path kept so `--tag v0.5.1` and earlier still verify.
  - **fail-closed option**: previously, deleting the signature assets from a release silently downgraded the install to unauthenticated checksums. Now a missing signature/missing cosign warns loudly, and `RWR_REQUIRE_SIGNATURE=1` refuses.
  - **anchored identity**: `github.com/FynxLabs/rwr` as a bare substring also matched attacker-controlled identities embedding that string; now `^https://github\.com/FynxLabs/rwr/`.
- **`install.ps1`**: opportunistic bundle verification when cosign is on PATH; explicit note of the gap otherwise.
- **`go.yml`**: new `release-snapshot` job runs the full `goreleaser release --snapshot` pipeline — signing included — on same-repo PRs and master pushes. The sign step previously only executed during a real publish, which is how this rotted unnoticed. Fork PRs skip it (no OIDC token) but still run `cross-compile`.

## Verification

- `goreleaser check` passes; `bash -n install.sh` passes; full local hook suite (go-test, gosec, govulncheck) green.
- The real proof is the `release-snapshot` job on this PR itself — it exercises the exact failing step with the fixed config.

From REVIEW-PR-PLAN.md Wave 0 (PR-0 + PR-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)