### PR TITLE
fix(system): thread elevation through every write path

### DIFF
--- a/internal/processors/fonts.go
+++ b/internal/processors/fonts.go
@@ -353,7 +353,7 @@ func extractFontTarball(tarballPath, destDir string, elevated bool, osInfo *type
 				if closeErr := tempFile.Close(); closeErr != nil {
 					log.Debugf("closing oversized font temp file: %v", closeErr)
 				}
-				return fmt.Errorf("font file %s decompresses past %d MB; refusing what looks like a decompression bomb", header.Name, maxFontFileBytes>>20)
+				return extracted, fmt.Errorf("font file %s decompresses past %d MB; refusing what looks like a decompression bomb", header.Name, maxFontFileBytes>>20)
 			}
 			if err := tempFile.Close(); err != nil {
 				return extracted, fmt.Errorf("error closing temp file after copy: %w", err)

--- a/internal/processors/services.go
+++ b/internal/processors/services.go
@@ -76,7 +76,10 @@ func createServiceFile(service types.Service, osInfo *types.OSInfo) error {
 			log.Infof("[DRY-RUN] Would create service file: %s", service.Target)
 			return nil
 		}
-		if err := os.WriteFile(service.Target, []byte(service.Content), 0644); err != nil { // #nosec G306 -- TODO(PR8): create with target mode instead of chmod-after
+		// system.WriteToFile, not a plain os.WriteFile: the unit file usually
+		// lives under /etc, and the plain write ignored `elevated` and died
+		// with EACCES for any non-root run that declared it.
+		if err := system.WriteToFile(service.Target, service.Content, service.Elevated); err != nil {
 			return fmt.Errorf("error creating service file: %v", err)
 		}
 	} else if service.Source != "" {
@@ -190,7 +193,10 @@ func createLaunchDaemon(service types.Service, osInfo *types.OSInfo) error {
 			log.Infof("[DRY-RUN] Would create launch daemon: %s", service.Target)
 			return nil
 		}
-		if err := os.WriteFile(service.Target, []byte(service.Content), 0644); err != nil { // #nosec G306 -- TODO(PR8): create with target mode instead of chmod-after
+		// system.WriteToFile, not a plain os.WriteFile: /Library/LaunchDaemons
+		// is root-owned, and the plain write ignored `elevated` and died with
+		// EACCES for any non-root run that declared it.
+		if err := system.WriteToFile(service.Target, service.Content, service.Elevated); err != nil {
 			return fmt.Errorf("error creating launch daemon: %v", err)
 		}
 	} else if service.Source != "" {
@@ -299,7 +305,7 @@ func createWindowsService(service types.Service, osInfo *types.OSInfo, initConfi
 	if service.Content != "" {
 		if system.IsDryRun() {
 			log.Infof("[DRY-RUN] Would create Windows service file: %s", service.Target)
-		} else if err := os.WriteFile(service.Target, []byte(service.Content), 0644); err != nil { // #nosec G306 -- TODO(PR8): create with target mode instead of chmod-after
+		} else if err := system.WriteToFile(service.Target, service.Content, service.Elevated); err != nil {
 			return fmt.Errorf("error creating service file: %v", err)
 		}
 	} else if service.Source != "" {

--- a/internal/processors/services_elevation_test.go
+++ b/internal/processors/services_elevation_test.go
@@ -1,0 +1,43 @@
+package processors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// services: action: create with inline content wrote via a plain os.WriteFile
+// on all three platforms, ignoring `elevated` — a unit file under /etc/systemd
+// died with EACCES for any non-root run that declared elevated: true.
+func TestCreateServiceFile_ContentHonorsElevated(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "etc", "systemd", "system", "app.service")
+
+	err := createServiceFile(types.Service{
+		Name:     "app",
+		Action:   "create",
+		Target:   target,
+		Content:  "[Unit]\nDescription=app\n",
+		Elevated: true,
+	}, &types.OSInfo{})
+	if err != nil {
+		t.Fatalf("createServiceFile: %v", err)
+	}
+
+	// The elevated write goes through an elevated mv of a staged file; nothing
+	// may have landed at the target with the invoking user's privileges.
+	mvs := rec.Find("mv")
+	if len(mvs) != 1 || !mvs[0].Elevated {
+		t.Fatalf("mv calls = %v, want one elevated mv", mvs)
+	}
+	if _, statErr := os.Stat(target); !os.IsNotExist(statErr) {
+		t.Error("service file was written without elevation")
+	}
+}

--- a/internal/system/elevation_test.go
+++ b/internal/system/elevation_test.go
@@ -1,0 +1,92 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
+)
+
+// An elevated copy has to create the target's directory with the same
+// privilege as the copy: os.MkdirAll ran unelevated first, so a copy into a
+// root-owned tree (files: elevated: true under /etc) died with EACCES before
+// the elevated mv ever ran.
+func TestCopyFile_ElevatedCreatesParentElevated(t *testing.T) {
+	rec := exectest.New()
+	defer SetExecutor(rec)()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "unit.service")
+	if err := os.WriteFile(source, []byte("[Unit]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "etc", "systemd", "system", "unit.service")
+
+	if err := CopyFile(source, target, true, nil); err != nil {
+		t.Fatalf("CopyFile: %v", err)
+	}
+
+	mkdirs := rec.Find("mkdir")
+	if len(mkdirs) != 1 || !mkdirs[0].Elevated {
+		t.Fatalf("mkdir calls = %v, want one elevated mkdir", mkdirs)
+	}
+	wantArgs := []string{"-p", "--", filepath.Dir(target)}
+	for i, want := range wantArgs {
+		if mkdirs[0].Args[i] != want {
+			t.Errorf("mkdir args = %v, want %v", mkdirs[0].Args, wantArgs)
+			break
+		}
+	}
+	// The parent must NOT have been created unelevated on the real filesystem.
+	if _, err := os.Stat(filepath.Dir(target)); !os.IsNotExist(err) {
+		t.Error("target directory was created without elevation")
+	}
+
+	mvs := rec.Find("mv")
+	if len(mvs) != 1 || !mvs[0].Elevated {
+		t.Fatalf("mv calls = %v, want one elevated mv", mvs)
+	}
+}
+
+// CopyDirectory accepted `elevated` and ignored it: every mkdir, remove and
+// file write ran with the invoking user's privileges, so a directories
+// blueprint with elevated: true failed on the first root-owned target.
+func TestCopyDirectory_ThreadsElevationThroughEveryWrite(t *testing.T) {
+	rec := exectest.New()
+	defer SetExecutor(rec)()
+
+	root := t.TempDir()
+	source := filepath.Join(root, "src")
+	if err := os.MkdirAll(filepath.Join(source, "conf.d"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "conf.d", "app.conf"), []byte("k=v\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "etc", "app")
+
+	if err := CopyDirectory(source, target, true, false); err != nil {
+		t.Fatalf("CopyDirectory: %v", err)
+	}
+
+	mkdirs := rec.Find("mkdir")
+	if len(mkdirs) < 2 {
+		t.Fatalf("mkdir calls = %v, want elevated mkdirs for the target tree", mkdirs)
+	}
+	for _, call := range mkdirs {
+		if !call.Elevated {
+			t.Errorf("unelevated mkdir reached the system: %v", call)
+		}
+	}
+
+	mvs := rec.Find("mv")
+	if len(mvs) != 1 || !mvs[0].Elevated {
+		t.Fatalf("mv calls = %v, want one elevated mv for the file copy", mvs)
+	}
+
+	// Nothing may have been written to the target without elevation.
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Error("target tree was created without elevation")
+	}
+}

--- a/internal/system/files.go
+++ b/internal/system/files.go
@@ -526,10 +526,18 @@ func CopyFile(source, target string, elevated bool, osInfo *types.OSInfo) error 
 		return fmt.Errorf("error getting source file info: %v", err)
 	}
 
+	// The directory has to be created with the same privilege as the copy:
+	// an elevated copy into /etc/new-dir ran os.MkdirAll unelevated first and
+	// died with EACCES before the elevated mv ever ran.
 	targetDir := filepath.Dir(target)
-	// 0755, not os.ModePerm: 0777 through a permissive umask is a directory
-	// every local user can write, on a path that may hold installed content.
-	if err := os.MkdirAll(targetDir, 0o755); err != nil { // #nosec G301 -- parent of a blueprint-named target; 0755 so installed content stays world-readable, never world-writable
+	if elevated {
+		mkdir := types.Command{Exec: "mkdir", Args: []string{"-p", "--", targetDir}, Elevated: true}
+		if err := RunCommand(mkdir, false); err != nil {
+			return fmt.Errorf("error creating target directory with elevated privileges: %v", err)
+		}
+		// 0755, not os.ModePerm: 0777 through a permissive umask is a directory
+		// every local user can write, on a path that may hold installed content.
+	} else if err := os.MkdirAll(targetDir, 0o755); err != nil { // #nosec G301 -- parent of a blueprint-named target; 0755 so installed content stays world-readable, never world-writable
 		return fmt.Errorf("error creating target directory: %v", err)
 	}
 
@@ -610,36 +618,6 @@ func ExpandPath(path string) string {
 	return path
 }
 
-func copyFileContent(source, target string) error {
-	log.Debugf("Copying file content from %s to %s", source, target)
-	sourceFile, err := os.Open(source) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
-	if err != nil {
-		return fmt.Errorf("error opening source file: %v", err)
-	}
-	defer func() {
-		if err := sourceFile.Close(); err != nil { //nolint:errcheck
-			log.Errorf("error closing source file: %v", err)
-		}
-	}()
-
-	targetFile, err := os.Create(target) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
-	if err != nil {
-		return fmt.Errorf("error creating target file: %v", err)
-	}
-	defer func() {
-		if err := targetFile.Close(); err != nil { //nolint:errcheck
-			log.Errorf("error closing target file: %v", err)
-		}
-	}()
-
-	_, err = io.Copy(targetFile, sourceFile)
-	if err != nil {
-		return fmt.Errorf("error copying file: %v", err)
-	}
-
-	return err
-}
-
 // CopyDirectory recursively copies a directory from source to target.
 // In interactive mode, it shows diffs and prompts before overwriting existing files.
 func CopyDirectory(source, target string, elevated, interactive bool) error {
@@ -658,8 +636,15 @@ func CopyDirectory(source, target string, elevated, interactive bool) error {
 		targetPath := filepath.Join(target, relPath)
 
 		if info.IsDir() {
-			err := os.MkdirAll(targetPath, info.Mode())
-			if err != nil {
+			// Created with the same privilege as the copy: `elevated` used to be
+			// accepted and ignored, so a directories blueprint with elevated: true
+			// failed with EACCES on the first root-owned target.
+			if elevated {
+				mkdir := types.Command{Exec: "mkdir", Args: []string{"-p", "--", targetPath}, Elevated: true}
+				if err := RunCommand(mkdir, false); err != nil {
+					return fmt.Errorf("error creating directory %s with elevated privileges: %v", targetPath, err)
+				}
+			} else if err := os.MkdirAll(targetPath, info.Mode()); err != nil {
 				return err
 			}
 		} else {
@@ -681,16 +666,18 @@ func CopyDirectory(source, target string, elevated, interactive bool) error {
 					}
 				}
 
-				// Overwrite the file
-				err := os.Remove(targetPath) //nolint:errcheck
-				if err != nil {
-					return err
+				// Overwrite the file. The elevated path replaces it via an
+				// elevated mv inside CopyFile, so only the unelevated copy has
+				// to clear the target itself.
+				if !elevated {
+					if err := os.Remove(targetPath); err != nil {
+						return err
+					}
 				}
 			}
 
-			// Copy the file
-			err = copyFileContent(path, targetPath)
-			if err != nil {
+			// Copy the file with the privilege the blueprint asked for.
+			if err := CopyFile(path, targetPath, elevated, nil); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Three places accepted `elevated` and then wrote with the invoking user's privileges — blueprints declaring `elevated: true` failed with EACCES on any root-owned target:

- **`CopyFile`** (`files.go:506-509`): `os.MkdirAll` ran unelevated *before* the elevated `mv`, so a copy into a not-yet-existing directory under `/etc` died before the elevated step ran. The parent is now created via elevated `mkdir -p --` when the copy is elevated.
- **`CopyDirectory`** (`files.go:618-679`): ignored the flag entirely — every mkdir, remove, and file write was unelevated. Directories now use the caller's privilege, and files route through `CopyFile` with the caller's elevation (which also preserves file modes, previously dropped by `copyFileContent` — now deleted as unused).
- **`services: action: create` + `content:`** (`services.go:79,193,302`): plain `os.WriteFile` on all three platforms. Now `system.WriteToFile(dest, content, elevated)` — the helper repository steps already use.

Tests (fail without the fix): `TestCopyFile_ElevatedCreatesParentElevated`, `TestCopyDirectory_ThreadsElevationThroughEveryWrite`, `TestCreateServiceFile_ContentHonorsElevated` — each asserts the recorded commands are elevated **and** that nothing landed on the real filesystem unelevated.

**Breaking-change statement:** nothing breaks — unelevated behavior is unchanged; elevated writes go from EACCES to working.

From REVIEW-PR-PLAN.md Wave 1 (PR-6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)