### PR TITLE
fix(security): re-validate every redirect hop, add timeouts, honor step digests

### DIFF
--- a/internal/processors/fonts.go
+++ b/internal/processors/fonts.go
@@ -29,7 +29,7 @@ type GithubRelease struct {
 }
 
 func getLatestReleaseURL() (string, error) {
-	resp, err := http.Get(nerdFontRepoAPI) // #nosec G107 -- package-level constant URL, a var only so tests can point it at their own server
+	resp, err := system.DownloadClient.Get(nerdFontRepoAPI) // #nosec G107 -- package-level constant URL, a var only so tests can point it at their own server
 	if err != nil {
 		return "", err
 	}
@@ -218,7 +218,7 @@ func downloadFontTarball(url, filepath string) error {
 	if err := system.ValidateDownloadURL(url); err != nil {
 		return err
 	}
-	resp, err := http.Get(url) // #nosec G107 -- scheme restricted by ValidateDownloadURL above
+	resp, err := system.DownloadClient.Get(url) // #nosec G107 -- scheme restricted by ValidateDownloadURL above and per redirect hop by the client
 	if err != nil {
 		return err
 	}

--- a/internal/processors/packageManager.go
+++ b/internal/processors/packageManager.go
@@ -113,7 +113,10 @@ func ProcessPackageManagers(packageManagers []types.PackageManagerInfo, osInfo *
 					log.Infof("[DRY-RUN] Would download file: %s -> %s", step.Source, step.Dest)
 					continue
 				}
-				if err := system.DownloadFile(step.Source, step.Dest, provider.Elevated); err != nil {
+				// step.Sha256 is rendered by renderActionStep like every other
+				// field; dropping it here silently waived the digest check the
+				// provider author asked for (repository.go threads it through).
+				if err := system.DownloadFileWithChecksum(step.Source, step.Dest, provider.Elevated, step.Sha256); err != nil {
 					return fmt.Errorf("error downloading file: %w", err)
 				}
 				continue

--- a/internal/processors/packageManager_checksum_test.go
+++ b/internal/processors/packageManager_checksum_test.go
@@ -1,0 +1,85 @@
+package processors
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// An install step's sha256 pins what the download must be. It was rendered by
+// renderActionStep like every other field and then silently discarded, so a
+// provider author's digest bought nothing on this path (repository download
+// steps honored theirs).
+func TestProcessPackageManagers_InstallStepVerifiesSha256(t *testing.T) {
+	content := []byte("installer script bytes")
+	sum := sha256.Sum256(content)
+	good := hex.EncodeToString(sum[:])
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	// Detection.Binary is deliberately absent from PATH: install steps only run
+	// when the manager's binary is not yet there.
+	newProvider := func(dest, digest string) *types.Provider {
+		return &types.Provider{
+			Name: "fake",
+			Detection: types.DetectionConfig{
+				Binary:        "rwr-test-binary-that-does-not-exist",
+				Distributions: []string{runtime.GOOS},
+			},
+			Install: types.InstallConfig{
+				Steps: []types.ActionStep{{
+					Action: "download",
+					Source: server.URL,
+					Dest:   dest,
+					Sha256: digest,
+				}},
+			},
+		}
+	}
+
+	run := func(t *testing.T, dest, digest string) error {
+		t.Helper()
+		defer system.SetExecutor(exectest.New())()
+		defer system.SetProvidersForTest(map[string]*types.Provider{"fake": newProvider(dest, digest)})()
+
+		return ProcessPackageManagers(
+			[]types.PackageManagerInfo{{Name: "fake", Action: "install"}},
+			&types.OSInfo{},
+			&types.InitConfig{},
+		)
+	}
+
+	t.Run("declared digest matches", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "installer.sh")
+		if err := run(t, dest, good); err != nil {
+			t.Fatalf("ProcessPackageManagers: %v", err)
+		}
+		if got, readErr := os.ReadFile(dest); readErr != nil || string(got) != string(content) {
+			t.Fatalf("dest = %q (%v), want the downloaded content", got, readErr)
+		}
+	})
+
+	t.Run("declared digest mismatch refuses", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "installer.sh")
+		err := run(t, dest, strings.Repeat("0", 64))
+		if err == nil || !strings.Contains(err.Error(), "sha256 mismatch") {
+			t.Fatalf("err = %v, want a sha256 mismatch refusal", err)
+		}
+		if _, statErr := os.Stat(dest); statErr == nil {
+			t.Fatal("dest written despite the mismatch")
+		}
+	})
+}

--- a/internal/system/download_integrity_test.go
+++ b/internal/system/download_integrity_test.go
@@ -52,6 +52,50 @@ func TestDownloadFile_RefusesPlainHTTP(t *testing.T) {
 	}
 }
 
+// Validating only the initial URL is worthless if a redirect can hop to plain
+// http: the default client follows it silently and the content is once again
+// substitutable in transit. Every hop is re-validated by DownloadClient's
+// CheckRedirect. The redirect target here is a non-loopback http URL — the
+// refusal happens in CheckRedirect before any request is made to it.
+func TestDownloadFile_RefusesRedirectToPlainHTTP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://example.invalid/key.gpg", http.StatusFound)
+	}))
+	defer server.Close()
+
+	target := filepath.Join(t.TempDir(), "out")
+	err := DownloadFile(server.URL, target, false)
+	if err == nil || !strings.Contains(err.Error(), "plain http") {
+		t.Fatalf("err = %v, want a plain-http refusal on the redirect hop", err)
+	}
+	if _, statErr := os.Stat(target); statErr == nil {
+		t.Fatal("target file exists despite the refusal")
+	}
+}
+
+// A same-origin redirect to another validated URL still works.
+func TestDownloadFile_FollowsValidatedRedirect(t *testing.T) {
+	content := []byte("redirected content")
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/moved", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, server.URL+"/real", http.StatusFound)
+	})
+	mux.HandleFunc("/real", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(content)
+	})
+
+	target := filepath.Join(t.TempDir(), "out")
+	if err := DownloadFile(server.URL+"/moved", target, false); err != nil {
+		t.Fatalf("DownloadFile: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || string(got) != string(content) {
+		t.Fatalf("target = %q (%v), want the redirected content", got, err)
+	}
+}
+
 func TestDownloadFileWithChecksum(t *testing.T) {
 	content := []byte("the artifact")
 	sum := sha256.Sum256(content)

--- a/internal/system/files.go
+++ b/internal/system/files.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/types"
@@ -172,6 +173,26 @@ func ValidateDownloadURL(raw string) error {
 	}
 }
 
+// DownloadClient is the HTTP client behind every content download rwr performs.
+// Two properties the default client lacks:
+//
+//   - every redirect hop is re-validated with ValidateDownloadURL. Validating
+//     only the initial URL is worthless the moment the server answers with a
+//     302 to plain http — the default client follows it silently and the
+//     content is once again substitutable in transit.
+//   - a timeout, so a stalled mirror fails the step instead of hanging the
+//     whole run forever. Generous, because font archives run to hundreds of MB
+//     on slow links; it exists to bound a hang, not to race the download.
+var DownloadClient = &http.Client{
+	Timeout: 15 * time.Minute,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return ValidateDownloadURL(req.URL.String())
+	},
+}
+
 // verifyFileSHA256 compares the file's digest against the expected hex string.
 func verifyFileSHA256(path, wantHex string) error {
 	f, err := os.Open(path) // #nosec G304 -- staging file created by this package
@@ -197,7 +218,7 @@ func downloadFileContent(url, filePath string) error {
 	}
 
 	// Send an HTTP GET request to the URL
-	response, err := http.Get(url) // #nosec G107 -- scheme restricted by ValidateDownloadURL above
+	response, err := DownloadClient.Get(url) // #nosec G107 -- scheme restricted by ValidateDownloadURL above and per redirect hop by the client
 	if err != nil {
 		return fmt.Errorf("error downloading file: %v", err)
 	}

--- a/openspec/specs/blueprint-processing/spec.md
+++ b/openspec/specs/blueprint-processing/spec.md
@@ -472,6 +472,36 @@ RWR SHALL enforce the schema version of every file in the chain.
   `schema_version`
 - **THEN** the run stops and no command is issued
 
+### Requirement: Downloads are validated on every hop, bounded, and pinnable
+
+Everything RWR downloads — package-signing keys, fonts, file sources, the init
+file — is installed with the operator's privileges, so a download URL SHALL be
+refused unless it is https (plain http is allowed only for loopback hosts), and
+that check SHALL be re-applied to **every redirect hop**, not only the initial
+URL. Validating only the first URL is worthless the moment a server answers
+with a 302 to plain http.
+
+Downloads SHALL time out rather than hang a run indefinitely.
+
+Where a step or blueprint entry declares a `sha256` for downloaded content, RWR
+SHALL verify the download against it before the content is moved into place,
+and SHALL discard the download on a mismatch. This applies to repository action
+steps and package-manager install/remove steps alike.
+
+#### Scenario: A redirect to plain http
+
+- **WHEN** an https download URL answers with a redirect to a plain-http,
+  non-loopback URL
+- **THEN** the download is refused before any request is made to the redirect
+  target
+
+#### Scenario: An install step with a wrong digest
+
+- **WHEN** a provider's install step declares `sha256` and the downloaded
+  content does not match it
+- **THEN** the step fails, the staged download is discarded, and nothing is
+  written to the destination
+
 ## Known Gaps
 
 - **The failure ledger covers four processors.** `packages`, `git`, `ssh_keys` and


### PR DESCRIPTION
## Why

The HIGH finding from the security track (minus the schema half, which rides the CUE change):

- `downloadFileContent` validated only the initial URL, then called bare `http.Get` — an https→http 302 was followed silently (empirically confirmed in the review). This path serves repo signing keys, fonts, file sources, and the init file, all installed with the operator's privileges.
- `http.Get` had no timeout: a stalled mirror hung the run forever.
- Package-manager `download` steps rendered `step.Sha256` via `renderActionStep` and then **discarded it** — compare the correct threading at `repository.go:162`.

## What

- **`system.DownloadClient`**: shared `http.Client` with a 15-minute timeout and a `CheckRedirect` that re-runs `ValidateDownloadURL` on every hop (capped at 10). `downloadFileContent` and both `fonts.go` fetches now use it.
- **`packageManager.go`**: `download` steps call `DownloadFileWithChecksum(..., step.Sha256)`, matching the repository processor.
- **Spec delta**: new "Downloads are validated on every hop, bounded, and pinnable" requirement in `blueprint-processing/spec.md`.

## Tests (fail without the fix)

- `TestDownloadFile_RefusesRedirectToPlainHTTP` — server 302s to a non-loopback http URL; refused in `CheckRedirect` before any request reaches the target.
- `TestDownloadFile_FollowsValidatedRedirect` — legitimate redirects still work.
- `TestProcessPackageManagers_InstallStepVerifiesSha256` — matching digest installs; mismatch refuses and writes nothing.

## Breaking-change statement

Nothing breaks for existing blueprints unless a source URL redirects https→http to a non-loopback host — a download that was substitutable in transit and is now refused.

From REVIEW-PR-PLAN.md Wave 0 (PR-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)