### PR TITLE
fix(fonts): restore the count return lost in the #203/#206 merge

### DIFF
--- a/internal/processors/fonts.go
+++ b/internal/processors/fonts.go
@@ -353,7 +353,7 @@ func extractFontTarball(tarballPath, destDir string, elevated bool, osInfo *type
 				if closeErr := tempFile.Close(); closeErr != nil {
 					log.Debugf("closing oversized font temp file: %v", closeErr)
 				}
-				return fmt.Errorf("font file %s decompresses past %d MB; refusing what looks like a decompression bomb", header.Name, maxFontFileBytes>>20)
+				return extracted, fmt.Errorf("font file %s decompresses past %d MB; refusing what looks like a decompression bomb", header.Name, maxFontFileBytes>>20)
 			}
 			if err := tempFile.Close(); err != nil {
 				return extracted, fmt.Errorf("error closing temp file after copy: %w", err)


### PR DESCRIPTION
Master does not compile: #203's decompression-bomb refusal and #206's `(int, error)` signature for `extractFontTarball` merged textually but not semantically — the bomb-refusal `return` still returned only an error.

```
internal/processors/fonts.go:356:12: not enough return values
	have (error)
	want (int, error)
```

One line: `return extracted, fmt.Errorf(...)`. Build + full processor suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)