### PR TITLE
fix(security): close the low-severity hardening list

### DIFF
--- a/internal/helpers/configCreator.go
+++ b/internal/helpers/configCreator.go
@@ -89,12 +89,19 @@ func CreateDefaultConfig() error {
 		viper.Set("repository.init-file", initFileLocationInput)
 	}
 
+	// The file holds a GitHub token and an SSH private key, and viper writes
+	// at 0644 with no way to ask for less. Pre-creating it at 0600 means the
+	// credentials are never on disk world-readable, not even briefly.
+	if err := PrecreateSecureConfigFile(configFilePath); err != nil {
+		return err
+	}
+
 	// Write the configuration to the specified file
 	if err := viper.WriteConfig(); err != nil {
 		return err
 	}
 
-	// viper writes at 0644; this file holds a GitHub token and an SSH private key.
+	// Belt and braces: verify nothing widened it.
 	if err := SecureConfigFile(configFilePath); err != nil {
 		return err
 	}

--- a/internal/helpers/configperms.go
+++ b/internal/helpers/configperms.go
@@ -35,6 +35,23 @@ func SecureConfigFile(path string) error {
 	return tighten(path, ConfigFilePerm)
 }
 
+// PrecreateSecureConfigFile makes sure path exists at owner-only permissions
+// BEFORE viper writes credentials into it. Writing first and tightening after
+// leaves a window in which the token is world-readable; viper truncates an
+// existing file in place, so a file pre-created at 0600 keeps its mode.
+func PrecreateSecureConfigFile(path string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, ConfigFilePerm) // #nosec G304 -- rwr's own config path
+	if err != nil {
+		return fmt.Errorf("error creating %s: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("error closing %s: %w", path, err)
+	}
+	// An already-existing file keeps whatever mode it had; narrow it now
+	// rather than after the credentials have landed in it.
+	return tighten(path, ConfigFilePerm)
+}
+
 // tighten clears any permission bits beyond want. It never widens: a caller who
 // has deliberately restricted something further keeps their setting.
 func tighten(path string, want os.FileMode) error {

--- a/internal/helpers/git.go
+++ b/internal/helpers/git.go
@@ -37,7 +37,9 @@ func HandleGitClone(opts types.GitOptions, initConfig *types.InitConfig) error {
 	}
 
 	targetDir := filepath.Dir(opts.Target)
-	err := os.MkdirAll(targetDir, os.ModePerm) // #nosec G301 -- TODO(PR8): blueprint-target directory; create with the requested mode
+	// 0755, not os.ModePerm: 0777 through a permissive umask is a directory
+	// every local user can write, on a path about to hold a cloned repository.
+	err := os.MkdirAll(targetDir, 0o755) // #nosec G301 -- parent of a blueprint-named clone target; 0755 so the checkout stays world-readable, never world-writable
 	if err != nil {
 		return fmt.Errorf("error creating target directory: %v", err)
 	}

--- a/internal/processors/fonts.go
+++ b/internal/processors/fonts.go
@@ -20,6 +20,11 @@ import (
 // A var so a test can point the release lookup at a server it controls.
 var nerdFontRepoAPI = "https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest"
 
+// maxFontFileBytes caps what a single archive entry may decompress to. The
+// largest Nerd Font faces are a few MB; 64MB is comfortably past any real font
+// and comfortably short of filling a tmpfs.
+const maxFontFileBytes int64 = 64 << 20
+
 type GithubRelease struct {
 	TagName string `json:"tag_name"`
 	Assets  []struct {
@@ -319,11 +324,22 @@ func extractFontTarball(tarballPath, destDir string, elevated bool, osInfo *type
 			if err != nil {
 				return err
 			}
-			if _, err := io.Copy(tempFile, tr); err != nil { // #nosec G110 -- archive comes from operator-configured font source; size limit added in PR8
+			// The cap turns a decompression bomb into an error instead of a
+			// filled tmpfs: the archive arrives xz-compressed from the network,
+			// and a small download can expand to arbitrary size. Real font
+			// faces are single-digit MB.
+			n, err := io.Copy(tempFile, io.LimitReader(tr, maxFontFileBytes+1))
+			if err != nil {
 				if closeErr := tempFile.Close(); closeErr != nil {
 					return fmt.Errorf("error copying font data: %w (also failed to close: %v)", err, closeErr)
 				}
 				return err
+			}
+			if n > maxFontFileBytes {
+				if closeErr := tempFile.Close(); closeErr != nil {
+					log.Debugf("closing oversized font temp file: %v", closeErr)
+				}
+				return fmt.Errorf("font file %s decompresses past %d MB; refusing what looks like a decompression bomb", header.Name, maxFontFileBytes>>20)
 			}
 			if err := tempFile.Close(); err != nil {
 				return fmt.Errorf("error closing temp file after copy: %w", err)

--- a/internal/processors/packageManager.go
+++ b/internal/processors/packageManager.go
@@ -3,7 +3,6 @@ package processors
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"charm.land/log/v2"
@@ -16,21 +15,24 @@ import (
 var (
 	pmTempDirOnce sync.Once
 	pmTempDirPath string
+	pmTempDirErr  error
 )
 
-func packageManagerTempDir() string {
+// packageManagerTempDir returns the run's private staging directory, or the
+// error that prevented creating it. A failure used to fall back to the
+// predictable <tmp>/rwr-pm-unavailable — a fixed, world-known name any local
+// user can pre-create, which is exactly the class {{ .TempDir }} exists to
+// eliminate.
+func packageManagerTempDir() (string, error) {
 	pmTempDirOnce.Do(func() {
 		dir, err := os.MkdirTemp("", "rwr-pm-")
 		if err != nil {
-			// Surfaced at use: the write into the unusable directory fails
-			// with a real error naming the path.
-			log.Errorf("could not create the package manager staging directory: %v", err)
-			pmTempDirPath = filepath.Join(os.TempDir(), "rwr-pm-unavailable")
+			pmTempDirErr = fmt.Errorf("could not create the package manager staging directory: %w", err)
 			return
 		}
 		pmTempDirPath = dir
 	})
-	return pmTempDirPath
+	return pmTempDirPath, pmTempDirErr
 }
 
 // ProcessPackageManagers installs package managers and their common dependencies
@@ -93,7 +95,11 @@ func ProcessPackageManagers(packageManagers []types.PackageManagerInfo, osInfo *
 			// the download and the elevated step that executes it — which is
 			// root code execution. {{ .TempDir }} renders to a per-run 0700
 			// directory other users cannot reach.
-			step, err := renderActionStep(rawStep, map[string]any{"TempDir": packageManagerTempDir()})
+			tempDir, err := packageManagerTempDir()
+			if err != nil {
+				return err
+			}
+			step, err := renderActionStep(rawStep, map[string]any{"TempDir": tempDir})
 			if err != nil {
 				return fmt.Errorf("error rendering %s step for %s: %w", pm.Action, pm.Name, err)
 			}

--- a/internal/processors/package_manager_staging_test.go
+++ b/internal/processors/package_manager_staging_test.go
@@ -49,13 +49,17 @@ func TestProcessPackageManagers_InstallStepsStageInPrivateTempDir(t *testing.T) 
 		t.Fatalf("ProcessPackageManagers: %v", err)
 	}
 
-	staged := filepath.Join(packageManagerTempDir(), "fakepm-install.sh")
+	tempDir, tempErr := packageManagerTempDir()
+	if tempErr != nil {
+		t.Fatalf("packageManagerTempDir: %v", tempErr)
+	}
+	staged := filepath.Join(tempDir, "fakepm-install.sh")
 	if got, readErr := os.ReadFile(staged); readErr != nil || !strings.Contains(string(got), "echo hi") {
 		t.Fatalf("staged installer = %q (%v), want the downloaded script in the private dir", got, readErr)
 	}
 
 	// The private directory is not reachable by other users.
-	if info, statErr := os.Stat(packageManagerTempDir()); statErr != nil || info.Mode().Perm() != 0o700 {
+	if info, statErr := os.Stat(tempDir); statErr != nil || info.Mode().Perm() != 0o700 {
 		t.Errorf("staging dir mode = %v (%v), want 0700", info.Mode().Perm(), statErr)
 	}
 

--- a/internal/processors/repository.go
+++ b/internal/processors/repository.go
@@ -115,7 +115,10 @@ func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *
 	}
 
 	// Execute each step
-	data := repositoryStepData(repo, repoConfig.Paths, provider)
+	data, err := repositoryStepData(repo, repoConfig.Paths, provider)
+	if err != nil {
+		return err
+	}
 	for _, rawStep := range steps {
 		// The condition is evaluated before the rest of the step is
 		// rendered: a skipped step is allowed to reference data this
@@ -274,13 +277,18 @@ func runRepositoryUpdates(initConfig *types.InitConfig) error {
 // "deb [arch={{ .Arch }} signed-by={{ .KeyPath }}] {{ .URL }} ..." — so every
 // placeholder they may use has to have a key here, and anything else is a
 // blueprint or provider defect rather than a value to silently drop.
-func repositoryStepData(repo types.Repository, paths types.RepositoryPaths, provider *types.Provider) map[string]any {
+func repositoryStepData(repo types.Repository, paths types.RepositoryPaths, provider *types.Provider) (map[string]any, error) {
 	// Providers reference a key file, but RepositoryPaths.Keys names the
 	// directory a distribution keeps keyrings in, so the per-repository file
 	// name is derived from the repository name rather than configured twice.
 	keyPath := ""
 	if paths.Keys != "" {
 		keyPath = filepath.Join(paths.Keys, repo.Name+".gpg")
+	}
+
+	tempDir, err := repositoryTempDir()
+	if err != nil {
+		return nil, err
 	}
 
 	data := map[string]any{
@@ -297,7 +305,7 @@ func repositoryStepData(repo types.Repository, paths types.RepositoryPaths, prov
 		"KeysPath":       paths.Keys,
 		"ConfigPath":     paths.Config,
 		"KeyPath":        keyPath,
-		"TempKeyPath":    filepath.Join(repositoryTempDir(), repo.Name+".gpg"),
+		"TempKeyPath":    filepath.Join(tempDir, repo.Name+".gpg"),
 		"KeyID":          repo.KeyID,
 		// The local file a snap or a GNOME extension is installed from. Only
 		// the steps gated on IsLocalFile/IsLocalSnap use it, and those are the
@@ -329,7 +337,7 @@ func repositoryStepData(repo types.Repository, paths types.RepositoryPaths, prov
 		data[name] = value
 	}
 
-	return data
+	return data, nil
 }
 
 // repositoryPredicates are the boolean-ish values provider steps gate
@@ -533,21 +541,23 @@ func removeRepositoryPath(path string, paths types.RepositoryPaths, elevated, de
 var (
 	repoTempDirOnce sync.Once
 	repoTempDirPath string
+	repoTempDirErr  error
 )
 
-func repositoryTempDir() string {
+// repositoryTempDir returns the run's private staging directory, or the error
+// that prevented creating it. A failure used to fall back to the predictable
+// <tmp>/rwr-repo-unavailable — a fixed, world-known name any local user can
+// pre-create, which is exactly the class {{ .TempDir }} exists to eliminate.
+func repositoryTempDir() (string, error) {
 	repoTempDirOnce.Do(func() {
 		dir, err := os.MkdirTemp("", "rwr-repo-")
 		if err != nil {
-			// Surfaced at use: the write into the unusable directory fails
-			// with a real error naming the path.
-			log.Errorf("could not create the repository staging directory: %v", err)
-			repoTempDirPath = filepath.Join(os.TempDir(), "rwr-repo-unavailable")
+			repoTempDirErr = fmt.Errorf("could not create the repository staging directory: %w", err)
 			return
 		}
 		repoTempDirPath = dir
 	})
-	return repoTempDirPath
+	return repoTempDirPath, repoTempDirErr
 }
 
 // repositoryWritePath resolves the destination a download/write/copy step
@@ -568,8 +578,12 @@ func repositoryWritePath(dest string, paths types.RepositoryPaths) (string, erro
 		return "", fmt.Errorf("refusing to write %q: path is not absolute", dest)
 	}
 
-	boundaries := append(repositoryBoundaries(paths), repositoryTempDir())
-	if resolved == repositoryTempDir() {
+	tempDir, err := repositoryTempDir()
+	if err != nil {
+		return "", err
+	}
+	boundaries := append(repositoryBoundaries(paths), tempDir)
+	if resolved == tempDir {
 		return "", fmt.Errorf("refusing to write %q: it is the staging directory itself", dest)
 	}
 	for _, boundary := range boundaries {

--- a/internal/processors/repository_test.go
+++ b/internal/processors/repository_test.go
@@ -130,7 +130,11 @@ func TestProcessRepositories_AptAddRendersProviderTemplates(t *testing.T) {
 	// The staging path is inside the run's private 0700 directory, not a
 	// world-known name under /tmp any local user could pre-create or swap
 	// between the download and the dearmor that imports it as root.
-	tempKeyPath := filepath.Join(repositoryTempDir(), "docker.gpg")
+	stagingDir, err := repositoryTempDir()
+	if err != nil {
+		t.Fatalf("repositoryTempDir: %v", err)
+	}
+	tempKeyPath := filepath.Join(stagingDir, "docker.gpg")
 
 	// The key is downloaded to the temporary path the dearmor step reads from.
 	if _, err := os.Stat(tempKeyPath); err != nil {
@@ -908,7 +912,13 @@ func TestProcessRepositories_DnfAddAndRemove(t *testing.T) {
 	if len(rpmCalls) != 1 {
 		t.Fatalf("recorded %d rpm calls, want 1: %v", len(rpmCalls), rec.Calls)
 	}
-	if got, want := rpmCalls[0].Argv(), []string{"rpm", "--import", keyPath}; !equalStrings(got, want) {
+	// The import reads from the run's private staging directory, mirroring
+	// apt: the key reaches its final /etc path only through the copy step.
+	dnfStagingDir, err := repositoryTempDir()
+	if err != nil {
+		t.Fatalf("repositoryTempDir: %v", err)
+	}
+	if got, want := rpmCalls[0].Argv(), []string{"rpm", "--import", filepath.Join(dnfStagingDir, "docker-ce.gpg")}; !equalStrings(got, want) {
 		t.Errorf("rpm argv = %#v, want %#v", got, want)
 	}
 

--- a/internal/prompts/github.go
+++ b/internal/prompts/github.go
@@ -127,6 +127,17 @@ func SaveGitHubTokenToConfig(token string, initConfig *types.InitConfig) error {
 	// Set the new token
 	viper.Set("repository.gh_api_token", token)
 
+	// The file holds the token, and viper writes at 0644 with no way to ask
+	// for less. Pre-creating it at 0600 means the token is never on disk
+	// world-readable, not even briefly. ConfigFileUsed is empty when no config
+	// was loaded — then SafeWriteConfig below creates the file and the tighten
+	// after it is the only guard (a first-run-only window).
+	if path := viper.ConfigFileUsed(); path != "" {
+		if err := helpers.PrecreateSecureConfigFile(path); err != nil {
+			return err
+		}
+	}
+
 	// Try to write config
 	if err := viper.WriteConfig(); err != nil {
 		// If config doesn't exist, create it
@@ -135,7 +146,7 @@ func SaveGitHubTokenToConfig(token string, initConfig *types.InitConfig) error {
 		}
 	}
 
-	// viper writes at 0644, and this file holds the token.
+	// Belt and braces: verify nothing widened it.
 	return helpers.SecureConfigFile(viper.ConfigFileUsed())
 }
 

--- a/internal/system/definitions/providers/dnf.toml
+++ b/internal/system/definitions/providers/dnf.toml
@@ -31,15 +31,23 @@ build-essentials = [
 sources = "/etc/yum.repos.d"
 keys = "/etc/pki/rpm-gpg"
 
+# The key is staged in the run's private directory and only then placed at its
+# final path, like apt: downloading straight into /etc/pki/rpm-gpg wrote to the
+# trusted-key directory before anything had looked at the content.
 [[provider.repository.add.steps]]
 action = "download"
 source = "{{ .KeyURL }}"
-dest = "{{ .KeyPath }}"
+dest = "{{ .TempKeyPath }}"
 
 [[provider.repository.add.steps]]
 action = "command"
 exec = "rpm"
-args = ["--import", "{{ .KeyPath }}"]
+args = ["--import", "{{ .TempKeyPath }}"]
+
+[[provider.repository.add.steps]]
+action = "copy"
+source = "{{ .TempKeyPath }}"
+dest = "{{ .KeyPath }}"
 
 [[provider.repository.add.steps]]
 action = "write"

--- a/internal/system/files.go
+++ b/internal/system/files.go
@@ -85,7 +85,7 @@ func copyFileContentMode(source, target string, mode os.FileMode) error {
 	}
 	defer sourceFile.Close() //nolint:errcheck
 
-	targetFile, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
+	targetFile, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|noFollow, mode) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
 	if err != nil {
 		return fmt.Errorf("error creating target file: %v", err)
 	}
@@ -235,9 +235,11 @@ func downloadFileContent(url, filePath string) error {
 }
 
 func moveFileWithElevatedPrivileges(source, target string) error {
+	// "--" so a path starting with "-" can never be read as an mv option:
+	// these paths come from blueprint values, and the command runs as root.
 	cmd := types.Command{
 		Exec:     "mv",
-		Args:     []string{source, target},
+		Args:     []string{"--", source, target},
 		Elevated: true,
 	}
 	err := RunCommand(cmd, false)
@@ -504,7 +506,9 @@ func CopyFile(source, target string, elevated bool, osInfo *types.OSInfo) error 
 	}
 
 	targetDir := filepath.Dir(target)
-	if err := os.MkdirAll(targetDir, os.ModePerm); err != nil { // #nosec G301 -- TODO(PR8): blueprint-target directory; create with the requested mode
+	// 0755, not os.ModePerm: 0777 through a permissive umask is a directory
+	// every local user can write, on a path that may hold installed content.
+	if err := os.MkdirAll(targetDir, 0o755); err != nil { // #nosec G301 -- parent of a blueprint-named target; 0755 so installed content stays world-readable, never world-writable
 		return fmt.Errorf("error creating target directory: %v", err)
 	}
 
@@ -558,9 +562,11 @@ func CopyFile(source, target string, elevated bool, osInfo *types.OSInfo) error 
 }
 
 func setFilePermissionsElevated(path string, mode os.FileMode) error {
+	// "--" so a path starting with "-" can never be read as a chmod option:
+	// the path comes from blueprint values, and the command runs as root.
 	cmd := types.Command{
 		Exec:     "chmod",
-		Args:     []string{fmt.Sprintf("%o", mode), path},
+		Args:     []string{fmt.Sprintf("%o", mode), "--", path},
 		Elevated: true,
 	}
 	return RunCommand(cmd, false)

--- a/internal/system/files_nofollow_unix.go
+++ b/internal/system/files_nofollow_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package system
+
+import "syscall"
+
+// noFollow makes an open refuse a symlink as the final path component. The
+// EXDEV copy fallback writes to a target in a directory that may be shared
+// (staging fell back to the system temp dir because the target's own directory
+// was not writable), where any local user can plant a symlink at the target
+// name and redirect the write.
+const noFollow = syscall.O_NOFOLLOW

--- a/internal/system/files_nofollow_windows.go
+++ b/internal/system/files_nofollow_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package system
+
+// Windows has no O_NOFOLLOW; symlink creation there needs a privilege ordinary
+// users do not hold, so the planted-symlink redirect this guards against is not
+// available to an unprivileged local user in the first place.
+const noFollow = 0

--- a/internal/system/files_owner_unix.go
+++ b/internal/system/files_owner_unix.go
@@ -17,3 +17,15 @@ func fileOwnedByEUID(info os.FileInfo) bool {
 	}
 	return int(st.Uid) == os.Geteuid()
 }
+
+// ownedByRootOrEUID reports whether the file or directory belongs to root or
+// to the effective user. A provider directory owned by any other account is
+// rewritable by that account regardless of its mode bits — a directory's owner
+// can always chmod it open.
+func ownedByRootOrEUID(info os.FileInfo) bool {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return st.Uid == 0 || int(st.Uid) == os.Geteuid()
+}

--- a/internal/system/files_owner_windows.go
+++ b/internal/system/files_owner_windows.go
@@ -10,3 +10,9 @@ import "os"
 func fileOwnedByEUID(os.FileInfo) bool {
 	return true
 }
+
+// ownedByRootOrEUID: see fileOwnedByEUID — Windows security is ACLs, which
+// os.FileInfo cannot express, so the unix ownership check always passes.
+func ownedByRootOrEUID(os.FileInfo) bool {
+	return true
+}

--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -406,6 +406,30 @@ func isProviderFileTrustedOn(goos, path string) bool {
 			"provider files run commands as root, so tighten it with chmod go-w", path, mode.Perm())
 		return false
 	}
+	if !ownedByRootOrEUID(info) {
+		log.Warnf("LoadProviders: Skipping provider %s: it is owned by another user; "+
+			"provider files run commands as root, so only root- or self-owned definitions are loaded", path)
+		return false
+	}
+
+	// A tight file in a loose directory is still rewritable: anyone who can
+	// write the directory can replace the file, and the directory's owner can
+	// always chmod it open. The same trust rules apply to the parent.
+	parent := filepath.Dir(path)
+	parentInfo, err := os.Stat(parent)
+	if err != nil {
+		log.Warnf("LoadProviders: Skipping provider %s: cannot inspect its directory: %v", path, err)
+		return false
+	}
+	if mode := parentInfo.Mode(); mode&0o022 != 0 {
+		log.Warnf("LoadProviders: Skipping provider %s: its directory %s is group- or world-writable (mode %04o); "+
+			"tighten it with chmod go-w", path, parent, mode.Perm())
+		return false
+	}
+	if !ownedByRootOrEUID(parentInfo) {
+		log.Warnf("LoadProviders: Skipping provider %s: its directory %s is owned by another user", path, parent)
+		return false
+	}
 	return true
 }
 

--- a/internal/system/providers_trust_test.go
+++ b/internal/system/providers_trust_test.go
@@ -26,6 +26,20 @@ func TestIsProviderFileTrustedOn(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// A tight file inside a group/world-writable directory: anyone who can
+	// write the directory can replace the file, so it must be skipped too.
+	looseDir := filepath.Join(dir, "loosedir")
+	if err := os.Mkdir(looseDir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(looseDir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	tightInLooseDir := filepath.Join(looseDir, "tight.toml")
+	if err := os.WriteFile(tightInLooseDir, []byte("[provider]\nname='x'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tt := range []struct {
 		name string
 		goos string
@@ -34,6 +48,7 @@ func TestIsProviderFileTrustedOn(t *testing.T) {
 	}{
 		{name: "linux private file loads", goos: "linux", path: private, want: true},
 		{name: "linux world-writable file skipped", goos: "linux", path: loose, want: false},
+		{name: "linux tight file in loose directory skipped", goos: "linux", path: tightInLooseDir, want: false},
 		// The same 0666 mode Windows reports for every normal file.
 		{name: "windows 0666 file loads", goos: "windows", path: loose, want: true},
 		{name: "windows missing file skipped", goos: "windows", path: filepath.Join(dir, "nope.toml"), want: false},


### PR DESCRIPTION
One batch PR for the verified-real but low-severity findings from the security track (REVIEW-PR-PLAN.md Wave 0, PR-3):

- **Predictable temp-dir fallback → hard error.** `repositoryTempDir`/`packageManagerTempDir` now return `(string, error)`; the old fallback to `<tmp>/rwr-repo-unavailable` was a fixed, world-known name any local user can pre-create — the exact class `{{ .TempDir }}` eliminates.
- **`O_NOFOLLOW` in the EXDEV copy fallback** (`copyFileContentMode`). Staging falls back to the shared system temp dir precisely when the target's directory is unwritable — where a planted symlink at the target name redirects the write. Windows gets `noFollow = 0` (no O_NOFOLLOW, and symlink creation is privileged there anyway).
- **`--` before paths** in elevated `mv`/`chmod`: blueprint-derived paths, run as root, must never parse as options.
- **Secrets 0600 from the start.** New `helpers.PrecreateSecureConfigFile` creates/tightens the config file *before* `viper.WriteConfig` lands the GitHub token + SSH key in it, closing the world-readable window of write-then-chmod. (The review's `internal/prompts/ssh_key.go` ref was stale — the key is base64 in the same viper config; both write sites are covered: `configCreator.go` and `prompts/github.go`.)
- **Provider trust checks the parent directory too** — writability *and* ownership (a directory's owner can always chmod it open, so mode bits alone aren't enough). New test case: tight file in a loose directory is skipped.
- **dnf key staging** mirrors apt: download to `{{ .TempKeyPath }}` (private, per-run), `rpm --import` from there, then `copy` to `{{ .KeyPath }}`. Test updated to assert the staged flow.
- **Font extraction size cap** (64MB per entry via `io.LimitReader`) — the `#nosec G110 "size limit added in PR8"` promise is now a fact; a decompression bomb is an error, not a filled tmpfs.
- **`os.ModePerm` MkdirAlls → 0755** (`system/files.go`, `helpers/git.go`).

## Breaking-change statement

Nothing breaks for existing blueprints: every change tightens a failure path or a permission; none changes blueprint semantics. The one observable behavior change: a run that cannot create its staging directory now stops with an error instead of continuing against a predictable path.

All tests pass (`-race`), gosec clean, golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)