### PR TITLE
fix(cli): one init-file key, effective configdir, tested wiring

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,9 +101,7 @@ func initializeSystemInfo() error {
 	var err error
 
 	// If no init file is specified via flag, check config
-	if initFilePath == "" {
-		initFilePath = viper.GetString("repository.init-file")
-	}
+	initFilePath = configuredInitFile(initFilePath)
 
 	// One resolver for every accepted form — local path, directory, https URL,
 	// GitHub blob URL, owner/repo[/path][@ref] shorthand. See its doc comment
@@ -179,9 +177,13 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVarP(&interactive, "interactive", "I", true, "Enable interactive mode (use --interactive=false to disable)")
 
-	// Flag for the init file path
+	// Flag for the init file path. Bound to repository.init-file — the key the
+	// config file and docs have always used. It was bound to rwr.init-file,
+	// which nothing read: a two-key split where the flag wrote one key and the
+	// config lookup read the other. rwr.init-file still works via a deprecation
+	// shim in configuredInitFile.
 	rootCmd.PersistentFlags().StringVarP(&initFilePath, "init-file", "i", "", "Path to the init file")
-	mustBindFlag("rwr.init-file", "init-file")
+	mustBindFlag("repository.init-file", "init-file")
 	mustBindFlag("log.level", "log-level")
 
 	viper.SetDefault("log.level", "info") // Default log level
@@ -227,6 +229,51 @@ func init() {
 	viper.AutomaticEnv()
 }
 
+// configuredInitFile resolves where the init file comes from: the --init-file
+// flag, then the repository.init-file config key (which the flag is also bound
+// to), then the deprecated rwr.init-file key — honored with a warning so
+// configs written against the old two-key split keep working.
+func configuredInitFile(flagValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if v := viper.GetString("repository.init-file"); v != "" {
+		return v
+	}
+	if legacy := viper.GetString("rwr.init-file"); legacy != "" {
+		log.Warnf("rwr.init-file is deprecated; use repository.init-file (honoring the value this run)")
+		return legacy
+	}
+	return ""
+}
+
+// resolveConfigLocation decides the config directory and, when --config named
+// a file, the config file path. Precedence: the --config flag, then the
+// rwr.configdir key (env: RWR_RWR_CONFIGDIR — it has to come from the
+// environment, since the config file cannot name its own directory), then
+// ~/.config/rwr. rwr.configdir used to be read and then unconditionally
+// overwritten, so documenting it was a lie.
+func resolveConfigLocation(homeDir, configFlag, configuredDir string) (location, file string) {
+	location = filepath.Join(homeDir, ".config", "rwr")
+	if configuredDir != "" {
+		location = system.ExpandPath(configuredDir)
+	}
+
+	// --config either names a config file directly or names the directory to
+	// look for config.yaml in. A file keeps its directory as the config
+	// location, so run_once stays next to the config it belongs to.
+	if configFlag != "" {
+		expanded := system.ExpandPath(configFlag)
+		if info, statErr := os.Stat(expanded); statErr == nil && info.IsDir() {
+			location = expanded
+		} else {
+			file = expanded
+			location = filepath.Dir(expanded)
+		}
+	}
+	return location, file
+}
+
 // mustBindFlag binds a viper config key to a persistent flag, panicking on failure.
 // Flag binding errors indicate a programming error (e.g., referencing a non-existent flag).
 func mustBindFlag(viperKey, flagName string) {
@@ -252,21 +299,11 @@ func config() error {
 	if err != nil {
 		return fmt.Errorf("error finding home directory: %w", err)
 	}
-	configLocation = filepath.Join(homeDir, ".config", "rwr")
 
-	// --config either names a config file directly or names the directory to
-	// look for config.yaml in. A file keeps its directory as the config
-	// location, so run_once stays next to the config it belongs to.
-	configFile := ""
-	if configPath != "" {
-		expanded := system.ExpandPath(configPath)
-		if info, statErr := os.Stat(expanded); statErr == nil && info.IsDir() {
-			configLocation = expanded
-		} else {
-			configFile = expanded
-			configLocation = filepath.Dir(expanded)
-		}
-	}
+	// rwr.configdir is read before the config file is (it decides where that
+	// file lives, so only the environment can supply it); --config wins.
+	var configFile string
+	configLocation, configFile = resolveConfigLocation(homeDir, configPath, viper.GetString("rwr.configdir"))
 
 	runOnceLocation = filepath.Join(configLocation, "run_once")
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// The --init-file flag is bound to repository.init-file, so config, env and
+// flag all meet at one key.
+func TestInitFileFlagBindsDocumentedKey(t *testing.T) {
+	if err := rootCmd.PersistentFlags().Set("init-file", "bound.yaml"); err != nil {
+		t.Fatalf("setting flag: %v", err)
+	}
+	defer func() {
+		_ = rootCmd.PersistentFlags().Set("init-file", "")
+	}()
+	if got := viper.GetString("repository.init-file"); got != "bound.yaml" {
+		t.Errorf("repository.init-file = %q after setting --init-file, want bound.yaml", got)
+	}
+}
+
+// The --init-file flag and the config file used to write and read two
+// different keys (rwr.init-file vs repository.init-file). Everything now
+// resolves through repository.init-file, with the old key honored as a
+// deprecated fallback.
+func TestConfiguredInitFile(t *testing.T) {
+	reset := func() {
+		viper.Set("repository.init-file", "")
+		viper.Set("rwr.init-file", "")
+	}
+
+	t.Run("flag wins over everything", func(t *testing.T) {
+		reset()
+		viper.Set("repository.init-file", "from-config.yaml")
+		if got := configuredInitFile("from-flag.yaml"); got != "from-flag.yaml" {
+			t.Errorf("configuredInitFile = %q, want the flag value", got)
+		}
+	})
+
+	t.Run("repository.init-file is the config key", func(t *testing.T) {
+		reset()
+		viper.Set("repository.init-file", "from-config.yaml")
+		if got := configuredInitFile(""); got != "from-config.yaml" {
+			t.Errorf("configuredInitFile = %q, want from-config.yaml", got)
+		}
+	})
+
+	t.Run("deprecated rwr.init-file still resolves", func(t *testing.T) {
+		reset()
+		viper.Set("rwr.init-file", "legacy.yaml")
+		if got := configuredInitFile(""); got != "legacy.yaml" {
+			t.Errorf("configuredInitFile = %q, want the legacy key's value", got)
+		}
+	})
+
+	t.Run("documented key wins over the deprecated one", func(t *testing.T) {
+		reset()
+		viper.Set("repository.init-file", "documented.yaml")
+		viper.Set("rwr.init-file", "legacy.yaml")
+		if got := configuredInitFile(""); got != "documented.yaml" {
+			t.Errorf("configuredInitFile = %q, want documented.yaml", got)
+		}
+	})
+}
+
+// rwr.configdir was read and then unconditionally overwritten, so setting it
+// could never take effect. It now participates with the right precedence:
+// --config wins, then rwr.configdir (from the environment), then the default.
+func TestResolveConfigLocation(t *testing.T) {
+	home := t.TempDir()
+
+	t.Run("default", func(t *testing.T) {
+		loc, file := resolveConfigLocation(home, "", "")
+		if want := filepath.Join(home, ".config", "rwr"); loc != want || file != "" {
+			t.Errorf("resolveConfigLocation = (%q, %q), want (%q, \"\")", loc, file, want)
+		}
+	})
+
+	t.Run("rwr.configdir is effective", func(t *testing.T) {
+		custom := t.TempDir()
+		loc, file := resolveConfigLocation(home, "", custom)
+		if loc != custom || file != "" {
+			t.Errorf("resolveConfigLocation = (%q, %q), want (%q, \"\")", loc, file, custom)
+		}
+	})
+
+	t.Run("--config directory wins over rwr.configdir", func(t *testing.T) {
+		flagDir := t.TempDir()
+		loc, file := resolveConfigLocation(home, flagDir, t.TempDir())
+		if loc != flagDir || file != "" {
+			t.Errorf("resolveConfigLocation = (%q, %q), want (%q, \"\")", loc, file, flagDir)
+		}
+	})
+
+	t.Run("--config file keeps its directory as the location", func(t *testing.T) {
+		flagDir := t.TempDir()
+		cfg := filepath.Join(flagDir, "config.yaml")
+		loc, file := resolveConfigLocation(home, cfg, "")
+		if loc != flagDir || file != cfg {
+			t.Errorf("resolveConfigLocation = (%q, %q), want (%q, %q)", loc, file, flagDir, cfg)
+		}
+	})
+}

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -40,7 +40,7 @@ The `rwr` section contains general settings for the RWR tool.
 
 | Option | Description |
 |--------|-------------|
-| `configdir` | The directory that `rwr config --create` writes `config.yaml` to, and the directory that holds the `bootstrap` marker file. The default is `$HOME/.config/rwr`. It does **not** change where RWR reads `config.yaml` from — use `--config` for that |
+| `configdir` | The config directory: where `config.yaml` is looked up, where `rwr config --create` writes it, and where the `bootstrap` marker lives. The default is `$HOME/.config/rwr`. Because it decides where the config file is, it only takes effect from the environment (`RWR_RWR_CONFIGDIR`) — a config file cannot name its own directory. `--config` overrides it |
 
 > [!NOTE]
 > There is no working `rwr.skipVersionCheck` option. The key is written by
@@ -113,7 +113,7 @@ not turned into an underscore.
 | `log.level` | `RWR_LOG_LEVEL` |
 | `repository.gh_api_token` | `RWR_REPOSITORY_GH_API_TOKEN` |
 | `repository.ssh_private_key` | `RWR_REPOSITORY_SSH_PRIVATE_KEY` |
-| `repository.init-file` | `RWR_REPOSITORY_INIT-FILE` |
+| `repository.init-file` | `RWR_REPOSITORY_INIT_FILE` |
 | `rwr.configdir` | `RWR_RWR_CONFIGDIR` |
 
 ```bash


### PR DESCRIPTION
From REVIEW-PR-PLAN.md Wave 1 (PR-11), applied per the plan's update notes (the "RWR_RWR_INIT_FILE is false" sub-claim was already obsoleted by #190 — the live work was the key collapse, configdir, and tests):

- **One init-file key.** `--init-file` bound `rwr.init-file` (`root.go:184`) while the config lookup read `repository.init-file` (`root.go:105`) — the flag wrote a key nothing read. The flag now binds `repository.init-file` (the documented key); `configuredInitFile` resolves flag → `repository.init-file` → deprecated `rwr.init-file` (honored with a deprecation warning).
- **`rwr.configdir` is now effective.** It was read then unconditionally overwritten (`viper.Set` at `root.go:277`). `resolveConfigLocation` gives it real precedence: `--config` wins, then `rwr.configdir` from the environment (`RWR_RWR_CONFIGDIR` — a config file cannot name its own directory), then `~/.config/rwr`. The doc row that said "does not change where RWR reads config.yaml from" now describes the working behavior.
- **First tests for `cmd/root.go`** (previously only `version_test.go`): key collapse precedence, deprecation shim, flag binding, configdir precedence.
- Rides along: the env-var table's `RWR_REPOSITORY_INIT-FILE` (a hyphen no POSIX shell can export) corrected to `RWR_REPOSITORY_INIT_FILE`.

**Breaking-change statement:** nothing breaks — `--init-file` behaves identically; configs using either key keep working (old key warns); `RWR_RWR_INIT_FILE` still resolves via the shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)