### PR TITLE
fix(run): stop dying mid-run, warn on skipped work

### DIFF
--- a/internal/processors/blueprints.go
+++ b/internal/processors/blueprints.go
@@ -172,6 +172,30 @@ func GetBlueprintFileOrder(blueprintDir string, order []interface{}, runOnlyList
 		return filepath.Dir(path)
 	}
 
+	// The run loop only executes buckets named after a processor. A file whose
+	// path matches none lands in a directory-named bucket ("." for a top-level
+	// file) that nothing ever reads — the flattened/minimal_files example
+	// layouts hit exactly this and exited 0 having executed nothing. Until
+	// detection is content-based, the least we owe the operator is a loud
+	// statement that the file will not run.
+	warnIfUnrouted := func(processor, relPath string) {
+		switch processor {
+		case types.BlueprintTypePackages, types.BlueprintTypeRepositories, types.BlueprintTypeFiles, types.BlueprintTypeServices, types.BlueprintTypeUsers,
+			types.BlueprintTypeGit, types.BlueprintTypeScripts, types.BlueprintTypeSSHKeys, types.BlueprintTypeFonts, types.BlueprintTypeConfiguration:
+			return
+		}
+		log.Warnf("Blueprint file %s is not under a recognized processor directory and will NOT be executed. "+
+			"Move it under one of: packages/, repositories/, files/, services/, users/, git/, scripts/, ssh_keys/, fonts/, configuration/.", relPath)
+	}
+
+	// The init file configures the run and bootstrap is dispatched separately
+	// (findBootstrapFile); neither is a processor blueprint, so neither belongs
+	// in a processor bucket — nor in the unrouted warning above.
+	isReservedFile := func(path string) bool {
+		base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		return base == "init" || base == "bootstrap"
+	}
+
 	// Process ordered items first
 	for _, item := range order {
 		if str, ok := item.(string); ok {
@@ -184,12 +208,13 @@ func GetBlueprintFileOrder(blueprintDir string, order []interface{}, runOnlyList
 						if err != nil {
 							return err
 						}
-						if !info.IsDir() && filepath.Ext(path) == "."+initConfig.Init.Format {
+						if !info.IsDir() && filepath.Ext(path) == "."+initConfig.Init.Format && !isReservedFile(path) {
 							relPath, err := filepath.Rel(blueprintDir, path)
 							if err != nil {
 								return err
 							}
 							processor := getProcessorType(relPath)
+							warnIfUnrouted(processor, relPath)
 							fileOrder[processor] = append(fileOrder[processor], relPath)
 							log.Debugf("Added file to processor %s: %s", processor, relPath)
 						}
@@ -218,12 +243,13 @@ func GetBlueprintFileOrder(blueprintDir string, order []interface{}, runOnlyList
 			if err != nil {
 				return err
 			}
-			if !info.IsDir() && filepath.Ext(path) == "."+initConfig.Init.Format {
+			if !info.IsDir() && filepath.Ext(path) == "."+initConfig.Init.Format && !isReservedFile(path) {
 				relPath, err := filepath.Rel(blueprintDir, path)
 				if err != nil {
 					return err
 				}
 				processor := getProcessorType(relPath)
+				warnIfUnrouted(processor, relPath)
 				if _, exists := fileOrder[processor]; !exists {
 					fileOrder[processor] = []string{relPath}
 				} else if !helpers.Contains(fileOrder[processor], relPath) {

--- a/internal/processors/blueprints_walk_test.go
+++ b/internal/processors/blueprints_walk_test.go
@@ -1,0 +1,44 @@
+package processors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// The walk must not route the init file or bootstrap into a processor bucket:
+// init configures the run and bootstrap is dispatched separately, so both used
+// to land in the dead "." bucket alongside genuinely misplaced files.
+func TestGetBlueprintFileOrder_SkipsInitAndBootstrap(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "packages"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"init.yaml", "bootstrap.yaml", filepath.Join("packages", "base.yaml")} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("packages: []\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	initConfig := &types.InitConfig{}
+	initConfig.Init.Format = "yaml"
+
+	fileOrder, err := GetBlueprintFileOrder(dir, nil, false, initConfig)
+	if err != nil {
+		t.Fatalf("GetBlueprintFileOrder: %v", err)
+	}
+
+	if got := fileOrder[types.BlueprintTypePackages]; len(got) != 1 || got[0] != filepath.Join("packages", "base.yaml") {
+		t.Errorf("packages bucket = %v, want [packages/base.yaml]", got)
+	}
+	for bucket, files := range fileOrder {
+		for _, f := range files {
+			base := filepath.Base(f)
+			if base == "init.yaml" || base == "bootstrap.yaml" {
+				t.Errorf("%s routed into bucket %q; init/bootstrap must not be walked", f, bucket)
+			}
+		}
+	}
+}

--- a/internal/processors/repository.go
+++ b/internal/processors/repository.go
@@ -61,16 +61,18 @@ func processRepositories(repositories []types.Repository, osInfo *types.OSInfo, 
 
 	// One repository failing does not stop the rest: the failure goes to the
 	// ledger, which puts it in the run's exit code, and processing continues.
+	declared := make(map[string]bool, len(repositories))
 	for _, repo := range repositories {
 		log.Infof("Processing repository %s", repo.Name)
 		log.Debugf("Repository definition: %s", repo.LogString())
+		declared[repo.PackageManager] = true
 
 		if err := processRepository(repo, osInfo, initConfig); err != nil {
 			recordFailure("repositories", repo.Name, err)
 		}
 	}
 
-	return runRepositoryUpdates(initConfig)
+	return runRepositoryUpdates(initConfig, declared)
 }
 
 // validateRepositoryName refuses names that would escape the paths derived
@@ -245,11 +247,19 @@ func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *
 	return nil
 }
 
-// runRepositoryUpdates refreshes package lists for every available provider.
-func runRepositoryUpdates(initConfig *types.InitConfig) error {
+// runRepositoryUpdates refreshes package lists for the providers this
+// blueprint file declared repositories for. It used to update every available
+// provider after every repositories file — a tree with three such files ran
+// `apt update`, `dnf makecache` etc. three times each, for managers whose
+// repositories never changed.
+//
+// A failed update is recorded in the ledger, not just logged: the operator's
+// new repository is not actually usable until its package list refresh
+// succeeds, so the run's exit code has to reflect the failure.
+func runRepositoryUpdates(initConfig *types.InitConfig, declared map[string]bool) error {
 	available := system.GetAvailableProviders()
 	for name, provider := range available {
-		if provider.Commands.Update == "" {
+		if !declared[name] || provider.Commands.Update == "" {
 			continue
 		}
 
@@ -261,7 +271,7 @@ func runRepositoryUpdates(initConfig *types.InitConfig) error {
 		}
 
 		if err := system.RunCommand(updateCmd, initConfig.Variables.Flags.Debug); err != nil {
-			log.Warnf("Error updating %s package lists: %v", name, err)
+			recordFailure("repositories", name+" update", err)
 			continue
 		}
 	}

--- a/internal/processors/repository_test.go
+++ b/internal/processors/repository_test.go
@@ -170,7 +170,32 @@ func TestProcessRepositories_AptAddRendersProviderTemplates(t *testing.T) {
 
 // The trailing repository refresh execs argv, so the update command may not
 // contain shell operators: apt would take "&&" and "upgrade" as package names.
-func TestProcessRepositories_UpdateCommandIsPlainArgv(t *testing.T) {
+func TestRunRepositoryUpdates_CommandIsPlainArgv(t *testing.T) {
+	sourcesDir := t.TempDir()
+	keysDir := t.TempDir()
+
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	provider := aptProviderForTest(t, sourcesDir, keysDir)
+	defer system.SetProvidersForTest(map[string]*types.Provider{"apt": provider})()
+
+	if err := runRepositoryUpdates(&types.InitConfig{}, map[string]bool{"apt": true}); err != nil {
+		t.Fatalf("runRepositoryUpdates: %v", err)
+	}
+
+	if len(rec.Calls) != 1 {
+		t.Fatalf("recorded %d calls, want 1: %v", len(rec.Calls), rec.Calls)
+	}
+	if got := rec.Calls[0].Args; !equalStrings(got, []string{"update"}) {
+		t.Errorf("update args = %#v, want [update]", got)
+	}
+}
+
+// The refresh only runs for providers this file declared repositories for: a
+// repositories file for apt must not also run every other manager's update,
+// and a file with no repositories runs none at all.
+func TestProcessRepositories_UpdatesOnlyDeclaredProviders(t *testing.T) {
 	sourcesDir := t.TempDir()
 	keysDir := t.TempDir()
 
@@ -183,12 +208,8 @@ func TestProcessRepositories_UpdateCommandIsPlainArgv(t *testing.T) {
 	if err := processRepositories(nil, &types.OSInfo{}, &types.InitConfig{}); err != nil {
 		t.Fatalf("processRepositories: %v", err)
 	}
-
-	if len(rec.Calls) != 1 {
-		t.Fatalf("recorded %d calls, want 1: %v", len(rec.Calls), rec.Calls)
-	}
-	if got := rec.Calls[0].Args; !equalStrings(got, []string{"update"}) {
-		t.Errorf("update args = %#v, want [update]", got)
+	if len(rec.Calls) != 0 {
+		t.Fatalf("no repositories declared, but %d commands ran: %v", len(rec.Calls), rec.Calls)
 	}
 }
 

--- a/internal/system/files.go
+++ b/internal/system/files.go
@@ -647,7 +647,10 @@ func CopyDirectory(source, target string, elevated, interactive bool) error {
 					if err != nil {
 						log.Errorf("Failed to show diff: %v", err)
 					}
-					overwrite := promptOverwrite()
+					overwrite, promptErr := promptOverwrite()
+					if promptErr != nil {
+						return promptErr
+					}
 					if !overwrite {
 						log.Infof("Skipping file: %s", targetPath)
 						return nil
@@ -714,12 +717,15 @@ func LookupGID(group string) (int, error) {
 	return gid, nil
 }
 
-func promptOverwrite() bool {
+// promptOverwrite returns an error instead of dying on a failed read:
+// log.Fatalf here bypassed the failure ledger and every deferred cleanup, and
+// interactive defaults to true, so a piped stdin hitting EOF killed the whole
+// run mid-flight.
+func promptOverwrite() (bool, error) {
 	var input string
 	fmt.Print("Do you want to overwrite the file? (y/n): ")
-	_, err := fmt.Scanln(&input)
-	if err != nil {
-		log.Fatalf("error reading input: %v", err)
+	if _, err := fmt.Scanln(&input); err != nil {
+		return false, fmt.Errorf("reading overwrite confirmation (run with --interactive=false to skip prompts): %w", err)
 	}
-	return strings.EqualFold(input, "y") || strings.EqualFold(input, "yes")
+	return strings.EqualFold(input, "y") || strings.EqualFold(input, "yes"), nil
 }


### PR DESCRIPTION
Three ways a run could silently skip work or die without cleanup (REVIEW-PR-PLAN.md Wave 1, PR-10):

- **`promptOverwrite` no longer `log.Fatalf`s** on a stdin read error (`system/files.go:717-725`) — that bypassed the failure ledger and deferred cleanups, and interactive defaults to true (`cmd/root.go:180`), so a piped stdin hitting EOF killed the whole run. It returns an error (pointing at `--interactive=false`) into the normal failure path.
- **Unrouted blueprint files warn loudly.** Files matching no processor directory land in a bucket the run loop never reads (`blueprints.go` + `all.go`) — the flattened/minimal_files example layouts exit 0 having executed nothing. Each such file now gets a WARN naming it and where to put it; `init.*`/`bootstrap.*` are excluded from the walk (matching `CollectProfiles`), so they stop tripping the same dead bucket. Interim guard until the CUE change decides content-based detection (Wave 2).
- **Repository updates are scoped and ledgered.** `runRepositoryUpdates` ran every available provider's update after every repositories file, and failures were `log.Warnf` — invisible to the exit code. Updates now run only for providers the file declared repositories for, and failures are recorded in the ledger.

Tests: `TestGetBlueprintFileOrder_SkipsInitAndBootstrap`, `TestProcessRepositories_UpdatesOnlyDeclaredProviders`, and `TestRunRepositoryUpdates_CommandIsPlainArgv` (the argv assertion retargeted to the new signature).

**Breaking-change statement:** a repositories file now refreshes only the managers it declares — a tree relying on the blanket-refresh side effect gets the refresh from its own manager's declaration. No blueprint schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)