### PR TITLE
fix(security): stage the macports installer privately, with a digest

### DIFF
--- a/internal/processors/package_manager_staging_test.go
+++ b/internal/processors/package_manager_staging_test.go
@@ -73,12 +73,33 @@ func TestProcessPackageManagers_InstallStepsStageInPrivateTempDir(t *testing.T) 
 	}
 }
 
-// No shipped install or remove step may name a fixed path under /tmp: a
-// world-known name in a shared directory is pre-creatable by any local user.
-func TestEmbeddedProviders_NoFixedTmpPathsInInstallSteps(t *testing.T) {
+// No shipped install or remove step may stage anywhere another local user can
+// reach or predict: not a fixed path under /tmp (pre-creatable by anyone), not
+// the operator's CWD (`curl -O`, a bare relative filename), because the staged
+// file is usually executed or installed by a later elevated step.
+func TestEmbeddedProviders_NoSharedOrCWDStagingInInstallSteps(t *testing.T) {
 	embedded, err := system.LoadEmbeddedProviders()
 	if err != nil {
 		t.Fatalf("LoadEmbeddedProviders: %v", err)
+	}
+
+	// A path argument is contained when it is inside the per-run private
+	// directory or explicitly absolute; a URL is not a path.
+	contained := func(p string) bool {
+		return strings.HasPrefix(p, "{{ .TempDir }}") ||
+			strings.HasPrefix(p, "/") ||
+			strings.HasPrefix(p, "~") ||
+			strings.Contains(p, "://")
+	}
+
+	// File-looking arguments: what a download stages and a later step consumes.
+	stagedFile := func(arg string) bool {
+		for _, ext := range []string{".pkg", ".sh", ".tar.gz", ".tar.xz", ".zip", ".dmg"} {
+			if strings.HasSuffix(arg, ext) {
+				return true
+			}
+		}
+		return false
 	}
 
 	for name, provider := range embedded {
@@ -88,6 +109,22 @@ func TestEmbeddedProviders_NoFixedTmpPathsInInstallSteps(t *testing.T) {
 				for _, field := range fields {
 					if strings.Contains(field, "/tmp/") {
 						t.Errorf("provider %s stages at a fixed /tmp path: %q — use {{ .TempDir }}", name, field)
+					}
+				}
+
+				if step.Action == "download" && !contained(step.Dest) {
+					t.Errorf("provider %s downloads to a relative dest: %q — use {{ .TempDir }}", name, step.Dest)
+				}
+
+				for i, arg := range step.Args {
+					// curl -O / --remote-name writes into the CWD by construction.
+					if step.Exec == "curl" && (arg == "-O" || arg == "--remote-name") {
+						t.Errorf("provider %s uses `curl %s`, which stages in the CWD — use a download step with a {{ .TempDir }} dest", name, arg)
+					}
+					// A bare relative file name consumed or produced by a step
+					// resolves against whatever directory rwr happens to run in.
+					if stagedFile(arg) && !contained(arg) {
+						t.Errorf("provider %s references a relative staged file: args[%d] = %q — use {{ .TempDir }}", name, i, arg)
 					}
 				}
 			}

--- a/internal/system/definitions/providers/macports.toml
+++ b/internal/system/definitions/providers/macports.toml
@@ -21,21 +21,25 @@ build-essentials = ["make", "cmake", "pkgconfig", "freetype", "fontconfig"]
 
 [provider.install]
 steps = [
-  # Download installer
-  { action = "command", exec = "curl", args = [
-    "-O",
-    "https://github.com/macports/macports-base/releases/download/v2.8.1/MacPorts-2.8.1-13-Ventura.pkg",
-  ] },
+  # Stage the installer in the per-run private directory ({{ .TempDir }} is
+  # 0700). `curl -O` downloaded it into the operator's CWD — a shared or
+  # world-writable directory lets any local user swap the package between the
+  # download and the elevated installer run, which is root code execution.
+  #
+  # The sha256 pins the exact package; it was computed from the GitHub release
+  # asset and cross-checked against the GPG-signed .asc published next to it
+  # (signed by Joshua Root <jmr@macports.org>, key C4037936...B4AAE6CD).
+  { action = "download", source = "https://github.com/macports/macports-base/releases/download/v2.8.1/MacPorts-2.8.1-13-Ventura.pkg", dest = "{{ .TempDir }}/MacPorts-2.8.1-13-Ventura.pkg", sha256 = "577512628a4b9237b3eccd0e18af28e06855f5d55bd71957c37a9c7c362de5f3" },
   # Install package
   { action = "command", exec = "installer", args = [
     "-pkg",
-    "MacPorts-2.8.1-13-Ventura.pkg",
+    "{{ .TempDir }}/MacPorts-2.8.1-13-Ventura.pkg",
     "-target",
     "/",
   ], elevated = true },
   # Clean up
   { action = "command", exec = "rm", args = [
-    "MacPorts-2.8.1-13-Ventura.pkg",
+    "{{ .TempDir }}/MacPorts-2.8.1-13-Ventura.pkg",
   ] },
   # Update ports tree
   { action = "command", exec = "port", args = [


### PR DESCRIPTION
## Why

`macports.toml` still did `curl -O` — downloading the MacPorts pkg into the operator's **CWD** — then ran `installer -pkg <relative path> -target /` elevated. Any local user can swap the package between the download and the elevated install: root code execution, the exact staging class #182 eliminated everywhere else.

## What

- **Download action into `{{ .TempDir }}`** (per-run, 0700) with a pinned `sha256`. The digest was computed from the GitHub release asset and cross-checked against the GPG-signed `.asc` published next to it (`Good signature from "Joshua Root <jmr@macports.org>"`).
- **Strengthened regression test**: `TestEmbeddedProviders_NoSharedOrCWDStagingInInstallSteps` now flags relative download dests, `curl -O`/`--remote-name`, and bare relative staged-file arguments across all shipped providers — the old test only caught literal `/tmp/` prefixes and was blind to CWD staging. It reports 3 errors on the old macports steps and passes on the new ones.

Note: the digest verification on this path is live only once #200 lands (package-manager steps currently discard `step.Sha256`); the private staging fix stands on its own either way.

## Breaking-change statement

Nothing breaks for existing blueprints — this changes how the macports provider stages its own installer, not blueprint semantics.

From REVIEW-PR-PLAN.md Wave 0 (PR-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)