### PR TITLE
feat(formats): centralize blueprint format handling in a registry

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -70,8 +70,8 @@ Examples:
 					validateBlueprints = true
 				}
 			} else {
-				// For files, check extension
-				if filepath.Ext(absPath) == ".toml" {
+				// For files, check extension (provider definitions are TOML-only)
+				if filepath.Ext(absPath) == types.FormatExtTOML {
 					validateProviders = true
 				} else {
 					validateBlueprints = true

--- a/internal/helpers/blueprints.go
+++ b/internal/helpers/blueprints.go
@@ -47,8 +47,15 @@ func UnmarshalBlueprintStrict(data []byte, format string, v interface{}) error {
 }
 
 func unmarshalBlueprint(data []byte, format string, v interface{}, strict bool) error {
-	switch format {
-	case types.FormatExtYAML, types.FormatExtYAMLAlt, types.FormatYAML, types.FormatYAMLAlt:
+	// The registry canonicalizes every accepted spelling (name, alias, dotted
+	// extension), so this switch is over canonical names only and unsupported
+	// formats fail with one message instead of falling through per spelling.
+	canonical, err := CanonicalFormat(format)
+	if err != nil {
+		return err
+	}
+	switch canonical {
+	case types.FormatYAML:
 		log.Debug("Unmarshaling YAML")
 		if !strict {
 			if err := yaml.Unmarshal(data, v); err != nil {
@@ -65,7 +72,7 @@ func unmarshalBlueprint(data []byte, format string, v interface{}, strict bool) 
 			}
 			return fmt.Errorf("error unmarshaling YAML: %w", err)
 		}
-	case types.FormatExtJSON, types.FormatJSON:
+	case types.FormatJSON:
 		log.Debug("Unmarshaling JSON")
 		if !strict {
 			if err := json.Unmarshal(data, v); err != nil {
@@ -81,7 +88,7 @@ func unmarshalBlueprint(data []byte, format string, v interface{}, strict bool) 
 			}
 			return fmt.Errorf("error unmarshaling JSON: %w", err)
 		}
-	case types.FormatExtTOML, types.FormatTOML:
+	case types.FormatTOML:
 		log.Debug("Unmarshaling TOML")
 		meta, err := toml.Decode(string(data), v)
 		if err != nil {

--- a/internal/helpers/blueprints_test.go
+++ b/internal/helpers/blueprints_test.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -114,9 +115,8 @@ func TestUnmarshalBlueprint_InvalidFormat(t *testing.T) {
 		t.Fatal("Expected error for unsupported format, got nil")
 	}
 
-	expectedErrorMsg := "unsupported blueprint format: xml"
-	if err.Error() != expectedErrorMsg {
-		t.Errorf("Expected error message '%s', got '%s'", expectedErrorMsg, err.Error())
+	if !strings.Contains(err.Error(), "unsupported blueprint format \"xml\"") {
+		t.Errorf("Expected an unsupported-format error naming xml, got '%s'", err.Error())
 	}
 }
 

--- a/internal/helpers/format_registry.go
+++ b/internal/helpers/format_registry.go
@@ -1,0 +1,86 @@
+package helpers
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// The format registry is the single source of blueprint format knowledge:
+// which extensions exist, which format a file is, and what candidate names
+// init/bootstrap discovery should try. Before it existed this knowledge was
+// duplicated across ~15 sites, each a hand edit for every new format — and the
+// copies had already diverged (half the tree assumed one format per tree via
+// Init.Format, half derived per file).
+//
+// Formats are canonical names ("yaml", "json", "toml"); extensions map onto
+// them, so ".yml" and ".yaml" are both format "yaml".
+var formatByExtension = map[string]string{
+	types.FormatExtYAML:    types.FormatYAML,
+	types.FormatExtYAMLAlt: types.FormatYAML,
+	types.FormatExtJSON:    types.FormatJSON,
+	types.FormatExtTOML:    types.FormatTOML,
+}
+
+// extensionOrder is the preference order for discovery and error messages:
+// yaml first because it is what the docs lead with and most trees use, so
+// probing (init.<ext> over the network) usually hits on the first try.
+var extensionOrder = []string{
+	types.FormatExtYAML,
+	types.FormatExtYAMLAlt,
+	types.FormatExtJSON,
+	types.FormatExtTOML,
+}
+
+// KnownExtensions returns every recognized blueprint extension (with the
+// leading dot), in preference order.
+func KnownExtensions() []string {
+	return append([]string(nil), extensionOrder...)
+}
+
+// FormatForPath resolves a file's format from its extension. An extensionless
+// or unknown-extension path is a diagnostic error naming the path — not a
+// panic, which is what `filepath.Ext(file)[1:]` produced for an extensionless
+// file.
+func FormatForPath(path string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext == "" {
+		return "", fmt.Errorf("%s has no extension; blueprint files need one of %s", path, strings.Join(KnownExtensions(), ", "))
+	}
+	format, ok := formatByExtension[ext]
+	if !ok {
+		return "", fmt.Errorf("%s: unsupported blueprint format %q; supported extensions are %s", path, ext, strings.Join(KnownExtensions(), ", "))
+	}
+	return format, nil
+}
+
+// IsBlueprintFile reports whether the path carries a recognized blueprint
+// extension. It is the walk-time filter: files that fail it are simply not
+// blueprints (READMEs, scripts), which is not an error.
+func IsBlueprintFile(path string) bool {
+	_, ok := formatByExtension[strings.ToLower(filepath.Ext(path))]
+	return ok
+}
+
+// CandidateFilenames returns the discovery candidates for a base name
+// ("init", "bootstrap") — one per known extension, in stable order.
+func CandidateFilenames(base string) []string {
+	exts := KnownExtensions()
+	names := make([]string, 0, len(exts))
+	for _, ext := range exts {
+		names = append(names, base+ext)
+	}
+	return names
+}
+
+// CanonicalFormat maps any accepted format spelling — canonical name, alias
+// ("yml"), or dotted extension (".yaml") — to the canonical format name.
+func CanonicalFormat(format string) (string, error) {
+	f := strings.ToLower(strings.TrimSpace(format))
+	if canonical, ok := formatByExtension["."+strings.TrimPrefix(f, ".")]; ok {
+		return canonical, nil
+	}
+	return "", fmt.Errorf("unsupported blueprint format %q; supported formats are yaml, json, toml", format)
+}

--- a/internal/helpers/format_registry_test.go
+++ b/internal/helpers/format_registry_test.go
@@ -1,0 +1,74 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatForPath(t *testing.T) {
+	for _, tt := range []struct {
+		path    string
+		want    string
+		wantErr bool
+	}{
+		{"packages.yaml", "yaml", false},
+		{"packages.yml", "yaml", false},
+		{"dir/files.JSON", "json", false},
+		{"a/b/repos.toml", "toml", false},
+		// An extensionless file used to panic via filepath.Ext(file)[1:].
+		{"Makefile", "", true},
+		{"packages.xml", "", true},
+	} {
+		got, err := FormatForPath(tt.path)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("FormatForPath(%q) = %q, want an error", tt.path, got)
+			} else if !strings.Contains(err.Error(), tt.path) {
+				t.Errorf("FormatForPath(%q) error %q does not name the path", tt.path, err)
+			}
+			continue
+		}
+		if err != nil || got != tt.want {
+			t.Errorf("FormatForPath(%q) = (%q, %v), want %q", tt.path, got, err, tt.want)
+		}
+	}
+}
+
+func TestIsBlueprintFile(t *testing.T) {
+	for path, want := range map[string]bool{
+		"x.yaml": true, "x.yml": true, "x.json": true, "x.toml": true,
+		"x.md": false, "x": false, "x.sh": false,
+	} {
+		if got := IsBlueprintFile(path); got != want {
+			t.Errorf("IsBlueprintFile(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestCandidateFilenames(t *testing.T) {
+	got := CandidateFilenames("init")
+	want := []string{"init.yaml", "init.yml", "init.json", "init.toml"}
+	if len(got) != len(want) {
+		t.Fatalf("CandidateFilenames = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("CandidateFilenames = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestCanonicalFormat(t *testing.T) {
+	for in, want := range map[string]string{
+		"yaml": "yaml", "yml": "yaml", ".yaml": "yaml", ".yml": "yaml",
+		"json": "json", ".json": "json", "toml": "toml", ".toml": "toml",
+		"YAML": "yaml",
+	} {
+		if got, err := CanonicalFormat(in); err != nil || got != want {
+			t.Errorf("CanonicalFormat(%q) = (%q, %v), want %q", in, got, err, want)
+		}
+	}
+	if _, err := CanonicalFormat("xml"); err == nil {
+		t.Error("CanonicalFormat(xml) succeeded, want an error")
+	}
+}

--- a/internal/helpers/init_source.go
+++ b/internal/helpers/init_source.go
@@ -13,8 +13,9 @@ import (
 )
 
 // initFileNames are the file names probed, in order, when the init source is a
-// directory (local or a repository root).
-var initFileNames = []string{"init.yaml", "init.yml", "init.json", "init.toml"}
+// directory (local or a repository root). Derived from the format registry so
+// a new format is discoverable without touching this file.
+var initFileNames = CandidateFilenames("init")
 
 // shorthandPattern matches GitHub repository shorthands: owner/repo, with an
 // optional /path/to/file and an optional @ref suffix. Owner and repo are a

--- a/internal/helpers/resolve_imports.go
+++ b/internal/helpers/resolve_imports.go
@@ -65,9 +65,14 @@ func resolveImports[T any](
 			return nil, fmt.Errorf("error reading import file %s: %w", fullPath, err)
 		}
 
-		fileFormat := format
-		if fileFormat == "" {
-			fileFormat = filepath.Ext(fullPath)
+		// The imported file's own extension decides its format; the importing
+		// file's format is only the fallback for a file with no recognized
+		// extension. It used to be the other way around: the parent's format
+		// was forced onto every import, so a .toml file imported from a .yaml
+		// blueprint was fed to the YAML decoder.
+		fileFormat, formatErr := FormatForPath(fullPath)
+		if formatErr != nil {
+			fileFormat = format
 		}
 
 		imported, err := decode(data, fileFormat)

--- a/internal/processors/all.go
+++ b/internal/processors/all.go
@@ -19,8 +19,8 @@ import (
 // findBootstrapFile returns the bootstrap blueprint in dir, in whichever format it
 // is written, or "" when the tree has none.
 func findBootstrapFile(dir string) string {
-	for _, ext := range []string{types.FormatExtYAML, types.FormatExtYAMLAlt, types.FormatExtJSON, types.FormatExtTOML} {
-		candidate := filepath.Join(dir, "bootstrap"+ext)
+	for _, name := range helpers.CandidateFilenames("bootstrap") {
+		candidate := filepath.Join(dir, name)
 		if system.FileExists(candidate) {
 			return candidate
 		}
@@ -145,7 +145,12 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 				}
 
 				blueprintDir := filepath.Dir(blueprintFile)
-				format := filepath.Ext(blueprintFile)[1:] // Remove the leading dot
+				// Per-file, via the registry: `filepath.Ext(file)[1:]` panicked
+				// outright on an extensionless file.
+				format, err := helpers.FormatForPath(blueprintFile)
+				if err != nil {
+					return err
+				}
 
 				blueprintData, err := os.ReadFile(blueprintFile) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
 				if err != nil {

--- a/internal/processors/blueprints.go
+++ b/internal/processors/blueprints.go
@@ -208,7 +208,7 @@ func GetBlueprintFileOrder(blueprintDir string, order []interface{}, runOnlyList
 						if err != nil {
 							return err
 						}
-						if !info.IsDir() && filepath.Ext(path) == "."+initConfig.Init.Format && !isReservedFile(path) {
+						if !info.IsDir() && helpers.IsBlueprintFile(path) && !isReservedFile(path) {
 							relPath, err := filepath.Rel(blueprintDir, path)
 							if err != nil {
 								return err
@@ -243,7 +243,7 @@ func GetBlueprintFileOrder(blueprintDir string, order []interface{}, runOnlyList
 			if err != nil {
 				return err
 			}
-			if !info.IsDir() && filepath.Ext(path) == "."+initConfig.Init.Format && !isReservedFile(path) {
+			if !info.IsDir() && helpers.IsBlueprintFile(path) && !isReservedFile(path) {
 				relPath, err := filepath.Rel(blueprintDir, path)
 				if err != nil {
 					return err

--- a/internal/processors/blueprints_walk_test.go
+++ b/internal/processors/blueprints_walk_test.go
@@ -42,3 +42,36 @@ func TestGetBlueprintFileOrder_SkipsInitAndBootstrap(t *testing.T) {
 		}
 	}
 }
+
+// The run-order walk sees every registered format, not only files matching the
+// tree-wide Init.Format.
+func TestGetBlueprintFileOrder_MixedFormatTree(t *testing.T) {
+	dir := t.TempDir()
+	for _, f := range []string{"packages/base.yaml", "files/conf.toml", "services/svc.json"} {
+		path := filepath.Join(dir, f)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	initConfig := &types.InitConfig{}
+	initConfig.Init.Format = "yaml"
+
+	fileOrder, err := GetBlueprintFileOrder(dir, nil, false, initConfig)
+	if err != nil {
+		t.Fatalf("GetBlueprintFileOrder: %v", err)
+	}
+	for bucket, wantFile := range map[string]string{
+		types.BlueprintTypePackages: filepath.Join("packages", "base.yaml"),
+		types.BlueprintTypeFiles:    filepath.Join("files", "conf.toml"),
+		types.BlueprintTypeServices: filepath.Join("services", "svc.json"),
+	} {
+		got := fileOrder[bucket]
+		if len(got) != 1 || got[0] != wantFile {
+			t.Errorf("bucket %s = %v, want [%s]", bucket, got, wantFile)
+		}
+	}
+}

--- a/internal/processors/bootstrap.go
+++ b/internal/processors/bootstrap.go
@@ -41,14 +41,20 @@ func ProcessBootstrap(blueprintFile string, initConfig *types.InitConfig, osInfo
 
 	blueprintDir := filepath.Dir(blueprintFile)
 
+	// Per-file via the registry; Init.Format is only the fallback for the
+	// no-file case (inline bootstrap data).
 	format := initConfig.Init.Format
 	if blueprintFile != "" {
-		format = filepath.Ext(blueprintFile)
+		derived, err := helpers.FormatForPath(blueprintFile)
+		if err != nil {
+			return err
+		}
+		format = derived
 	}
 
 	// Unmarshal the blueprint data
 	log.Debugf("Unmarshaling bootstrap data from %s", blueprintFile)
-	err = helpers.DecodeBlueprintInto(blueprintData, filepath.Ext(blueprintFile),
+	err = helpers.DecodeBlueprintInto(blueprintData, format,
 		types.BlueprintTypeBootstrap, helpers.TreeSchemaVersion(initConfig), &bootstrapData)
 	if err != nil {
 		log.Errorf("Error unmarshaling bootstrap blueprint: %v", err)

--- a/internal/processors/initialize.go
+++ b/internal/processors/initialize.go
@@ -79,8 +79,9 @@ func Initialize(initFilePath string, flags types.Flags) (*types.InitConfig, erro
 	if err != nil {
 		return nil, fmt.Errorf("error processing init file as a template: %w", err)
 	}
-	// Convert TOML to YAML if necessary
-	if fileExt == ".toml" {
+	// Convert TOML to YAML if necessary (the registry decides what counts as
+	// TOML rather than a literal extension compare).
+	if format, formatErr := helpers.FormatForPath(tempInitFile); formatErr == nil && format == types.FormatTOML {
 		processedInit, fileExt, err = convertTomlToYaml(processedInit)
 		if err != nil {
 			return nil, err

--- a/internal/processors/profiles.go
+++ b/internal/processors/profiles.go
@@ -46,12 +46,6 @@ func CollectProfiles(initConfig *types.InitConfig) (*ProfileSummary, error) {
 		return finish(summary), nil
 	}
 
-	format := initConfig.Init.Format
-	if format == "" {
-		format = types.FormatYAML
-	}
-	wantExt := "." + format
-
 	err := filepath.WalkDir(location, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -62,7 +56,9 @@ func CollectProfiles(initConfig *types.InitConfig) (*ProfileSummary, error) {
 			}
 			return nil
 		}
-		if filepath.Ext(path) != wantExt {
+		// Per-file via the registry: filtering on the tree-wide Init.Format
+		// made profile discovery blind to every blueprint in another format.
+		if !helpers.IsBlueprintFile(path) {
 			return nil
 		}
 		base := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
@@ -87,6 +83,11 @@ func CollectProfiles(initConfig *types.InitConfig) (*ProfileSummary, error) {
 			return nil
 		}
 
+		format, formatErr := helpers.FormatForPath(path)
+		if formatErr != nil {
+			log.Warnf("Could not determine format of %s: %v", path, formatErr)
+			return nil
+		}
 		if err := collectFromFile(summary, resolved, format, blueprintType); err != nil {
 			log.Warnf("Could not read profiles from %s: %v", path, err)
 			return nil

--- a/internal/processors/profiles_discovery_test.go
+++ b/internal/processors/profiles_discovery_test.go
@@ -136,3 +136,32 @@ func TestCollectProfiles_EmptyTreeReportsNothing(t *testing.T) {
 		t.Fatalf("empty tree reported %v / %d base items", summary.Names, summary.BaseItems)
 	}
 }
+
+// Format is derived per file: a tree mixing formats used to be visible only to
+// the half of the code that derived per file, while profile discovery and the
+// run-order walk filtered on the tree-wide Init.Format and skipped the rest.
+func TestCollectProfiles_MixedFormatTree(t *testing.T) {
+	root := writeBlueprintTree(t, map[string]string{
+		"packages/base.yaml": "packages:\n  - name: git\n    action: install\n    profiles: [dev]\n",
+		"files/conf.toml":    "[[files]]\nname = \"conf\"\naction = \"create\"\ntarget = \"/tmp/conf\"\ncontent = \"x\"\nprofiles = [\"work\"]\n",
+	})
+
+	summary, err := CollectProfiles(treeConfig(root))
+	if err != nil {
+		t.Fatalf("CollectProfiles: %v", err)
+	}
+	if summary.Files != 2 {
+		t.Errorf("Files = %d, want 2 (both formats seen)", summary.Files)
+	}
+	for _, want := range []string{"dev", "work"} {
+		found := false
+		for _, name := range summary.Names {
+			if name == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("profile %q not discovered; got %v", want, summary.Names)
+		}
+	}
+}

--- a/internal/validate/blueprints.go
+++ b/internal/validate/blueprints.go
@@ -45,7 +45,6 @@ func ValidateBlueprints(path string, verbose bool, results *types.ValidationResu
 	// top directory meant `rwr validate` on such a tree checked the init file and
 	// nothing else, and reported success. The command an operator runs to find out
 	// whether their configuration is sound was inspecting one file out of dozens.
-	initExt := filepath.Ext(initFile)
 
 	err = filepath.WalkDir(path, func(filePath string, entry fs.DirEntry, err error) error {
 		if err != nil {
@@ -61,7 +60,10 @@ func ValidateBlueprints(path string, verbose bool, results *types.ValidationResu
 			return nil
 		}
 
-		if filePath == initFile || filepath.Ext(filePath) != initExt {
+		// Per-file via the registry: filtering on the init file's extension
+		// silently skipped every blueprint written in another format, so a
+		// mixed tree validated only the files that happened to match init.
+		if filePath == initFile || !helpers.IsBlueprintFile(filePath) {
 			return nil
 		}
 
@@ -93,6 +95,13 @@ func isInitFileName(name string) bool {
 	return base == "init"
 }
 
+// isBootstrapFileName reports whether a filename is a bootstrap file, in any
+// registered format.
+func isBootstrapFileName(name string) bool {
+	base := strings.TrimSuffix(name, filepath.Ext(name))
+	return base == "bootstrap" && helpers.IsBlueprintFile(name)
+}
+
 // findInitFile searches for an init file in the specified directory (non-recursive).
 func findInitFile(dir string) string {
 	// Check for init files with common extensions
@@ -119,7 +128,12 @@ func validateInitFile(initFile string, results *types.ValidationResults) (*types
 	}
 
 	// Unmarshal the init file data
-	err = helpers.UnmarshalBlueprint(initData, filepath.Ext(initFile)[1:], &initConfig)
+	initFormat, formatErr := helpers.FormatForPath(initFile)
+	if formatErr != nil {
+		AddIssue(results, types.ValidationError, formatErr.Error(), initFile, 0, "Use a file with a supported blueprint extension")
+		return nil, nil
+	}
+	err = helpers.UnmarshalBlueprint(initData, initFormat, &initConfig)
 	if err != nil {
 		AddIssue(results, types.ValidationError, fmt.Sprintf("Error unmarshaling init file: %s", err), initFile, 0, "Check file format and syntax")
 		return nil, nil
@@ -208,10 +222,9 @@ func validateBlueprintFile(blueprintFile string, initConfig *types.InitConfig, r
 	dir := filepath.Base(filepath.Dir(blueprintFile))
 
 	var blueprintType string
-	switch filename {
-	case "bootstrap.yaml", "bootstrap.yml", "bootstrap.json", "bootstrap.toml":
+	if isBootstrapFileName(filename) {
 		blueprintType = types.BlueprintTypeBootstrap
-	default:
+	} else {
 		blueprintType = strings.ToLower(dir)
 	}
 
@@ -228,7 +241,12 @@ func validateBlueprintFile(blueprintFile string, initConfig *types.InitConfig, r
 		return nil
 	}
 
-	return validator(blueprintFileData, filepath.Ext(blueprintFile)[1:], blueprintFile, results)
+	format, formatErr := helpers.FormatForPath(blueprintFile)
+	if formatErr != nil {
+		AddIssue(results, types.ValidationError, formatErr.Error(), blueprintFile, 0, "Use a file with a supported blueprint extension")
+		return nil
+	}
+	return validator(blueprintFileData, format, blueprintFile, results)
 }
 
 // blueprintValidator unmarshals and validates a single blueprint type.

--- a/internal/validate/helpers.go
+++ b/internal/validate/helpers.go
@@ -110,11 +110,11 @@ func validateImportWithVisited(importPath string, fieldPath string, blueprintDir
 		return true
 	}
 
-	fileFormat := strings.TrimPrefix(filepath.Ext(absPath), ".")
-	if fileFormat == "" {
+	fileFormat, formatErr := helpers.FormatForPath(absPath)
+	if formatErr != nil {
 		AddIssue(results, types.ValidationWarning,
-			fmt.Sprintf("Import file '%s' has no extension, cannot determine format", importPath),
-			file, 0, "Use a file with .yaml, .json, or .toml extension")
+			fmt.Sprintf("Cannot determine format of import file '%s': %v", importPath, formatErr),
+			file, 0, "Use a file with a supported blueprint extension")
 		return true
 	}
 

--- a/openspec/changes/add-format-registry/tasks.md
+++ b/openspec/changes/add-format-registry/tasks.md
@@ -1,13 +1,13 @@
 # Tasks
 
-- [ ] 1. Add format registry: extensions set, `FormatForPath(path) (Format, error)`,
+- [x] 1. Add format registry: extensions set, `FormatForPath(path) (Format, error)`,
       `CandidateFilenames(base) []string`, decoder dispatch. Unit tests, including
       extensionless and unknown extensions (fails today via `all.go:148` panic).
-- [ ] 2. Replace the hardcoded extension lists in `cmd/`, `internal/processors/`,
+- [x] 2. Replace the hardcoded extension lists in `cmd/`, `internal/processors/`,
       `internal/helpers/`, `internal/validate/` with registry calls.
-- [ ] 3. Remove tree-uniform `Init.Format` assumption in
+- [x] 3. Remove tree-uniform `Init.Format` assumption in
       `processors/blueprints.go` and `processors/profiles.go`; add a test with a
       mixed-format tree (fails without the change).
-- [ ] 4. Fix `rwr.init-file` vs `repository.init-file` binding; test that
+- [x] 4. Fix `rwr.init-file` vs `repository.init-file` binding; test that
       `--init-file` and the config key resolve identically (fails today).
-- [ ] 5. `mise run ci` green; `examples/` unchanged and passing.
+- [x] 5. `mise run ci` green; `examples/` unchanged and passing.


### PR DESCRIPTION
Implements the **add-format-registry** OpenSpec change (Wave 2 prerequisite — unblocks `add-cue-blueprints` and `add-blueprint-manifest`). Tasks 5/5 complete; spec deltas were already authored in the change (#197).

## What

- **`internal/helpers/format_registry.go`** — the single source of format knowledge: `KnownExtensions` (preference order: yaml, yml, json, toml), `FormatForPath` (diagnostic error naming the path instead of the `filepath.Ext(file)[1:]` **panic** on extensionless files), `IsBlueprintFile`, `CandidateFilenames`, `CanonicalFormat`. `unmarshalBlueprint` now dispatches on canonical names.
- **All ~15 hardcoded sites replaced**: `findBootstrapFile`, `all.go` format derivation, `init_source.go` candidate names, `initialize.go` TOML conversion check, `bootstrap.go`, `resolve_imports.go`, `validate/{blueprints,helpers}.go`, `cmd/validate.go`.
- **Per-file format everywhere** (tree-uniform `Init.Format` assumption removed): the run-order walk, profile discovery, and validate's tree walk accept any registered extension. Previously a mixed tree was half-visible — validate literally skipped every blueprint whose extension differed from the init file's.
- **Import formats fixed**: the imported file's own extension wins; the parent's format is only the fallback for unrecognized extensions. It was backwards — a `.toml` import in a `.yaml` tree went to the YAML decoder.
- Task 4 (init-file viper binding) was already delivered by #211 and is marked complete in the change.

## Tests

Registry unit tests (extensionless/unknown ⇒ diagnostics, per the spec scenario), `TestGetBlueprintFileOrder_MixedFormatTree`, `TestCollectProfiles_MixedFormatTree` (both fail without the change). Full `-race` suite, lint, gosec green; `rwr validate` run over all 22 example trees unchanged.

## Breaking-change statement

Nothing breaks for existing blueprints. A mixed-format tree — previously undefined behavior — becomes supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)