### PR TITLE
fix(scripts): derive the inline-script extension from the executor

### DIFF
--- a/internal/processors/scripts.go
+++ b/internal/processors/scripts.go
@@ -96,8 +96,12 @@ func runScript(script types.Script, osInfo *types.OSInfo, initConfig *types.Init
 	if script.Source != "" {
 		scriptPath = filepath.Join(blueprintDir, script.Source, script.Name)
 	} else if script.Content != "" {
-		// Write the script content to a temporary file
-		tempFile, err := os.CreateTemp("", fmt.Sprintf("%s-*.sh", script.Name))
+		// Write the script content to a temporary file, named for the executor
+		// that will run it. The extension used to be .sh unconditionally, and
+		// `powershell -File` refuses any file not ending in .ps1 — so every
+		// inline script on Windows (where powershell is the default executor)
+		// failed before its first line ran.
+		tempFile, err := os.CreateTemp("", fmt.Sprintf("%s-*%s", script.Name, scriptTempExtension(script.Exec)))
 		if err != nil {
 			return fmt.Errorf("error creating temporary file for script: %v", err)
 		}
@@ -204,6 +208,27 @@ func runScript(script types.Script, osInfo *types.OSInfo, initConfig *types.Init
 	}
 
 	return nil
+}
+
+// scriptTempExtension names an inline script's staging file for the executor
+// that will run it. Only powershell actually enforces its extension
+// (`-File` refuses non-.ps1 files); the rest are for the reader and for any
+// tooling that keys off the suffix.
+func scriptTempExtension(executor string) string {
+	switch executor {
+	case "powershell":
+		return ".ps1"
+	case "python":
+		return ".py"
+	case "ruby":
+		return ".rb"
+	case "perl":
+		return ".pl"
+	case "lua":
+		return ".lua"
+	default: // bash, /bin/bash, self
+		return ".sh"
+	}
 }
 
 func processScriptImports(items []types.Script, blueprintDir string, format string, treeVersion int) ([]types.Script, error) {

--- a/internal/processors/scripts_argv_test.go
+++ b/internal/processors/scripts_argv_test.go
@@ -101,3 +101,37 @@ scripts:
 		t.Errorf("Args = %#v, want exactly [%q]", got, scriptPath)
 	}
 }
+
+// Inline `content:` scripts used to stage as *.sh unconditionally, but the
+// Windows default executor is `powershell -File`, which refuses any file not
+// ending in .ps1 — every inline script on Windows failed before its first line.
+func TestProcessScripts_InlineContentExtensionMatchesExecutor(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	osInfo := &types.OSInfo{}
+	osInfo.System.OS = "windows"
+	osInfo.Tools.PowerShell = types.ToolInfo{Exists: true, Bin: "powershell"}
+
+	blueprint := []byte(`
+scripts:
+  - name: "hello"
+    action: "run"
+    content: "Write-Host hi"
+`)
+
+	if err := ProcessScripts(blueprint, t.TempDir(), "yaml", osInfo, &types.InitConfig{}); err != nil {
+		t.Fatalf("ProcessScripts: %v", err)
+	}
+
+	calls := rec.Find("powershell")
+	if len(calls) != 1 {
+		t.Fatalf("recorded %d powershell calls, want 1: %v", len(calls), rec.Calls)
+	}
+	if len(calls[0].Args) != 2 || calls[0].Args[0] != "-File" {
+		t.Fatalf("powershell args = %v, want [-File <path>]", calls[0].Args)
+	}
+	if got := calls[0].Args[1]; filepath.Ext(got) != ".ps1" {
+		t.Errorf("staged script = %q, want a .ps1 extension — powershell -File refuses anything else", got)
+	}
+}


### PR DESCRIPTION
Inline `content:` scripts always landed as `*.sh` (`scripts.go:100`), but the Windows default executor is `powershell -File` (`scripts.go:159-164`), which refuses non-`.ps1` files — **every inline script on Windows failed today** before its first line ran.

The staging file is now named for the executor via `scriptTempExtension` (`.ps1`/`.py`/`.rb`/`.pl`/`.lua`, `.sh` otherwise). Only powershell actually enforces its extension; the rest are for the reader.

Test: `TestProcessScripts_InlineContentExtensionMatchesExecutor` — a `content:` script on a Windows OSInfo must reach powershell as `-File <something>.ps1`. Fails without the fix.

**Breaking-change statement:** nothing breaks — POSIX inline scripts keep `.sh`, and the Windows path never worked.

From REVIEW-PR-PLAN.md Wave 1 (PR-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)