### PR TITLE
fix(files): let metadata actions run without content or source

### DIFF
--- a/internal/processors/files.go
+++ b/internal/processors/files.go
@@ -113,12 +113,28 @@ func processFiles(files []types.File, blueprintDir string, osInfo *types.OSInfo)
 	return nil
 }
 
+// fileActionConsumesContent reports whether an action reads file content at
+// all. The metadata actions act on a target that already exists; the empty
+// action defaults to create-from-content later in processFile.
+func fileActionConsumesContent(action string) bool {
+	switch action {
+	case types.FileActionChmod, types.FileActionChown, types.FileActionChgrp, types.FileActionDelete:
+		return false
+	}
+	return true
+}
+
 func processFile(file types.File, blueprintDir string, osInfo *types.OSInfo) error {
 
 	log.Debugf("Processing file: %s", file.Name)
 
-	if file.Content == "" && file.Source == "" {
-		return fmt.Errorf("either Content or Source must be provided for file %s", file.Name)
+	// Only the actions that consume content need it. chmod/chown/chgrp/delete
+	// operate on an existing target — demanding content or source for them
+	// broke the documented metadata examples (docs/blueprints/files.md), which
+	// pair a copy entry with a follow-up chmod/chown entry. The validator
+	// (internal/validate/components.go) has always gated this by action.
+	if file.Content == "" && file.Source == "" && fileActionConsumesContent(file.Action) {
+		return fmt.Errorf("either Content or Source must be provided for file %s (action %q)", file.Name, file.Action)
 	}
 
 	// Handle URL source

--- a/internal/processors/files_test.go
+++ b/internal/processors/files_test.go
@@ -902,3 +902,69 @@ files:
 		t.Errorf("target content = %q, want %q", got, "abs contents")
 	}
 }
+
+// The metadata actions act on an existing target and carry no content, but
+// processFile demanded content or source for every entry — which broke the
+// documented pattern of a copy entry followed by a chmod/chown entry
+// (docs/blueprints/files.md). The validator has always allowed them.
+func TestProcessFile_MetadataActionsNeedNoContentOrSource(t *testing.T) {
+	osInfo := &types.OSInfo{}
+	osInfo.System.OS = "linux"
+
+	t.Run("chmod", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "script.sh")
+		if err := os.WriteFile(target, []byte("#!/bin/sh\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := processFile(types.File{
+			Name:   "script.sh",
+			Action: "chmod",
+			Target: target,
+			Mode:   types.FileMode(0o755),
+		}, dir, osInfo)
+		if err != nil {
+			t.Fatalf("processFile(chmod): %v", err)
+		}
+		info, err := os.Stat(target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o755 {
+			t.Errorf("mode = %o, want 0755", info.Mode().Perm())
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "stale.conf")
+		if err := os.WriteFile(target, []byte("old"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := processFile(types.File{
+			Name:   "stale.conf",
+			Action: "delete",
+			Target: target,
+		}, dir, osInfo)
+		if err != nil {
+			t.Fatalf("processFile(delete): %v", err)
+		}
+		if _, err := os.Stat(target); !os.IsNotExist(err) {
+			t.Errorf("target still exists after delete: %v", err)
+		}
+	})
+
+	t.Run("copy still requires a source", func(t *testing.T) {
+		dir := t.TempDir()
+		err := processFile(types.File{
+			Name:   "orphan",
+			Action: "copy",
+			Target: filepath.Join(dir, "out"),
+		}, dir, osInfo)
+		if err == nil {
+			t.Fatal("processFile(copy without source) succeeded, want an error")
+		}
+	})
+}


### PR DESCRIPTION
`processFile` (`files.go:120-122`) demanded `content` or `source` for **every** entry, which broke the documented `chmod`/`chown`/`chgrp`/`delete` examples — `docs/blueprints/files.md` explicitly pairs a `copy` entry with a follow-up `chmod`/`chown` entry ("A copy takes the source's permissions; set them with a chmod entry").

The requirement is now gated by action via `fileActionConsumesContent`: metadata actions operate on an existing target and need neither. The validator (`internal/validate/components.go:85-89`) already gated by action — no mirror change needed there; the processor now agrees with it. The docs were right all along, so no doc change either.

Tests (fail without the fix): chmod without content changes the mode; delete removes the target; copy without source still errors.

**Breaking-change statement:** nothing breaks — content-consuming actions keep their requirement; the metadata actions go from always-erroring to working as documented.

From REVIEW-PR-PLAN.md Wave 1 (PR-9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)