### PR TITLE
fix(cli): kill the fossils

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,7 +12,9 @@ var initFlag bool
 var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Create or modify rwr configuration",
-	Long:  `Create or modify rwr configuration for JumpCloud and rwr settings`,
+	Long: `Create the rwr configuration file. With --create, prompts for each
+setting and writes the config; without it, this help is shown — there is no
+config view or edit mode yet.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if initFlag {
 			if err := helpers.CreateDefaultConfig(); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,9 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "rwr",
 	Short: "Rinse, Wash, and Repeat - Distrohopper's Friend",
-	Long:  `rwr is a cli to manage your Linux system's package manager and repositories.`,
+	Long: `rwr provisions Linux, macOS and Windows machines from blueprint files:
+packages, repositories, files and templates, services, users, SSH keys, fonts,
+git checkouts, scripts, and desktop configuration.`,
 	// A run that fails partway through is not a usage mistake. Printing the full
 	// flag listing after "validation failed with 3 errors" buries the errors the
 	// operator actually needs to read under a screen of help text. Errors are

--- a/internal/processors/packages.go
+++ b/internal/processors/packages.go
@@ -150,7 +150,7 @@ func ProcessPackages(data []byte, packages *types.PackagesData, format string, o
 				continue
 			}
 
-			log.Infof("Successfully %sed package %s via %s", pkg.Action, name, provider.Name)
+			log.Infof("Successfully %s package %s via %s", pastTense(pkg.Action), name, provider.Name)
 		}
 	}
 
@@ -166,6 +166,15 @@ func ProcessPackages(data []byte, packages *types.PackagesData, format string, o
 // sorted because Go randomizes map iteration: selecting "whatever the map yields
 // first" meant an unqualified package could be installed by a different package
 // manager on every run.
+// pastTense renders a package action for the success message. The old
+// "%sed" format produced "removeed": actions ending in "e" only take a "d".
+func pastTense(action string) string {
+	if strings.HasSuffix(action, "e") {
+		return action + "d"
+	}
+	return action + "ed"
+}
+
 func defaultProviderFor(osInfo *types.OSInfo, available map[string]*types.Provider) (*types.Provider, bool) {
 	if osInfo != nil {
 		if name := osInfo.PackageManager.Default.Name; name != "" {

--- a/internal/processors/user.go
+++ b/internal/processors/user.go
@@ -885,9 +885,10 @@ func macAddGroups(name string, groups []string, initConfig *types.InitConfig) er
 // therefore appears in the argv of a sudo'd process, visible in `ps` to every
 // local user and recorded in sudo's syslog entry.
 //
-// TODO: feed the password to `dscl . -passwd` on stdin instead. That needs a
-// Stdin field on types.Command plus wiring in system.RunCommand; neither exists
-// yet, and those files are outside this change.
+// TODO: feed the password to `dscl . -passwd` on stdin instead.
+// types.Command.Stdin and its RunCommand wiring exist now (this file already
+// uses them for the Linux chpasswd path below); what remains is confirming
+// dscl reads a password from stdin non-interactively on current macOS.
 func macSetPassword(user types.User, initConfig *types.InitConfig) error {
 	if user.Password == "" {
 		return nil

--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -244,16 +244,22 @@ func GetProvider(name string) (*types.Provider, bool) {
 		return nil, false
 	}
 
-	// Check if the provider exists in the loaded providers
+	// Under providersMu like every other reader: this was the one lookup that
+	// read the map unlocked, a data race against SetProvidersForTest and any
+	// future reload. The lock is not held across FindTool below — only the map
+	// access needs it.
+	providersMu.Lock()
 	provider, exists := providers[name]
 	if !exists {
 		names := make([]string, 0, len(providers))
 		for name := range providers {
 			names = append(names, name)
 		}
+		providersMu.Unlock()
 		log.Errorf("GetProvider: Provider %s not found in loaded providers. Available providers: %v", name, names)
 		return nil, false
 	}
+	providersMu.Unlock()
 	log.Debugf("GetProvider: Found provider %s in loaded providers", name)
 
 	// Check if binary exists using FindTool


### PR DESCRIPTION
The CLI-fossil batch (REVIEW-PR-PLAN.md Wave 1, PR-13), applied per the plan's verified update notes:

- **Root `Long`** (not `Short` — that was already fixed; the fossil had moved): "manage your Linux system's package manager" → describes what rwr actually provisions, on all three platforms.
- **`rwr config` Long** dropped the "for JumpCloud" claim and now says what the command does (`--create` prompts and writes; bare invocation shows help; no view/edit mode yet).
- **Stale Stdin TODO** (`user.go:888-890`): claimed `types.Command.Stdin` doesn't exist while the same file uses it at `:986` for chpasswd. Rewritten to state the actual remaining question (does `dscl` read a password from stdin non-interactively).
- **"Successfully removeed package"** — a format-string artifact (`"%sed" % action`), not a typo: fixed with suffix handling (`pastTense`), so `remove`→removed, `install`→installed.
- **`GetProvider` data race** — promoted out of "cosmetic" per the update note: it was the one reader of the `providers` map that didn't take `providersMu` (`GetProviderDefinition`/`GetAvailableProviders` both lock). Now locks around the map access; the full suite runs under `-race`.

The `--gh-key` docs recommendations are deferred to the docs-drift PR (PR-15) — the flag itself is already `MarkDeprecated`.

**Breaking-change statement:** nothing breaks; help text, a log message, a comment, and a lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)