### PR TITLE
fix(fonts): install every font face, not just .ttf

### DIFF
--- a/internal/processors/fonts.go
+++ b/internal/processors/fonts.go
@@ -153,16 +153,22 @@ func installFont(font types.Font, osInfo *types.OSInfo, releaseURL string) error
 	}
 
 	fontDir := getFontDirectory(font.Location, osInfo)
-	err = extractFontTarball(tarballPath, fontDir, font.Location == "system", osInfo)
+	extracted, err := extractFontTarball(tarballPath, fontDir, font.Location == "system", osInfo)
 	if err != nil {
 		return fmt.Errorf("error extracting font tarball: %v", err)
+	}
+	// An archive that produced nothing is a failure, not a success: reporting
+	// "installed successfully" with zero files written is how the .ttf-only
+	// filter hid OTF archives for so long.
+	if extracted == 0 {
+		return fmt.Errorf("font archive for %s contained no font faces (.ttf/.otf); nothing was installed", font.Name)
 	}
 
 	if err := updateFontCache(font.Location == "system"); err != nil {
 		log.Warnf("Failed to update font cache: %v", err)
 	}
 
-	log.Infof("Font %s installed successfully", font.Name)
+	log.Infof("Font %s installed successfully (%d files)", font.Name, extracted)
 	return nil
 }
 
@@ -174,11 +180,15 @@ func removeFont(font types.Font, osInfo *types.OSInfo) error {
 	}
 
 	fontDir := getFontDirectory(font.Location, osInfo)
-	fontPattern := filepath.Join(fontDir, font.Name+"*.ttf")
-
-	matches, err := filepath.Glob(fontPattern)
-	if err != nil {
-		return fmt.Errorf("error finding font files: %v", err)
+	// Same face filter as install: removal was .ttf-blind too, so an installed
+	// OTF face would have survived its own removal.
+	var matches []string
+	for _, ext := range []string{"*.ttf", "*.otf"} {
+		found, err := filepath.Glob(filepath.Join(fontDir, font.Name+ext))
+		if err != nil {
+			return fmt.Errorf("error finding font files: %v", err)
+		}
+		matches = append(matches, found...)
 	}
 
 	for _, match := range matches {
@@ -268,28 +278,32 @@ func resolveTarEntryPath(destDir, name string) (string, error) {
 	return targetPath, nil
 }
 
-func extractFontTarball(tarballPath, destDir string, elevated bool, osInfo *types.OSInfo) error {
+// extractFontTarball writes every font face in the archive into destDir and
+// returns how many it installed, so the caller can refuse to call an archive
+// that produced nothing a success.
+func extractFontTarball(tarballPath, destDir string, elevated bool, osInfo *types.OSInfo) (int, error) {
 	file, err := os.Open(tarballPath) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer file.Close() //nolint:errcheck
 
 	// Create a new XZ reader
 	xzReader, err := xz.NewReader(file)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	tr := tar.NewReader(xzReader)
 
+	extracted := 0
 	for {
 		header, err := tr.Next()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			return err
+			return extracted, err
 		}
 
 		// Links are never needed to install a font and are the cheapest way to make a
@@ -299,49 +313,58 @@ func extractFontTarball(tarballPath, destDir string, elevated bool, osInfo *type
 			continue
 		}
 
-		if header.Typeflag == tar.TypeReg && strings.HasSuffix(header.Name, ".ttf") {
+		if header.Typeflag == tar.TypeReg && isFontFace(header.Name) {
 			targetPath, err := resolveTarEntryPath(destDir, header.Name)
 			if err != nil {
-				return fmt.Errorf("error extracting font archive: %w", err)
+				return extracted, fmt.Errorf("error extracting font archive: %w", err)
 			}
 
 			// Create a temporary file for the extracted font
 			tempFile, err := os.CreateTemp("", "font-")
 			if err != nil {
-				return err
+				return extracted, err
 			}
 			if err := tempFile.Close(); err != nil {
-				return fmt.Errorf("error closing temp file: %w", err)
+				return extracted, fmt.Errorf("error closing temp file: %w", err)
 			}
 
 			// Write the font data to the temporary file
 			tempFile, err = os.OpenFile(tempFile.Name(), os.O_WRONLY, 0755) // #nosec G302 -- TODO(PR8): create with target mode instead of chmod-after
 			if err != nil {
-				return err
+				return extracted, err
 			}
 			if _, err := io.Copy(tempFile, tr); err != nil { // #nosec G110 -- archive comes from operator-configured font source; size limit added in PR8
 				if closeErr := tempFile.Close(); closeErr != nil {
-					return fmt.Errorf("error copying font data: %w (also failed to close: %v)", err, closeErr)
+					return extracted, fmt.Errorf("error copying font data: %w (also failed to close: %v)", err, closeErr)
 				}
-				return err
+				return extracted, err
 			}
 			if err := tempFile.Close(); err != nil {
-				return fmt.Errorf("error closing temp file after copy: %w", err)
+				return extracted, fmt.Errorf("error closing temp file after copy: %w", err)
 			}
 
 			if tempFile == nil || targetPath == "" {
-				return fmt.Errorf("invalid arguments: tempFile or targetPath is nil/empty")
+				return extracted, fmt.Errorf("invalid arguments: tempFile or targetPath is nil/empty")
 			}
 			// Elevated only for a system-scoped install; a user font goes under $HOME
 			// and needs no privilege.
 			err = system.CopyFile(tempFile.Name(), targetPath, elevated, osInfo)
 			if err != nil {
-				return fmt.Errorf("error copying font file to destination: %v", err)
+				return extracted, fmt.Errorf("error copying font file to destination: %v", err)
 			}
+			extracted++
 		}
 	}
 
-	return nil
+	return extracted, nil
+}
+
+// isFontFace reports whether an archive entry is a font face rwr installs.
+// The filter used to be ".ttf" alone, so an OTF-only archive — several Nerd
+// Fonts ship only .otf — "installed successfully" with zero files written.
+func isFontFace(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.HasSuffix(lower, ".ttf") || strings.HasSuffix(lower, ".otf")
 }
 
 func getFontDirectory(location string, osInfo *types.OSInfo) string {

--- a/internal/processors/fonts_extract_test.go
+++ b/internal/processors/fonts_extract_test.go
@@ -103,7 +103,7 @@ func TestExtractFontTarball_RejectsEntriesEscapingDestDir(t *testing.T) {
 			tarballPath := filepath.Join(root, "font.tar.xz")
 			writeFontTarball(t, tarballPath, []tarEntry{{name: tt.entry, body: "ttf-bytes"}})
 
-			err := extractFontTarball(tarballPath, destDir, false, fontOSInfo())
+			_, err := extractFontTarball(tarballPath, destDir, false, fontOSInfo())
 			if err == nil {
 				t.Fatal("expected extraction to fail, got nil")
 			}
@@ -135,7 +135,7 @@ func TestExtractFontTarball_SkipsLinkEntries(t *testing.T) {
 		{name: "hard.ttf", typeflag: tar.TypeLink, linkname: "../../outside.ttf"},
 	})
 
-	if err := extractFontTarball(tarballPath, destDir, false, fontOSInfo()); err != nil {
+	if _, err := extractFontTarball(tarballPath, destDir, false, fontOSInfo()); err != nil {
 		t.Fatalf("extractFontTarball: %v", err)
 	}
 
@@ -172,7 +172,7 @@ func TestExtractFontTarball_ElevatesOnlyWhenAsked(t *testing.T) {
 			tarballPath := filepath.Join(root, "font.tar.xz")
 			writeFontTarball(t, tarballPath, []tarEntry{{name: "Good.ttf", body: "ttf-bytes"}})
 
-			if err := extractFontTarball(tarballPath, destDir, tt.elevated, fontOSInfo()); err != nil {
+			if _, err := extractFontTarball(tarballPath, destDir, tt.elevated, fontOSInfo()); err != nil {
 				t.Fatalf("extractFontTarball: %v", err)
 			}
 
@@ -293,5 +293,71 @@ func assertNoFileOutside(t *testing.T, root, destDir, base string) {
 	})
 	if err != nil {
 		t.Fatalf("walking %s: %v", root, err)
+	}
+}
+
+// The face filter used to be ".ttf" alone: an OTF-only archive — several Nerd
+// Fonts ship only .otf — "installed successfully" with zero files written.
+func TestExtractFontTarball_InstallsEveryFontFace(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	root := t.TempDir()
+	destDir := filepath.Join(root, "fonts")
+	if err := os.MkdirAll(destDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	tarballPath := filepath.Join(root, "font.tar.xz")
+	writeFontTarball(t, tarballPath, []tarEntry{
+		{name: "Mono-Regular.otf", body: "otf-bytes"},
+		{name: "Mono-Bold.TTF", body: "ttf-bytes"},
+		{name: "README.md", body: "not a font"},
+	})
+
+	extracted, err := extractFontTarball(tarballPath, destDir, false, fontOSInfo())
+	if err != nil {
+		t.Fatalf("extractFontTarball: %v", err)
+	}
+	if extracted != 2 {
+		t.Errorf("extracted = %d, want 2 (both faces, not the README)", extracted)
+	}
+	for _, name := range []string{"Mono-Regular.otf", "Mono-Bold.TTF"} {
+		if _, err := os.Stat(filepath.Join(destDir, name)); err != nil {
+			t.Errorf("expected %s to be installed: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "README.md")); err == nil {
+		t.Error("README.md installed into the font directory")
+	}
+}
+
+// Removal has to see the same faces the install writes, or an installed OTF
+// face survives its own removal.
+func TestRemoveFont_RemovesEveryFontFace(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	fontDir := getFontDirectory("user", fontOSInfo())
+	if err := os.MkdirAll(fontDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, name := range []string{"Mono-Regular.otf", "Mono-Bold.ttf"} {
+		if err := os.WriteFile(filepath.Join(fontDir, name), []byte("face"), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+
+	if err := removeFont(types.Font{Name: "Mono", Action: "remove", Location: "user"}, fontOSInfo()); err != nil {
+		t.Fatalf("removeFont: %v", err)
+	}
+
+	entries, err := os.ReadDir(fontDir)
+	if err != nil {
+		t.Fatalf("reading font dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("font dir not empty after removal: %v", entries)
 	}
 }


### PR DESCRIPTION
The extraction filter kept only `.ttf` names (`fonts.go:302`), so an OTF-only archive — several Nerd Fonts ship only `.otf` — **"installed successfully" with zero files written**. The removal glob `Name*.ttf` (`fonts.go:177`) had the same blindness, so an installed OTF face would survive its own removal.

- `isFontFace` accepts `.ttf`/`.otf` case-insensitively (a `.TTF` entry was dropped before too).
- `extractFontTarball` now returns the count of faces written; `installFont` errors when an archive produced nothing instead of logging success.
- `removeFont` globs both extensions.

Tests (fail without the fix): `TestExtractFontTarball_InstallsEveryFontFace` (OTF + uppercase TTF install, README does not), `TestRemoveFont_RemovesEveryFontFace`.

**Breaking-change statement:** nothing breaks — TTF archives behave as before; OTF archives go from silent no-op to installing; a truly font-free archive goes from false success to an error naming the problem.

From REVIEW-PR-PLAN.md Wave 1 (PR-8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)