### PR TITLE
feat(blueprints): unify semantics, close the download-integrity schema gaps

### DIFF
--- a/cmd/all.go
+++ b/cmd/all.go
@@ -1,34 +1,15 @@
 package cmd
 
 import (
-	"fmt"
-
-	"charm.land/log/v2"
-	"github.com/fynxlabs/rwr/internal/processors"
-
 	"github.com/spf13/cobra"
 )
 
 var allCmd = &cobra.Command{
 	Use:   "all",
 	Short: "Run All Blueprints - New System Initialization",
+	Long:  `Run everything. Same as bare "rwr run".`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Handle GitHub OAuth authentication if --gh-auth flag is set
-		if ghAuth {
-			token, err := processors.AuthenticateWithGitHub(initConfig)
-			if err != nil {
-				return fmt.Errorf("GitHub authentication failed: %w", err)
-			}
-			// Update the token in both global var and initConfig
-			ghApiToken = token
-			initConfig.Variables.Flags.GHAPIToken = token
-		}
-
-		log.Debugf("ForceBootstrap: %v", initConfig.Variables.Flags.ForceBootstrap)
-		if err := processors.All(initConfig, osInfo, nil); err != nil {
-			return fmt.Errorf("error running all processors: %w", err)
-		}
-		return nil
+		return runEverything()
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,10 @@ git checkouts, scripts, and desktop configuration.`,
 	// own line as well produced every failure twice.
 	SilenceUsage:  true,
 	SilenceErrors: true,
+	// Cobra's default arg validation rejects anything that is not a declared
+	// subcommand before RunE ever sees it; the task-runner shorthand
+	// (`rwr packages`) needs the args to reach RunE.
+	Args: cobra.ArbitraryArgs,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Skip initialization for these commands
 		skipInit := map[string]bool{
@@ -65,13 +69,23 @@ git checkouts, scripts, and desktop configuration.`,
 
 		return initializeSystemInfo()
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Processor names work straight off the root, task-runner style:
+		// `rwr packages` is `rwr run packages`. They are not part of the
+		// prime command namespace, so there is nothing to collide with.
+		if len(args) > 0 {
+			if p, ok := processorShorthand(args[0]); ok {
+				return runOneProcessor(p)
+			}
+			if err := cmd.Help(); err != nil {
+				return err
+			}
+			return fmt.Errorf("unknown command or processor %q", args[0])
+		}
+
 		fmt.Println("Welcome to rwr - The Distrohopper's Friend!")
 		log.Debugf("Variables: %+v", initConfig.Variables)
-		err := cmd.Help()
-		if err != nil {
-			return
-		}
+		return cmd.Help()
 	},
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,43 +3,66 @@ package cmd
 import (
 	"fmt"
 
+	"charm.land/log/v2"
+
 	"github.com/fynxlabs/rwr/internal/processors"
 
 	"github.com/spf13/cobra"
 )
 
 var runCmd = &cobra.Command{
-	Use:   "run <processor>",
-	Short: "Run an individual processor",
-	Long: `Run a single processor instead of the whole blueprint.
+	Use:   "run [processor]",
+	Short: "Run the blueprints — everything, or a single processor",
+	Long: `Run the blueprint tree.
 
-"run" is not a command on its own: it needs the name of the processor to run,
-for example "rwr run packages" or "rwr run files". To run everything, use
-"rwr all".`,
-	// A parent command with no action silently prints help and exits 0, which
-	// reads like a successful run that did nothing. Make the miss explicit.
+"rwr run" on its own runs everything, the same as "rwr all". Name a processor
+to run just that piece: "rwr run packages", "rwr run files".`,
+	// Bare `rwr run` is the landing command: it runs the whole tree. It used
+	// to print help and error, while the docs told people to run it.
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := cmd.Help(); err != nil {
-			return err
+		if len(args) > 0 {
+			if err := cmd.Help(); err != nil {
+				return err
+			}
+			return fmt.Errorf("unknown processor %q (see the list above)", args[0])
 		}
-		if len(args) == 0 {
-			return fmt.Errorf("run needs a processor to run (see the list above), or use \"rwr all\" to run everything")
-		}
-		return fmt.Errorf("unknown processor %q (see the list above)", args[0])
+		return runEverything()
 	},
+}
+
+// runEverything is the whole-tree run both `rwr run` and `rwr all` dispatch.
+func runEverything() error {
+	// Handle GitHub OAuth authentication if --gh-auth flag is set
+	if ghAuth {
+		token, err := processors.AuthenticateWithGitHub(initConfig)
+		if err != nil {
+			return fmt.Errorf("GitHub authentication failed: %w", err)
+		}
+		// Update the token in both global var and initConfig
+		ghApiToken = token
+		initConfig.Variables.Flags.GHAPIToken = token
+	}
+
+	log.Debugf("ForceBootstrap: %v", initConfig.Variables.Flags.ForceBootstrap)
+	if err := processors.All(initConfig, osInfo, nil); err != nil {
+		return fmt.Errorf("error running all processors: %w", err)
+	}
+	return nil
 }
 
 // runProcessors maps each subcommand to the blueprint type it dispatches. One
 // table instead of ten hand-written near-identical command declarations: the
 // subcommand names and behavior are unchanged.
-var runProcessors = []struct {
+type runProcessorSpec struct {
 	use       string
 	short     string
 	blueprint string
 	// ssh_keys is the one processor with pre-work: --gh-auth runs the GitHub
 	// device flow before the processor needs the token.
 	githubAuth bool
-}{
+}
+
+var runProcessors = []runProcessorSpec{
 	{use: "packages", short: "Run packages processor", blueprint: "packages"},
 	{use: "repository", short: "Run repository processor", blueprint: "repositories"},
 	{use: "services", short: "Run services processor", blueprint: "services"},
@@ -52,6 +75,33 @@ var runProcessors = []struct {
 	{use: "fonts", short: "Run fonts processor", blueprint: "fonts"},
 }
 
+// runOneProcessor dispatches a single processor, shared by the `rwr run <p>`
+// subcommands and the root-level shorthand (`rwr packages`, mise-style).
+func runOneProcessor(p runProcessorSpec) error {
+	if p.githubAuth && ghAuth {
+		token, err := processors.AuthenticateWithGitHub(initConfig)
+		if err != nil {
+			return fmt.Errorf("GitHub authentication failed: %w", err)
+		}
+		// Update the token in both global var and initConfig
+		ghApiToken = token
+		initConfig.Variables.Flags.GHAPIToken = token
+	}
+	return processors.All(initConfig, osInfo, []string{p.blueprint})
+}
+
+// processorShorthand resolves a root-level argument to a processor, so
+// `rwr packages` works like `rwr run packages` — the processor names are not
+// part of the prime command namespace, exactly like a task runner's tasks.
+func processorShorthand(name string) (runProcessorSpec, bool) {
+	for _, p := range runProcessors {
+		if p.use == name {
+			return p, true
+		}
+	}
+	return runProcessorSpec{}, false
+}
+
 func init() {
 	rootCmd.AddCommand(runCmd)
 
@@ -60,16 +110,7 @@ func init() {
 			Use:   p.use,
 			Short: p.short,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				if p.githubAuth && ghAuth {
-					token, err := processors.AuthenticateWithGitHub(initConfig)
-					if err != nil {
-						return fmt.Errorf("GitHub authentication failed: %w", err)
-					}
-					// Update the token in both global var and initConfig
-					ghApiToken = token
-					initConfig.Variables.Flags.GHAPIToken = token
-				}
-				return processors.All(initConfig, osInfo, []string{p.blueprint})
+				return runOneProcessor(p)
 			},
 		})
 	}

--- a/docs/init-file.md
+++ b/docs/init-file.md
@@ -85,18 +85,6 @@ The `packageManagers` section defines the configuration settings for package man
 | `action` | The action to perform (install, remove) | Yes |
 | `asUser` | The user to run the package manager commands as | No |
 
-### `repositories`
-
-The `repositories` section defines the configuration settings for repositories.
-
-| Field | Description | Required |
-|-------|-------------|----------|
-| `name` | The name of the repository | Yes |
-| `package_manager` | The package manager associated with the repository | Yes |
-| `action` | The action to perform (add, remove) | Yes |
-| `url` | The URL of the repository | Yes |
-| `key_url` | The URL of the repository's signing key | No |
-
 ### `variables`
 
 The `variables` section holds the custom variables that your blueprints can read.
@@ -142,12 +130,6 @@ packageManagers:
   - name: brew
     action: install
 
-repositories:
-  - name: homebrew-core
-    package_manager: brew
-    action: add
-    url: https://github.com/Homebrew/homebrew-core.git
-
 variables:
   userDefined:
     app_version: 1.0.0
@@ -156,7 +138,7 @@ variables:
 
 In this example, the Init file specifies the format and location of the blueprint
 files and the order of execution. It also configures package managers,
-repositories, and defines custom variables. A blueprint in this tree reads them
+and defines custom variables. A blueprint in this tree reads them
 as `{{ .UserDefined.app_version }}` and `{{ .UserDefined.api_key }}`.
 
 ### Package Manager Installation

--- a/examples/alternative_layouts/flattened/README.md
+++ b/examples/alternative_layouts/flattened/README.md
@@ -54,15 +54,15 @@ Choose your preferred format:
 ```bash
 # YAML format
 cd flattened/yaml
-rwr all
+rwr run
 
 # JSON format
 cd flattened/json
-rwr all
+rwr run
 
 # TOML format
 cd flattened/toml
-rwr all
+rwr run
 ```
 
 RWR will automatically discover and process all files with the specified format extension in the directory, regardless of their names.

--- a/examples/alternative_layouts/flattened/README.md
+++ b/examples/alternative_layouts/flattened/README.md
@@ -54,15 +54,15 @@ Choose your preferred format:
 ```bash
 # YAML format
 cd flattened/yaml
-rwr run
+rwr all
 
 # JSON format
 cd flattened/json
-rwr run
+rwr all
 
 # TOML format
 cd flattened/toml
-rwr run
+rwr all
 ```
 
 RWR will automatically discover and process all files with the specified format extension in the directory, regardless of their names.

--- a/examples/alternative_layouts/minimal_files/README.md
+++ b/examples/alternative_layouts/minimal_files/README.md
@@ -46,15 +46,15 @@ Choose your preferred format and run:
 ```bash
 # YAML format
 cd yaml
-rwr run
+rwr all
 
 # JSON format
 cd json
-rwr run
+rwr all
 
 # TOML format
 cd toml
-rwr run
+rwr all
 ```
 
 ## What This Demonstrates

--- a/examples/alternative_layouts/minimal_files/README.md
+++ b/examples/alternative_layouts/minimal_files/README.md
@@ -46,15 +46,15 @@ Choose your preferred format and run:
 ```bash
 # YAML format
 cd yaml
-rwr all
+rwr run
 
 # JSON format
 cd json
-rwr all
+rwr run
 
 # TOML format
 cd toml
-rwr all
+rwr run
 ```
 
 ## What This Demonstrates

--- a/internal/helpers/template.go
+++ b/internal/helpers/template.go
@@ -3,6 +3,8 @@ package helpers
 import (
 	"bytes"
 	"fmt"
+	"regexp"
+	"sort"
 	"text/template"
 
 	"charm.land/log/v2"
@@ -66,4 +68,39 @@ func resolveTemplate(templateData []byte, variables types.Variables, missingKey 
 	}
 
 	return renderedTemplate.Bytes(), nil
+}
+
+// builtinRefPattern matches simple references into the fixed template
+// namespaces — {{ .User.home }}, {{ if .System.os }} — whose keys are known at
+// validate time, unlike UserDefined's.
+var builtinRefPattern = regexp.MustCompile(`\.(User|System|Flags)\.([A-Za-z0-9_]+)`)
+
+// UnknownTemplateReferences reports references into the User, System, and
+// Flags namespaces that name no existing key. UserDefined is deliberately
+// exempt: its values vary per machine, so a reference to one is not a defect
+// validate can report. The fixed namespaces have no such excuse — validate
+// used to render every namespace with missingkey=zero, so a typo like
+// {{ .User.hoem }} validated clean and failed at run time.
+func UnknownTemplateReferences(templateData []byte, variables types.Variables) []string {
+	namespaces := map[string]map[string]interface{}{
+		"User":   variables.User.ToMap(),
+		"System": variables.System.ToMap(),
+		"Flags":  variables.Flags.ToMap(),
+	}
+
+	var unknown []string
+	seen := map[string]bool{}
+	for _, match := range builtinRefPattern.FindAllSubmatch(templateData, -1) {
+		namespace, key := string(match[1]), string(match[2])
+		ref := "." + namespace + "." + key
+		if seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		if _, ok := namespaces[namespace][key]; !ok {
+			unknown = append(unknown, ref)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
 }

--- a/internal/processors/all.go
+++ b/internal/processors/all.go
@@ -162,31 +162,39 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 					return fmt.Errorf("error resolving variables in %s: %w", processor, err)
 				}
 
+				// A multi-type file (content-routed into several buckets) is cut
+				// down to this processor's sections; single-type files pass
+				// through untouched and keep strict decode's typo protection.
+				resolvedBlueprint, format, err = subsetForProcessor(resolvedBlueprint, format, processor)
+				if err != nil {
+					return fmt.Errorf("error preparing %s for the %s processor: %w", blueprintFile, processor, err)
+				}
+
 				switch processor {
 				case types.BlueprintTypeRepositories:
 					log.Infof("Processing repositories")
-					err = ProcessRepositories(resolvedBlueprint, format, osInfo, initConfig)
+					err = ProcessRepositories(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
 				case types.BlueprintTypePackages:
 					log.Infof("Processing packages")
-					err = ProcessPackages(resolvedBlueprint, nil, format, osInfo, initConfig)
+					err = ProcessPackages(resolvedBlueprint, nil, blueprintDir, format, osInfo, initConfig)
 				case types.BlueprintTypeFiles:
 					log.Infof("Processing files")
 					err = ProcessFiles(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
 				case types.BlueprintTypeServices:
 					log.Infof("Processing services")
-					err = ProcessServices(resolvedBlueprint, format, osInfo, initConfig)
+					err = ProcessServices(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
 				case types.BlueprintTypeUsers:
 					log.Infof("Processing users")
-					err = ProcessUsers(resolvedBlueprint, format, initConfig)
+					err = ProcessUsers(resolvedBlueprint, blueprintDir, format, initConfig)
 				case types.BlueprintTypeGit:
 					log.Infof("Processing git repositories")
-					err = ProcessGitRepositories(resolvedBlueprint, format, initConfig)
+					err = ProcessGitRepositories(resolvedBlueprint, blueprintDir, format, initConfig)
 				case types.BlueprintTypeScripts:
 					log.Infof("Processing scripts")
 					err = ProcessScripts(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
 				case types.BlueprintTypeSSHKeys:
 					log.Infof("Processing ssh keys")
-					err = ProcessSSHKeys(resolvedBlueprint, format, osInfo, initConfig)
+					err = ProcessSSHKeys(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
 				case types.BlueprintTypeFonts:
 					log.Info("Processing fonts")
 					err = ProcessFonts(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)

--- a/internal/processors/blueprints.go
+++ b/internal/processors/blueprints.go
@@ -1,6 +1,7 @@
 package processors
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -172,20 +173,34 @@ func GetBlueprintFileOrder(blueprintDir string, order []interface{}, runOnlyList
 		return filepath.Dir(path)
 	}
 
-	// The run loop only executes buckets named after a processor. A file whose
-	// path matches none lands in a directory-named bucket ("." for a top-level
-	// file) that nothing ever reads — the flattened/minimal_files example
-	// layouts hit exactly this and exited 0 having executed nothing. Until
-	// detection is content-based, the least we owe the operator is a loud
-	// statement that the file will not run.
-	warnIfUnrouted := func(processor, relPath string) {
+	isKnownProcessor := func(processor string) bool {
 		switch processor {
 		case types.BlueprintTypePackages, types.BlueprintTypeRepositories, types.BlueprintTypeFiles, types.BlueprintTypeServices, types.BlueprintTypeUsers,
 			types.BlueprintTypeGit, types.BlueprintTypeScripts, types.BlueprintTypeSSHKeys, types.BlueprintTypeFonts, types.BlueprintTypeConfiguration:
-			return
+			return true
 		}
-		log.Warnf("Blueprint file %s is not under a recognized processor directory and will NOT be executed. "+
-			"Move it under one of: packages/, repositories/, files/, services/, users/, git/, scripts/, ssh_keys/, fonts/, configuration/.", relPath)
+		return false
+	}
+
+	// The run loop only executes buckets named after a processor. A file whose
+	// path names none is typed by its content instead — the flattened and
+	// minimal_files layouts the examples ship have no processor directories at
+	// all, and used to land in a dead bucket and exit 0 having executed
+	// nothing. A multi-type file (minimal_files' all_in_one) routes to every
+	// type it declares; the dispatch subsets it per processor. A file whose
+	// content matches nothing gets a loud statement that it will not run.
+	routeByPath := func(absPath, relPath string) []string {
+		processor := getProcessorType(relPath)
+		if isKnownProcessor(processor) {
+			return []string{processor}
+		}
+		if detected := detectBlueprintTypesFromContent(absPath, initConfig); len(detected) > 0 {
+			log.Debugf("Blueprint file %s routed to %v by its content", relPath, detected)
+			return detected
+		}
+		log.Warnf("Blueprint file %s is not under a recognized processor directory and its content matches no blueprint type; it will NOT be executed. "+
+			"Move it under one of: packages/, repositories/, files/, services/, users/, git/, scripts/, ssh_keys/, fonts/, configuration/ — or give it top-level blueprint keys.", relPath)
+		return []string{processor}
 	}
 
 	// The init file configures the run and bootstrap is dispatched separately
@@ -213,10 +228,10 @@ func GetBlueprintFileOrder(blueprintDir string, order []interface{}, runOnlyList
 							if err != nil {
 								return err
 							}
-							processor := getProcessorType(relPath)
-							warnIfUnrouted(processor, relPath)
-							fileOrder[processor] = append(fileOrder[processor], relPath)
-							log.Debugf("Added file to processor %s: %s", processor, relPath)
+							for _, processor := range routeByPath(path, relPath) {
+								fileOrder[processor] = append(fileOrder[processor], relPath)
+								log.Debugf("Added file to processor %s: %s", processor, relPath)
+							}
 						}
 						return nil
 					})
@@ -248,14 +263,14 @@ func GetBlueprintFileOrder(blueprintDir string, order []interface{}, runOnlyList
 				if err != nil {
 					return err
 				}
-				processor := getProcessorType(relPath)
-				warnIfUnrouted(processor, relPath)
-				if _, exists := fileOrder[processor]; !exists {
-					fileOrder[processor] = []string{relPath}
-				} else if !helpers.Contains(fileOrder[processor], relPath) {
-					fileOrder[processor] = append(fileOrder[processor], relPath)
+				for _, processor := range routeByPath(path, relPath) {
+					if _, exists := fileOrder[processor]; !exists {
+						fileOrder[processor] = []string{relPath}
+					} else if !helpers.Contains(fileOrder[processor], relPath) {
+						fileOrder[processor] = append(fileOrder[processor], relPath)
+					}
+					log.Debugf("Added additional file to processor %s: %s", processor, relPath)
 				}
-				log.Debugf("Added additional file to processor %s: %s", processor, relPath)
 			}
 			return nil
 		})
@@ -273,4 +288,111 @@ func GetBlueprintFileOrder(blueprintDir string, order []interface{}, runOnlyList
 	}
 
 	return fileOrder, nil
+}
+
+// blueprintKeyToType maps a file's top-level keys to the processor that reads
+// them, for content-based routing when the path names no processor directory.
+var blueprintKeyToType = map[string]string{
+	"packages":       types.BlueprintTypePackages,
+	"repositories":   types.BlueprintTypeRepositories,
+	"files":          types.BlueprintTypeFiles,
+	"templates":      types.BlueprintTypeFiles,
+	"directories":    types.BlueprintTypeFiles,
+	"services":       types.BlueprintTypeServices,
+	"git":            types.BlueprintTypeGit,
+	"scripts":        types.BlueprintTypeScripts,
+	"ssh_keys":       types.BlueprintTypeSSHKeys,
+	"fonts":          types.BlueprintTypeFonts,
+	"users":          types.BlueprintTypeUsers,
+	"groups":         types.BlueprintTypeUsers,
+	"configurations": types.BlueprintTypeConfiguration,
+}
+
+// detectBlueprintTypesFromContent types a blueprint by its top-level keys,
+// returning every matched type in run-order-stable form. Templates are
+// resolved leniently first — content routing happens before the run renders
+// anything for real.
+func detectBlueprintTypesFromContent(path string, initConfig *types.InitConfig) []string {
+	top, _, err := decodeTopLevel(path, initConfig)
+	if err != nil {
+		return nil
+	}
+
+	seen := map[string]bool{}
+	var detected []string
+	for key := range top {
+		blueprintType, known := blueprintKeyToType[key]
+		if known && !seen[blueprintType] {
+			seen[blueprintType] = true
+			detected = append(detected, blueprintType)
+		}
+	}
+	sort.Strings(detected)
+	return detected
+}
+
+// decodeTopLevel reads a blueprint's top-level mapping leniently.
+func decodeTopLevel(path string, initConfig *types.InitConfig) (map[string]interface{}, string, error) {
+	format, err := helpers.FormatForPath(path)
+	if err != nil {
+		return nil, "", err
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- read-only inspection of the operator's own blueprint tree
+	if err != nil {
+		return nil, "", err
+	}
+	resolved, err := helpers.ResolveTemplateForValidation(data, initConfig.Variables)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var top map[string]interface{}
+	if err := helpers.UnmarshalBlueprint(resolved, format, &top); err != nil {
+		return nil, "", err
+	}
+	return top, format, nil
+}
+
+// subsetForProcessor prepares one processor's view of a blueprint. A
+// single-type file passes through untouched, so strict decode keeps its
+// unknown-key typo protection. A multi-type file (minimal_files'
+// all_in_one.yaml) is cut down to the keys this processor reads — plus
+// schema_version — re-encoded as JSON; a top-level key belonging to no type at
+// all is an error rather than something to silently drop.
+func subsetForProcessor(resolved []byte, format, processor string) ([]byte, string, error) {
+	var top map[string]interface{}
+	if err := helpers.UnmarshalBlueprint(resolved, format, &top); err != nil {
+		return nil, "", err
+	}
+
+	typesPresent := map[string]bool{}
+	for key := range top {
+		if blueprintType, ok := blueprintKeyToType[key]; ok {
+			typesPresent[blueprintType] = true
+		}
+	}
+	if len(typesPresent) <= 1 {
+		return resolved, format, nil
+	}
+
+	subset := map[string]interface{}{}
+	for key, value := range top {
+		blueprintType, known := blueprintKeyToType[key]
+		switch {
+		case known && blueprintType == processor:
+			subset[key] = value
+		case known:
+			// Another processor's section; it gets its own dispatch.
+		case key == "schema_version" || key == "variables":
+			subset[key] = value
+		default:
+			return nil, "", fmt.Errorf("multi-type blueprint declares unknown top-level key %q", key)
+		}
+	}
+
+	out, err := json.Marshal(subset)
+	if err != nil {
+		return nil, "", fmt.Errorf("error re-encoding multi-type blueprint for %s: %w", processor, err)
+	}
+	return out, types.FormatJSON, nil
 }

--- a/internal/processors/blueprints_walk_test.go
+++ b/internal/processors/blueprints_walk_test.go
@@ -75,3 +75,50 @@ func TestGetBlueprintFileOrder_MixedFormatTree(t *testing.T) {
 		}
 	}
 }
+
+// A flattened tree — blueprint files at the root, no processor directories —
+// is routed by content: a file with a single recognized top-level key executes
+// under that processor. This is the layout examples/alternative_layouts ships,
+// which used to land in a dead bucket and exit 0 having executed nothing.
+func TestGetBlueprintFileOrder_ContentBasedDetection(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("packages.yaml", "packages:\n  - name: git\n    action: install\n")
+	write("everything.yaml", "services:\n  - name: sshd\n    action: enable\n")
+	// Multi-type: routes to every type it declares (the minimal_files layout).
+	write("mixed.yaml", "packages: []\nservices: []\n")
+
+	initConfig := &types.InitConfig{}
+	initConfig.Init.Format = "yaml"
+	initConfig.Variables.UserDefined = map[string]interface{}{}
+
+	fileOrder, err := GetBlueprintFileOrder(dir, nil, false, initConfig)
+	if err != nil {
+		t.Fatalf("GetBlueprintFileOrder: %v", err)
+	}
+
+	has := func(bucket, file string) bool {
+		for _, f := range fileOrder[bucket] {
+			if f == file {
+				return true
+			}
+		}
+		return false
+	}
+	if !has(types.BlueprintTypePackages, "packages.yaml") {
+		t.Errorf("packages bucket = %v, want packages.yaml routed", fileOrder[types.BlueprintTypePackages])
+	}
+	if !has(types.BlueprintTypeServices, "everything.yaml") {
+		t.Errorf("services bucket = %v, want everything.yaml routed", fileOrder[types.BlueprintTypeServices])
+	}
+	// The multi-type file appears in BOTH buckets; the dispatch subsets it.
+	if !has(types.BlueprintTypePackages, "mixed.yaml") || !has(types.BlueprintTypeServices, "mixed.yaml") {
+		t.Errorf("mixed.yaml not routed to both buckets: packages=%v services=%v",
+			fileOrder[types.BlueprintTypePackages], fileOrder[types.BlueprintTypeServices])
+	}
+}

--- a/internal/processors/bootstrap.go
+++ b/internal/processors/bootstrap.go
@@ -66,7 +66,7 @@ func ProcessBootstrap(blueprintFile string, initConfig *types.InitConfig, osInfo
 	packagesData := &types.PackagesData{
 		Packages: bootstrapData.Packages,
 	}
-	err = ProcessPackages(nil, packagesData, format, osInfo, initConfig)
+	err = ProcessPackages(nil, packagesData, blueprintDir, format, osInfo, initConfig)
 	if err != nil {
 		log.Errorf("Error processing packages: %v", err)
 		return err

--- a/internal/processors/bootstrap_test.go
+++ b/internal/processors/bootstrap_test.go
@@ -36,7 +36,7 @@ func TestProcessPackages_DefaultSystemState(t *testing.T) {
 		}
 
 		// With enhanced path searching, this should now find package managers and attempt installation
-		err := ProcessPackages(nil, packagesData, "yaml", osInfo, initConfig)
+		err := ProcessPackages(nil, packagesData, "", "yaml", osInfo, initConfig)
 
 		if err == nil {
 			t.Log("ProcessPackages succeeded - package manager detection working correctly")
@@ -82,7 +82,7 @@ func TestProcessPackages_DefaultSystemState(t *testing.T) {
 		}
 
 		// This should not return the "no package managers available" error
-		err := ProcessPackages(nil, packagesData, "yaml", osInfo, initConfig)
+		err := ProcessPackages(nil, packagesData, "", "yaml", osInfo, initConfig)
 
 		// We might get other errors (like package installation failures),
 		// but we specifically want to avoid the "no package managers available" error
@@ -133,7 +133,7 @@ func TestProcessPackages_DefaultSystemState(t *testing.T) {
 		}
 
 		// With enhanced path searching, this should now find system package managers
-		err := ProcessPackages(nil, packagesData, "yaml", osInfo, initConfig)
+		err := ProcessPackages(nil, packagesData, "", "yaml", osInfo, initConfig)
 
 		if err == nil {
 			t.Log("ProcessPackages succeeded - enhanced path searching found system package managers")
@@ -176,7 +176,7 @@ func TestBootstrapPackageManagerDetection(t *testing.T) {
 		}
 
 		// Test that package manager detection now works
-		err := ProcessPackages(nil, packagesData, "yaml", osInfo, initConfig)
+		err := ProcessPackages(nil, packagesData, "", "yaml", osInfo, initConfig)
 
 		// Verify package manager detection is working
 		if err == nil {
@@ -214,7 +214,7 @@ func TestBootstrapPackageManagerDetection(t *testing.T) {
 		}
 
 		// Call should complete without panic and work with enhanced path searching
-		err := ProcessPackages(nil, packagesData, "yaml", osInfo, initConfig)
+		err := ProcessPackages(nil, packagesData, "", "yaml", osInfo, initConfig)
 
 		if err == nil {
 			t.Log("ProcessPackages succeeded with debug logging enabled")
@@ -247,7 +247,7 @@ func TestPackageProcessingEdgeCases(t *testing.T) {
 
 	t.Run("NilPackagesConfig", func(t *testing.T) {
 		// Should handle nil packages config gracefully
-		err := ProcessPackages(nil, nil, "yaml", osInfo, initConfig)
+		err := ProcessPackages(nil, nil, "", "yaml", osInfo, initConfig)
 
 		// Nil config should be handled gracefully, not cause panic
 		if err != nil {
@@ -261,7 +261,7 @@ func TestPackageProcessingEdgeCases(t *testing.T) {
 		packagesData := &types.PackagesData{}
 
 		// Should handle empty packages config gracefully
-		err := ProcessPackages(nil, packagesData, "yaml", osInfo, initConfig)
+		err := ProcessPackages(nil, packagesData, "", "yaml", osInfo, initConfig)
 
 		if err != nil {
 			t.Logf("Empty packages config handled with error: %s", err.Error())
@@ -276,7 +276,7 @@ func TestPackageProcessingEdgeCases(t *testing.T) {
 		}
 
 		// Should handle empty install list gracefully
-		err := ProcessPackages(nil, packagesData, "yaml", osInfo, initConfig)
+		err := ProcessPackages(nil, packagesData, "", "yaml", osInfo, initConfig)
 
 		if err != nil {
 			t.Logf("Empty install list handled with error: %s", err.Error())
@@ -312,6 +312,6 @@ func BenchmarkProcessPackagesError(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ProcessPackages(nil, packagesData, "yaml", osInfo, initConfig)
+		ProcessPackages(nil, packagesData, "", "yaml", osInfo, initConfig)
 	}
 }

--- a/internal/processors/files.go
+++ b/internal/processors/files.go
@@ -156,7 +156,13 @@ func processFile(file types.File, blueprintDir string, osInfo *types.OSInfo) err
 			name = filepath.Base(file.Source)
 		}
 		downloadPath := filepath.Join(tempDir, name)
-		err = system.DownloadFile(file.Source, downloadPath, false)
+		// A URL source without a declared digest is trusted on nothing but the
+		// TLS connection that served it. Warn now; a later major refuses.
+		if file.Sha256 == "" {
+			log.Warnf("File %s downloads %s with no sha256 declared — the content is unpinned. "+
+				"Add sha256 to the entry; a future major version will refuse this.", file.Name, file.Source)
+		}
+		err = system.DownloadFileWithChecksum(file.Source, downloadPath, false, file.Sha256)
 		if err != nil {
 			return fmt.Errorf("error downloading file: %v", err)
 		}

--- a/internal/processors/files.go
+++ b/internal/processors/files.go
@@ -385,11 +385,11 @@ func moveFile(source, target string) error {
 		return fmt.Errorf("error creating target directory: %w", err)
 	}
 
-	if err := os.Rename(source, target); err != nil {
+	if err := os.Rename(source, target); err != nil { // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 		// A move already carried out on an earlier run has no source left. That is
 		// the state the blueprint asked for, so it is not a failure.
 		if os.IsNotExist(err) {
-			if _, statErr := os.Lstat(target); statErr == nil {
+			if _, statErr := os.Lstat(target); statErr == nil { // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 				log.Infof("File already moved: %s", target)
 				return nil
 			}
@@ -402,7 +402,7 @@ func moveFile(source, target string) error {
 }
 
 func deleteFile(target string) error {
-	if err := os.Remove(target); err != nil {
+	if err := os.Remove(target); err != nil { // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 		if os.IsNotExist(err) {
 			log.Debugf("File already absent: %s", target)
 			return nil
@@ -429,14 +429,14 @@ func createFile(file types.File, targetPath string) error {
 
 	targetDir := filepath.Dir(targetPath)
 	log.Debugf("Creating file dir: %s", targetDir)
-	if err := os.MkdirAll(targetDir, dirMode); err != nil {
+	if err := os.MkdirAll(targetDir, dirMode); err != nil { // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 		return fmt.Errorf("error creating target directory: %v", err)
 	}
 
 	// The mode is carried into the open so the content is never readable by anyone
 	// the blueprint did not name — a later chmod would leave a window in which a
 	// rendered credential sat on disk world-readable.
-	f, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY, mode) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
+	f, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY, mode) // #nosec G304 G703 -- path is operator-supplied blueprint/config input; containment added in PR8
 	if err != nil {
 		return fmt.Errorf("error creating file: %v", err)
 	}
@@ -481,7 +481,7 @@ func chmodFile(file types.File, target string) error {
 		return fmt.Errorf("no mode declared for chmod of %s: add mode: \"0644\" to the file entry", target)
 	}
 
-	if err := os.Chmod(target, file.Mode.OSMode()); err != nil {
+	if err := os.Chmod(target, file.Mode.OSMode()); err != nil { // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 		return fmt.Errorf("error changing file permissions: %w", err)
 	}
 
@@ -495,7 +495,7 @@ func chownFile(file types.File, target string) error {
 		if err != nil {
 			return fmt.Errorf("error looking up owner UID: %w", err)
 		}
-		if err := os.Chown(target, uid, -1); err != nil {
+		if err := os.Chown(target, uid, -1); err != nil { // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 			return fmt.Errorf("error changing file owner: %w", err)
 		}
 	}
@@ -505,7 +505,7 @@ func chownFile(file types.File, target string) error {
 		if err != nil {
 			return fmt.Errorf("error looking up group GID: %w", err)
 		}
-		if err := os.Chown(target, -1, gid); err != nil {
+		if err := os.Chown(target, -1, gid); err != nil { // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 			return fmt.Errorf("error changing file group: %w", err)
 		}
 	}
@@ -531,7 +531,7 @@ func symlinkFile(source, target string) error {
 // EEXIST on the second run of a blueprint, and one failing file aborts the
 // whole run.
 func ensureSymlink(source, target string) error {
-	info, err := os.Lstat(target)
+	info, err := os.Lstat(target) // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 	switch {
 	case err == nil && info.Mode()&os.ModeSymlink == 0:
 		return fmt.Errorf("cannot create symlink at %s: a regular file or directory already exists there", target)
@@ -545,14 +545,14 @@ func ensureSymlink(source, target string) error {
 			return nil
 		}
 		log.Infof("Replacing symlink %s: pointed at %s, should point at %s", target, existing, source)
-		if err := os.Remove(target); err != nil {
+		if err := os.Remove(target); err != nil { // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 			return fmt.Errorf("error removing existing symlink %s: %w", target, err)
 		}
 	case !os.IsNotExist(err):
 		return fmt.Errorf("error inspecting symlink target %s: %w", target, err)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(target), defaultDirMode); err != nil {
+	if err := os.MkdirAll(filepath.Dir(target), defaultDirMode); err != nil { // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 		return fmt.Errorf("error creating symlink parent directory: %w", err)
 	}
 
@@ -568,7 +568,7 @@ func copyDirectory(dir types.Directory, blueprintDir string, initConfig *types.I
 	source := filepath.Join(blueprintDir, dir.Source, dir.Name)
 	target := filepath.Join(system.ExpandPath(dir.Target), dir.Name)
 
-	if err := os.MkdirAll(target, directoryMode(dir)); err != nil {
+	if err := os.MkdirAll(target, directoryMode(dir)); err != nil { // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 		return fmt.Errorf("error creating target directory: %w", err)
 	}
 
@@ -621,7 +621,7 @@ func deleteDirectory(dir types.Directory) error {
 func createDirectory(dir types.Directory) error {
 	target := filepath.Join(system.ExpandPath(dir.Target), dir.Name)
 
-	if err := os.MkdirAll(target, directoryMode(dir)); err != nil {
+	if err := os.MkdirAll(target, directoryMode(dir)); err != nil { // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 		return fmt.Errorf("error creating directory: %w", err)
 	}
 
@@ -699,7 +699,7 @@ func directoryMode(dir types.Directory) os.FileMode {
 
 func applyFileAttributes(targetPath string, file types.File) error {
 	if file.Mode.IsSet() {
-		if err := os.Chmod(targetPath, file.Mode.OSMode()); err != nil {
+		if err := os.Chmod(targetPath, file.Mode.OSMode()); err != nil { // #nosec G703 -- target path is operator-supplied blueprint/config input; containment added in PR8
 			return fmt.Errorf("error changing file permissions: %v", err)
 		}
 	}

--- a/internal/processors/files_test.go
+++ b/internal/processors/files_test.go
@@ -1,10 +1,13 @@
 package processors
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/fynxlabs/rwr/internal/types"
@@ -965,6 +968,50 @@ func TestProcessFile_MetadataActionsNeedNoContentOrSource(t *testing.T) {
 		}, dir, osInfo)
 		if err == nil {
 			t.Fatal("processFile(copy without source) succeeded, want an error")
+		}
+	})
+}
+
+// A files entry with a URL source and a sha256 is verified before install; a
+// mismatch refuses and writes nothing (the digest used to be hard-coded "").
+func TestProcessFile_URLSourceSha256(t *testing.T) {
+	content := []byte("remote payload")
+	sum := sha256.Sum256(content)
+	good := hex.EncodeToString(sum[:])
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	osInfo := &types.OSInfo{}
+	run := func(t *testing.T, digest string) (string, error) {
+		t.Helper()
+		dir := t.TempDir()
+		target := filepath.Join(dir, "out")
+		err := processFile(types.File{
+			Name:   "payload",
+			Action: "copy",
+			Source: server.URL + "/payload",
+			Sha256: digest,
+			Target: target,
+		}, dir, osInfo)
+		return filepath.Join(target, "payload"), err
+	}
+
+	t.Run("matching digest installs", func(t *testing.T) {
+		if _, err := run(t, good); err != nil {
+			t.Fatalf("processFile: %v", err)
+		}
+	})
+
+	t.Run("mismatch refuses and installs nothing", func(t *testing.T) {
+		installed, err := run(t, strings.Repeat("0", 64))
+		if err == nil || !strings.Contains(err.Error(), "sha256 mismatch") {
+			t.Fatalf("err = %v, want a sha256 mismatch refusal", err)
+		}
+		if _, statErr := os.Stat(installed); statErr == nil {
+			t.Fatal("file installed despite the mismatch")
 		}
 	})
 }

--- a/internal/processors/git.go
+++ b/internal/processors/git.go
@@ -12,7 +12,7 @@ import (
 
 // ProcessGitRepositories clones or updates Git repositories defined in blueprint data,
 // with support for profile filtering and import resolution.
-func ProcessGitRepositories(blueprintData []byte, format string, initConfig *types.InitConfig) error {
+func ProcessGitRepositories(blueprintData []byte, blueprintDir string, format string, initConfig *types.InitConfig) error {
 	var gitData types.GitData
 	var err error
 
@@ -26,7 +26,6 @@ func ProcessGitRepositories(blueprintData []byte, format string, initConfig *typ
 	}
 
 	// Process imports and merge imported git repos
-	blueprintDir := initConfig.Init.Location
 	allRepos, err := processGitImports(gitData.Repos, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return fmt.Errorf("error processing git imports: %w", err)

--- a/internal/processors/imports_recursive_test.go
+++ b/internal/processors/imports_recursive_test.go
@@ -63,7 +63,7 @@ func TestImports_FollowANestedChain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ProcessPackages(data, nil, "yaml", newTestOSInfo(), init); err != nil {
+	if err := ProcessPackages(data, nil, root, "yaml", newTestOSInfo(), init); err != nil {
 		t.Fatal(err)
 	}
 
@@ -101,7 +101,7 @@ func TestImports_ResolveRelativeToTheImportingFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ProcessPackages(data, nil, "yaml", newTestOSInfo(), init); err != nil {
+	if err := ProcessPackages(data, nil, root, "yaml", newTestOSInfo(), init); err != nil {
 		t.Fatal(err)
 	}
 
@@ -128,7 +128,7 @@ func TestImports_CycleIsReported(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ProcessPackages(data, nil, "yaml", newTestOSInfo(), init)
+	err = ProcessPackages(data, nil, root, "yaml", newTestOSInfo(), init)
 	if err == nil {
 		t.Fatal("a cycle between a.yaml and b.yaml was not reported")
 	}
@@ -158,7 +158,7 @@ func TestImports_DiamondIsNotACycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ProcessPackages(data, nil, "yaml", newTestOSInfo(), init); err != nil {
+	if err := ProcessPackages(data, nil, root, "yaml", newTestOSInfo(), init); err != nil {
 		t.Fatalf("a shared file reached twice was treated as a cycle: %v", err)
 	}
 }
@@ -178,7 +178,7 @@ func TestImports_MissingFileIsReported(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ProcessPackages(data, nil, "yaml", newTestOSInfo(), init); err == nil {
+	if err := ProcessPackages(data, nil, root, "yaml", newTestOSInfo(), init); err == nil {
 		t.Fatal("a missing import file was accepted")
 	}
 }
@@ -203,11 +203,43 @@ func TestImports_SchemaVersionEnforcedThroughTheChain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ProcessPackages(data, nil, "yaml", newTestOSInfo(), init)
+	err = ProcessPackages(data, nil, root, "yaml", newTestOSInfo(), init)
 	if err == nil {
 		t.Fatalf("version 99 two levels down was accepted; %d command(s) ran", len(rec.Calls))
 	}
 	if len(rec.Calls) != 0 {
 		t.Errorf("refused chain still ran %d command(s)", len(rec.Calls))
+	}
+}
+
+// Import paths resolve relative to the file that declares them, in every
+// processor. Six processors (packages among them) used to resolve top-level
+// imports against the tree root instead, so `import: ../shared/common.yaml`
+// written in packages/base.yaml meant a different file than the same string in
+// files/base.yaml — and the spec has always mandated file-relative.
+func TestImports_TopLevelResolvesRelativeToTheBlueprintFile(t *testing.T) {
+	useTestProvider(t)
+	root := writeFiles(t, map[string]string{
+		"packages/base.yaml": "packages:\n  - import: ../shared/common.yaml\n",
+		"shared/common.yaml": "packages:\n  - name: from-shared\n    action: install\n    package_manager: pacman\n",
+	})
+
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	init := &types.InitConfig{}
+	init.Init.Location = root
+
+	data, err := os.ReadFile(filepath.Join(root, "packages", "base.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ProcessPackages(data, nil, filepath.Join(root, "packages"), "yaml", newTestOSInfo(), init); err != nil {
+		t.Fatal(err)
+	}
+
+	installed := installedNames(rec.Calls)
+	if len(installed) != 1 || installed[0] != "from-shared" {
+		t.Errorf("installed = %v, want [from-shared] resolved relative to packages/base.yaml", installed)
 	}
 }

--- a/internal/processors/imports_test.go
+++ b/internal/processors/imports_test.go
@@ -65,7 +65,7 @@ func TestPackageImports(t *testing.T) {
 	}
 
 	// Process packages (this will trigger import processing)
-	err = ProcessPackages(data, nil, "yaml", osInfo, initConfig)
+	err = ProcessPackages(data, nil, tempDir, "yaml", osInfo, initConfig)
 
 	// We expect this to fail because package managers aren't available
 	// but we can verify the import was processed by checking the error doesn't mention import issues
@@ -132,7 +132,7 @@ func TestCircularImportDetection(t *testing.T) {
 
 	// Process should complete without infinite loop
 	// Circular import should be detected and skipped
-	err = ProcessPackages(data, nil, "yaml", osInfo, initConfig)
+	err = ProcessPackages(data, nil, tempDir, "yaml", osInfo, initConfig)
 
 	// Should complete without hanging (circular detection works)
 	if err != nil && containsString(err.Error(), "circular") {
@@ -205,7 +205,7 @@ func TestMultipleImports(t *testing.T) {
 		},
 	}
 
-	err = ProcessPackages(data, nil, "yaml", osInfo, initConfig)
+	err = ProcessPackages(data, nil, tempDir, "yaml", osInfo, initConfig)
 
 	// Verify imports were processed (no import-related errors)
 	if err != nil {
@@ -257,7 +257,7 @@ func TestMissingImportFile(t *testing.T) {
 		},
 	}
 
-	err = ProcessPackages(data, nil, "yaml", osInfo, initConfig)
+	err = ProcessPackages(data, nil, tempDir, "yaml", osInfo, initConfig)
 
 	// Should fail with import error
 	if err == nil {
@@ -323,7 +323,7 @@ func TestRelativeImportPaths(t *testing.T) {
 		},
 	}
 
-	err = ProcessPackages(data, nil, "yaml", osInfo, initConfig)
+	err = ProcessPackages(data, nil, tempDir, "yaml", osInfo, initConfig)
 
 	// Verify relative import worked (no import-related errors)
 	if err != nil {

--- a/internal/processors/initialize.go
+++ b/internal/processors/initialize.go
@@ -115,6 +115,18 @@ func Initialize(initFilePath string, flags types.Flags) (*types.InitConfig, erro
 		return nil, fmt.Errorf("error unmarshaling %s: %w", processedInitFile, err)
 	}
 
+	// The inline resource sections were removed from the schema: they were
+	// decoded, validated, and never applied at runtime. Viper ignores unknown
+	// keys, so without this check a tree still carrying them would go from
+	// silent no-op to silent drop — an error naming the key is the only honest
+	// answer. (`rwr convert --migrate` is the planned mover.)
+	for _, removed := range []string{"repositories", "packages", "services", "files", "templates", "directories", "configuration"} {
+		if viper.IsSet(removed) {
+			return nil, fmt.Errorf("init file %s declares %q, which init files no longer support: "+
+				"declare it in a blueprint file under the tree instead", initFilePath, removed)
+		}
+	}
+
 	// A tree-wide schema version applies to every blueprint type, so it has to be
 	// readable everywhere. Checked here rather than per file: an unreadable tree
 	// version is wrong before a single blueprint is opened.

--- a/internal/processors/initialize_test.go
+++ b/internal/processors/initialize_test.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/fynxlabs/rwr/internal/types"
@@ -400,5 +401,29 @@ packageManagers: [{name: "brew", action: "install"}]
 	}
 	if len(initConfig.PackageManagers) != 1 || initConfig.PackageManagers[0].Name != "brew" {
 		t.Errorf("PackageManagers = %+v, want the declared brew entry", initConfig.PackageManagers)
+	}
+}
+
+// The init file's inline resource sections were decoded, validated, and never
+// applied. They are gone from the schema; strict decode turns a leftover key
+// into an error naming it instead of a silent no-op.
+func TestInitialize_InlineResourceSectionsAreRejected(t *testing.T) {
+	dir := t.TempDir()
+	initFile := filepath.Join(dir, "init.yaml")
+	content := `
+blueprints:
+  format: yaml
+  location: ` + dir + `
+packages:
+  - name: git
+    action: install
+`
+	if err := os.WriteFile(initFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Initialize(initFile, types.Flags{})
+	if err == nil || !strings.Contains(err.Error(), "packages") {
+		t.Fatalf("err = %v, want a strict-decode error naming the packages key", err)
 	}
 }

--- a/internal/processors/packages.go
+++ b/internal/processors/packages.go
@@ -23,7 +23,7 @@ import (
 //
 // Returns an error if no package managers are available or if unmarshaling fails.
 // Individual package installation errors are logged but do not stop processing.
-func ProcessPackages(data []byte, packages *types.PackagesData, format string, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
+func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir string, format string, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
 	// If data is provided, unmarshal it
 	if data != nil {
 		var pkgData types.PackagesData
@@ -40,7 +40,6 @@ func ProcessPackages(data []byte, packages *types.PackagesData, format string, o
 	}
 
 	// Process imports and merge imported packages
-	blueprintDir := initConfig.Init.Location
 	allPackages, err := helpers.ResolveImports(packages.Packages, blueprintDir,
 		func(item types.Package) string { return item.Import },
 		func(data []byte, fileFormat string) ([]types.Package, error) {
@@ -96,12 +95,17 @@ func ProcessPackages(data []byte, packages *types.PackagesData, format string, o
 			}
 		}
 
-		// Get package names
+		// Get package names. `names` wins over `name` when both are set,
+		// matching files and fonts — packages had the precedence backwards,
+		// so the same both-declared entry meant different things per type.
 		var names []string
-		if pkg.Name != "" {
-			names = []string{pkg.Name}
-		} else {
+		if len(pkg.Names) > 0 {
 			names = pkg.Names
+			if pkg.Name != "" {
+				log.Warnf("Package entry declares both name (%q) and names; processing the names list and ignoring name", pkg.Name)
+			}
+		} else if pkg.Name != "" {
+			names = []string{pkg.Name}
 		}
 
 		// Process each package

--- a/internal/processors/packages_test.go
+++ b/internal/processors/packages_test.go
@@ -4,7 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fynxlabs/rwr/internal/exectest"
 	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/types"
 )
 
@@ -579,5 +581,35 @@ func TestProcessPackages_ResolveInteractiveIntegration(t *testing.T) {
 				t.Errorf("ResolveInteractive() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// `names` wins over `name` when both are set — matching files and fonts.
+// packages had it backwards.
+func TestProcessPackages_NamesWinsOverName(t *testing.T) {
+	useTestProvider(t)
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	data := []byte("packages:\n  - name: ignored\n    names: [vim, tmux]\n    action: install\n    package_manager: pacman\n")
+	if err := ProcessPackages(data, nil, t.TempDir(), "yaml", newTestOSInfo(), &types.InitConfig{}); err != nil {
+		t.Fatalf("ProcessPackages: %v", err)
+	}
+
+	var installed []string
+	for _, call := range rec.Calls {
+		if len(call.Args) > 0 {
+			installed = append(installed, call.Args[len(call.Args)-1])
+		}
+	}
+	want := map[string]bool{"vim": true, "tmux": true}
+	for _, name := range installed {
+		if name == "ignored" {
+			t.Fatalf("name field was processed despite names being set: %v", installed)
+		}
+		delete(want, name)
+	}
+	if len(want) != 0 {
+		t.Errorf("missing installs %v; recorded %v", want, installed)
 	}
 }

--- a/internal/processors/profiles.go
+++ b/internal/processors/profiles.go
@@ -33,14 +33,6 @@ type ProfileSummary struct {
 func CollectProfiles(initConfig *types.InitConfig) (*ProfileSummary, error) {
 	summary := &ProfileSummary{Counts: map[string]int{}}
 
-	// The init file may carry entries of its own; keep counting those.
-	collectFrom(summary, initConfig.Packages)
-	collectFrom(summary, initConfig.Services)
-	collectFrom(summary, initConfig.Files)
-	collectFrom(summary, initConfig.Templates)
-	collectFrom(summary, initConfig.Directories)
-	collectFrom(summary, initConfig.Repositories)
-
 	location := initConfig.Init.Location
 	if location == "" {
 		return finish(summary), nil

--- a/internal/processors/repository.go
+++ b/internal/processors/repository.go
@@ -17,7 +17,7 @@ import (
 
 // ProcessRepositories adds or removes package manager repositories from blueprint data,
 // with support for profile filtering and import resolution.
-func ProcessRepositories(blueprintData []byte, format string, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
+func ProcessRepositories(blueprintData []byte, blueprintDir string, format string, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
 	var repositoriesBlueprint types.RepositoriesData
 	var err error
 
@@ -31,7 +31,6 @@ func ProcessRepositories(blueprintData []byte, format string, osInfo *types.OSIn
 	}
 
 	// Process imports and merge imported repositories
-	blueprintDir := initConfig.Init.Location
 	allRepositories, err := processRepositoryImports(repositoriesBlueprint.Repositories, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return fmt.Errorf("error processing repository imports: %w", err)
@@ -100,6 +99,15 @@ func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *
 	provider, exists := system.GetProvider(repo.PackageManager)
 	if !exists {
 		return fmt.Errorf("unsupported package manager: %s", repo.PackageManager)
+	}
+
+	// A signing key fetched without a declared digest is trusted on nothing
+	// but the TLS connection that served it. Warn now; a later major refuses
+	// (the policy ratchets, never loosens).
+	if repo.Action == "add" && repo.KeyURL != "" && repo.KeySha256 == "" {
+		log.Warnf("Repository %s downloads its signing key from %s with no key_sha256 declared — "+
+			"the key is unpinned. Add key_sha256 to the repository entry; a future major version will refuse this.",
+			repo.Name, repo.KeyURL)
 	}
 
 	// Get repository config
@@ -315,6 +323,7 @@ func repositoryStepData(repo types.Repository, paths types.RepositoryPaths, prov
 		"KeysPath":       paths.Keys,
 		"ConfigPath":     paths.Config,
 		"KeyPath":        keyPath,
+		"KeySha256":      repo.KeySha256,
 		"TempKeyPath":    filepath.Join(tempDir, repo.Name+".gpg"),
 		"KeyID":          repo.KeyID,
 		// The local file a snap or a GNOME extension is installed from. Only

--- a/internal/processors/repository_checksum_test.go
+++ b/internal/processors/repository_checksum_test.go
@@ -92,3 +92,58 @@ func TestProcessRepository_DownloadStepVerifiesSha256(t *testing.T) {
 		}
 	})
 }
+
+// key_sha256 pins the signing key the apt/dnf key-download step fetches. The
+// shipped apt provider's own step template carries `sha256 = "{{ .KeySha256 }}"`,
+// so the pin flows from the blueprint entry into the download verification.
+func TestProcessRepository_KeySha256PinsTheAptKey(t *testing.T) {
+	content := []byte("armored key bytes")
+	sum := sha256.Sum256(content)
+	good := hex.EncodeToString(sum[:])
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	run := func(t *testing.T, digest string) error {
+		t.Helper()
+		root := t.TempDir()
+		sourcesDir := filepath.Join(root, "sources.list.d")
+		keysDir := filepath.Join(root, "keyrings")
+		for _, dir := range []string{sourcesDir, keysDir} {
+			if err := os.MkdirAll(dir, 0o750); err != nil {
+				t.Fatal(err)
+			}
+		}
+		defer system.SetExecutor(exectest.New())()
+		defer system.SetProvidersForTest(map[string]*types.Provider{
+			"apt": providerForTest(t, "apt", sourcesDir, keysDir),
+		})()
+
+		return processRepository(types.Repository{
+			Name:           "pinned",
+			PackageManager: "apt",
+			Action:         "add",
+			URL:            "https://example.com/repo",
+			KeyURL:         server.URL + "/gpg",
+			KeySha256:      digest,
+			Arch:           "amd64",
+			Channel:        "stable",
+			Component:      "main",
+		}, &types.OSInfo{}, &types.InitConfig{})
+	}
+
+	t.Run("matching key digest proceeds", func(t *testing.T) {
+		if err := run(t, good); err != nil {
+			t.Fatalf("processRepository: %v", err)
+		}
+	})
+
+	t.Run("mismatched key digest refuses", func(t *testing.T) {
+		err := run(t, strings.Repeat("0", 64))
+		if err == nil || !strings.Contains(err.Error(), "sha256 mismatch") {
+			t.Fatalf("err = %v, want a sha256 mismatch refusal", err)
+		}
+	})
+}

--- a/internal/processors/schema_version_test.go
+++ b/internal/processors/schema_version_test.go
@@ -76,21 +76,21 @@ var unsupportedVersionCases = []struct {
 		name:      "packages",
 		blueprint: "schema_version: 99\npackages:\n  - name: git\n    action: install\n    package_manager: pacman\n",
 		run: func(data []byte, osInfo *types.OSInfo, init *types.InitConfig) error {
-			return ProcessPackages(data, nil, "yaml", osInfo, init)
+			return ProcessPackages(data, nil, "", "yaml", osInfo, init)
 		},
 	},
 	{
 		name:      "services",
 		blueprint: "schema_version: 99\nservices:\n  - name: sshd\n    action: enable\n",
 		run: func(data []byte, osInfo *types.OSInfo, init *types.InitConfig) error {
-			return ProcessServices(data, "yaml", osInfo, init)
+			return ProcessServices(data, "", "yaml", osInfo, init)
 		},
 	},
 	{
 		name:      "git",
 		blueprint: "schema_version: 99\nrepositories:\n  - name: dots\n    url: https://example.invalid/d.git\n    path: /tmp/rwr-test-dots\n",
 		run: func(data []byte, osInfo *types.OSInfo, init *types.InitConfig) error {
-			return ProcessGitRepositories(data, "yaml", init)
+			return ProcessGitRepositories(data, "", "yaml", init)
 		},
 	},
 	{
@@ -104,7 +104,7 @@ var unsupportedVersionCases = []struct {
 		name:      "users",
 		blueprint: "schema_version: 99\nusers:\n  - name: tester\n    action: create\n",
 		run: func(data []byte, osInfo *types.OSInfo, init *types.InitConfig) error {
-			return ProcessUsers(data, "yaml", init)
+			return ProcessUsers(data, "", "yaml", init)
 		},
 	},
 	{
@@ -151,7 +151,7 @@ func TestProcessors_AcceptSupportedSchemaVersion(t *testing.T) {
 	init.Init.Location = t.TempDir()
 
 	blueprint := []byte("schema_version: 1\npackages:\n  - name: git\n    action: install\n    package_manager: pacman\n")
-	if err := ProcessPackages(blueprint, nil, "yaml", newTestOSInfo(), init); err != nil {
+	if err := ProcessPackages(blueprint, nil, t.TempDir(), "yaml", newTestOSInfo(), init); err != nil {
 		t.Fatalf("schema_version 1 should be accepted: %v", err)
 	}
 	if len(rec.Calls) == 0 {
@@ -170,7 +170,7 @@ func TestProcessors_UndeclaredVersionIsAccepted(t *testing.T) {
 	init.Init.Location = t.TempDir()
 
 	blueprint := []byte("packages:\n  - name: git\n    action: install\n    package_manager: pacman\n")
-	if err := ProcessPackages(blueprint, nil, "yaml", newTestOSInfo(), init); err != nil {
+	if err := ProcessPackages(blueprint, nil, t.TempDir(), "yaml", newTestOSInfo(), init); err != nil {
 		t.Fatalf("undeclared version should resolve to latest: %v", err)
 	}
 	if len(rec.Calls) == 0 {
@@ -189,7 +189,7 @@ func TestProcessors_TreeVersionApplies(t *testing.T) {
 	init.Init.SchemaVersion = 99
 
 	blueprint := []byte("packages:\n  - name: git\n    action: install\n    package_manager: pacman\n")
-	err := ProcessPackages(blueprint, nil, "yaml", newTestOSInfo(), init)
+	err := ProcessPackages(blueprint, nil, t.TempDir(), "yaml", newTestOSInfo(), init)
 	if err == nil {
 		t.Fatalf("tree version 99 was accepted; %d command(s) ran: %+v", len(rec.Calls), rec.Calls)
 	}
@@ -210,7 +210,7 @@ func TestProcessors_FileVersionOverridesTree(t *testing.T) {
 	init.Init.SchemaVersion = 99 // unreadable tree-wide
 
 	blueprint := []byte("schema_version: 1\npackages:\n  - name: git\n    action: install\n    package_manager: pacman\n")
-	if err := ProcessPackages(blueprint, nil, "yaml", newTestOSInfo(), init); err != nil {
+	if err := ProcessPackages(blueprint, nil, t.TempDir(), "yaml", newTestOSInfo(), init); err != nil {
 		t.Fatalf("file declaration should override the tree version: %v", err)
 	}
 	if len(rec.Calls) == 0 {
@@ -236,7 +236,7 @@ func TestProcessors_ImportedFileVersionIsEnforced(t *testing.T) {
 	init.Init.Location = dir
 
 	blueprint := []byte("packages:\n  - import: extra.yaml\n")
-	err := ProcessPackages(blueprint, nil, "yaml", newTestOSInfo(), init)
+	err := ProcessPackages(blueprint, nil, t.TempDir(), "yaml", newTestOSInfo(), init)
 	if err == nil {
 		t.Fatalf("imported blueprint with version 99 was accepted; %d command(s) ran: %+v",
 			len(rec.Calls), rec.Calls)
@@ -255,7 +255,7 @@ func TestProcessors_UnsupportedVersionErrorIsActionable(t *testing.T) {
 	init.Init.Location = t.TempDir()
 
 	blueprint := []byte("schema_version: 7\npackages:\n  - name: git\n    action: install\n")
-	err := ProcessPackages(blueprint, nil, "yaml", newTestOSInfo(), init)
+	err := ProcessPackages(blueprint, nil, t.TempDir(), "yaml", newTestOSInfo(), init)
 	if err == nil {
 		t.Fatal("expected refusal")
 	}

--- a/internal/processors/services.go
+++ b/internal/processors/services.go
@@ -14,7 +14,7 @@ import (
 
 // ProcessServices manages system services (enable, disable, start, stop, restart)
 // as defined in blueprint data, with cross-platform support via systemctl, launchctl, etc.
-func ProcessServices(blueprintData []byte, format string, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
+func ProcessServices(blueprintData []byte, blueprintDir string, format string, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
 	var servicesData types.ServiceData
 	var err error
 
@@ -26,7 +26,6 @@ func ProcessServices(blueprintData []byte, format string, osInfo *types.OSInfo, 
 	}
 
 	// Process imports and merge imported services
-	blueprintDir := initConfig.Init.Location
 	allServices, err := processServiceImports(servicesData.Services, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return fmt.Errorf("error processing service imports: %w", err)

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -77,7 +77,7 @@ type accessTokenResponse struct {
 
 // ProcessSSHKeys generates SSH key pairs from blueprint data and optionally
 // uploads public keys to GitHub via API token or OAuth device flow.
-func ProcessSSHKeys(blueprintData []byte, format string, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
+func ProcessSSHKeys(blueprintData []byte, blueprintDir string, format string, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
 	var sshKeyData types.SSHKeyData
 	var err error
 
@@ -91,7 +91,6 @@ func ProcessSSHKeys(blueprintData []byte, format string, osInfo *types.OSInfo, i
 	}
 
 	// Process imports and merge imported SSH keys
-	blueprintDir := initConfig.Init.Location
 	allSSHKeys, err := processSSHKeyImports(sshKeyData.SSHKeys, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return fmt.Errorf("error processing SSH key imports: %w", err)
@@ -170,14 +169,14 @@ func ensureSSHPackages(osInfo *types.OSInfo, initConfig *types.InitConfig) error
 				{Name: "openssh", Action: "install", PackageManager: "chocolatey"},
 			},
 		}
-		return ProcessPackages(nil, pkgData, "", osInfo, initConfig)
+		return ProcessPackages(nil, pkgData, "", "", osInfo, initConfig)
 	case "darwin":
 		pkgData := &types.PackagesData{
 			Packages: []types.Package{
 				{Name: "openssh", Action: "install", PackageManager: "brew"},
 			},
 		}
-		return ProcessPackages(nil, pkgData, "", osInfo, initConfig)
+		return ProcessPackages(nil, pkgData, "", "", osInfo, initConfig)
 	default:
 		// For Linux, OpenSSH is typically pre-installed
 		return nil

--- a/internal/processors/tilde_test.go
+++ b/internal/processors/tilde_test.go
@@ -36,7 +36,7 @@ ssh_keys:
 
 	// Ignore the error: this asserts on the command that was built, and the key
 	// may already exist on the machine running the test.
-	_ = ProcessSSHKeys(blueprint, "yaml", &types.OSInfo{}, &types.InitConfig{})
+	_ = ProcessSSHKeys(blueprint, t.TempDir(), "yaml", &types.OSInfo{}, &types.InitConfig{})
 
 	calls := rec.Find("ssh-keygen")
 	if len(calls) == 0 {

--- a/internal/processors/user.go
+++ b/internal/processors/user.go
@@ -40,7 +40,7 @@ const macDefaultPrimaryGroupID = "20"
 // gpasswd); macOS goes through Open Directory (dscl, sysadminctl, dseditgroup,
 // pwpolicy) — none of the shadow-utils binaries exist there. Windows has no
 // implementation and logs a warning per entry.
-func ProcessUsers(blueprintData []byte, format string, initConfig *types.InitConfig) error {
+func ProcessUsers(blueprintData []byte, blueprintDir string, format string, initConfig *types.InitConfig) error {
 	var usersData types.UsersData
 	var err error
 
@@ -53,7 +53,6 @@ func ProcessUsers(blueprintData []byte, format string, initConfig *types.InitCon
 	}
 
 	// Process imports and merge imported users and groups
-	blueprintDir := initConfig.Init.Location
 	allGroups, err := processGroupImports(usersData.Groups, blueprintDir, format, helpers.TreeSchemaVersion(initConfig))
 	if err != nil {
 		return fmt.Errorf("error processing group imports: %w", err)

--- a/internal/system/definitions/providers/apt.toml
+++ b/internal/system/definitions/providers/apt.toml
@@ -36,6 +36,9 @@ keys = "/usr/share/keyrings"
 action = "download"
 source = "{{ .KeyURL }}"
 dest = "{{ .TempKeyPath }}"
+# Empty when the blueprint declares no key_sha256; the download helper treats
+# an empty digest as "no check" and the processor warns about the unpinned key.
+sha256 = "{{ .KeySha256 }}"
 
 [[provider.repository.add.steps]]
 action = "command"

--- a/internal/system/definitions/providers/dnf.toml
+++ b/internal/system/definitions/providers/dnf.toml
@@ -38,6 +38,9 @@ keys = "/etc/pki/rpm-gpg"
 action = "download"
 source = "{{ .KeyURL }}"
 dest = "{{ .TempKeyPath }}"
+# Empty when the blueprint declares no key_sha256; the download helper treats
+# an empty digest as "no check" and the processor warns about the unpinned key.
+sha256 = "{{ .KeySha256 }}"
 
 [[provider.repository.add.steps]]
 action = "command"

--- a/internal/types/file.go
+++ b/internal/types/file.go
@@ -215,6 +215,7 @@ type File struct {
 	Action      string                 `mapstructure:"action" yaml:"action" json:"action" toml:"action"`
 	Content     string                 `mapstructure:"content,omitempty" yaml:"content,omitempty" json:"content,omitempty" toml:"content,omitempty"`
 	Source      string                 `mapstructure:"source,omitempty" yaml:"source,omitempty" json:"source,omitempty" toml:"source,omitempty"`
+	Sha256      string                 `mapstructure:"sha256,omitempty" yaml:"sha256,omitempty" json:"sha256,omitempty" toml:"sha256,omitempty"` // digest of a URL source, verified before install
 	Target      string                 `mapstructure:"target" yaml:"target" json:"target" toml:"target"`
 	Owner       string                 `mapstructure:"owner,omitempty" yaml:"owner,omitempty" json:"owner,omitempty" toml:"owner,omitempty"`
 	Group       string                 `mapstructure:"group,omitempty" yaml:"group,omitempty" json:"group,omitempty" toml:"group,omitempty"`

--- a/internal/types/initialize.go
+++ b/internal/types/initialize.go
@@ -56,13 +56,11 @@ type Variables struct {
 type InitConfig struct {
 	Init            Init                 `mapstructure:"blueprints" yaml:"blueprints" json:"blueprints" toml:"blueprints"`
 	PackageManagers []PackageManagerInfo `mapstructure:"packageManagers,omitempty" yaml:"packageManagers,omitempty" json:"packageManagers,omitempty" toml:"packageManagers,omitempty"`
-	Repositories    []Repository         `mapstructure:"repositories,omitempty" yaml:"repositories,omitempty" json:"repositories,omitempty" toml:"repositories,omitempty"`
-	Packages        []Package            `mapstructure:"packages,omitempty" yaml:"packages,omitempty" json:"packages,omitempty" toml:"packages,omitempty"`
-	Services        []Service            `mapstructure:"services,omitempty" yaml:"services,omitempty" json:"services,omitempty" toml:"services,omitempty"`
-	Files           []File               `mapstructure:"files,omitempty" yaml:"files,omitempty" json:"files,omitempty" toml:"files,omitempty"`
-	Templates       []File               `mapstructure:"templates,omitempty" yaml:"templates,omitempty" json:"templates,omitempty" toml:"templates,omitempty"`
-	Directories     []Directory          `mapstructure:"directories,omitempty" yaml:"directories,omitempty" json:"directories,omitempty" toml:"directories,omitempty"`
-	Configuration   []Configuration      `mapstructure:"configuration,omitempty" yaml:"configuration,omitempty" json:"configuration,omitempty" toml:"configuration,omitempty"`
+	// The inline resource sections (repositories, packages, services, files,
+	// templates, directories, configuration) are gone: they were decoded,
+	// validated, profile-counted — and never applied at runtime. Blueprints
+	// are the single declaration path; under strict decode a leftover key is
+	// an error naming it instead of a silent no-op.
 	// Squashing this made the `variables:` block in the init file decode into
 	// nothing at all, so every {{ .UserDefined.x }} in a blueprint rendered empty.
 	Variables Variables `mapstructure:"variables,omitempty" yaml:"variables,omitempty" json:"variables,omitempty" toml:"variables,omitempty"`

--- a/internal/types/repository.go
+++ b/internal/types/repository.go
@@ -8,6 +8,7 @@ type Repository struct {
 	URL            string   `mapstructure:"url" yaml:"url" json:"url" toml:"url"`                                                                         // URL of the repository
 	Arch           string   `mapstructure:"arch,omitempty" yaml:"arch,omitempty" json:"arch,omitempty" toml:"arch,omitempty"`                             // Architecture of the repository
 	KeyURL         string   `mapstructure:"key_url,omitempty" yaml:"key_url,omitempty" json:"key_url,omitempty" toml:"key_url,omitempty"`                 // Key URL of the repository
+	KeySha256      string   `mapstructure:"key_sha256,omitempty" yaml:"key_sha256,omitempty" json:"key_sha256,omitempty" toml:"key_sha256,omitempty"`     // sha256 of the signing key at key_url; the key-download step verifies it
 	Channel        string   `mapstructure:"channel,omitempty" yaml:"channel,omitempty" json:"channel,omitempty" toml:"channel,omitempty"`                 // Channel of the repository
 	Component      string   `mapstructure:"component,omitempty" yaml:"component,omitempty" json:"component,omitempty" toml:"component,omitempty"`         // Component of the repository
 	Repository     string   `mapstructure:"repository,omitempty" yaml:"repository,omitempty" json:"repository,omitempty" toml:"repository,omitempty"`     // Repository name

--- a/internal/validate/blueprints.go
+++ b/internal/validate/blueprints.go
@@ -176,21 +176,6 @@ func validateInitFile(initFile string, results *types.ValidationResults) (*types
 		}
 	}
 
-	// Validate the Repositories field
-	if initConfig.Repositories != nil {
-		for i, repo := range initConfig.Repositories {
-			if repo.Name == "" {
-				AddIssue(results, types.ValidationError, fmt.Sprintf("Missing required field 'repositories[%d].name'", i), initFile, 0, "Add name field to repository")
-			}
-			if repo.PackageManager == "" {
-				AddIssue(results, types.ValidationError, fmt.Sprintf("Missing required field 'repositories[%d].package_manager'", i), initFile, 0, "Add package_manager field to repository")
-			}
-			if repo.Action == "" {
-				AddIssue(results, types.ValidationError, fmt.Sprintf("Missing required field 'repositories[%d].action'", i), initFile, 0, "Add action field to repository")
-			}
-		}
-	}
-
 	return &initConfig, nil
 }
 
@@ -211,6 +196,15 @@ func validateBlueprintFile(blueprintFile string, initConfig *types.InitConfig, r
 	// {{ .User.home }} is not valid YAML until it is rendered — the braces read as a
 	// flow mapping — so validating the raw bytes reports a parse error against a
 	// blueprint that works.
+	// Strict for the fixed namespaces, lenient only for UserDefined: validate
+	// used to render everything with missingkey=zero, so a typo like
+	// {{ .User.hoem }} validated clean and failed at run time.
+	for _, ref := range helpers.UnknownTemplateReferences(blueprintFileData, initConfig.Variables) {
+		AddIssue(results, types.ValidationError,
+			fmt.Sprintf("Template references %s, which does not exist", ref),
+			blueprintFile, 0, "Fix the reference; User/System/Flags keys are fixed (UserDefined values are not checked)")
+	}
+
 	blueprintFileData, err = helpers.ResolveTemplateForValidation(blueprintFileData, initConfig.Variables)
 	if err != nil {
 		return fmt.Errorf("error resolving variables in %s: %w", filepath.Base(blueprintFile), err)

--- a/internal/validate/components.go
+++ b/internal/validate/components.go
@@ -20,6 +20,14 @@ func ValidatePackages(packages []types.Package, file string, results *types.Vali
 			continue
 		}
 
+		// Only the names list is processed when both are declared; say so
+		// rather than silently ignoring one of them.
+		if pkg.Name != "" && len(pkg.Names) > 0 {
+			AddIssue(results, types.ValidationWarning,
+				fmt.Sprintf("packages[%d] declares both 'name' and 'names'; only the names list is processed", i),
+				file, 0, "Remove one of the two fields")
+		}
+
 		// A package entry names one package with `name` or several with `names`.
 		// Requiring `name` and separately warning on an empty `names` reported two
 		// problems against every correct entry, whichever form it used.

--- a/internal/validate/examples_test.go
+++ b/internal/validate/examples_test.go
@@ -158,3 +158,46 @@ packages: [{name: "git", action: "explode"}]
 		t.Errorf("no diagnostic names the failed constraint; issues: %+v", results.Issues)
 	}
 }
+
+// Validate is strict for the fixed namespaces and lenient only for
+// UserDefined: {{ .User.hoem }} is an error; {{ .UserDefined.anything }} is not.
+func TestValidate_TemplateStrictnessPerNamespace(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "files"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile("init.yaml", "blueprints:\n  format: yaml\n  location: "+dir+"\n")
+	writeFile("files/typo.yaml", `files:
+  - name: rc
+    action: create
+    target: "{{ .User.hoem }}/.rc"
+    content: "x={{ .UserDefined.undeclared }}"
+`)
+
+	results := &types.ValidationResults{}
+	if err := ValidateBlueprints(dir, false, results, &types.OSInfo{}); err != nil {
+		t.Fatalf("ValidateBlueprints: %v", err)
+	}
+
+	foundTypo := false
+	for _, issue := range results.Issues {
+		if strings.Contains(issue.Message, ".User.hoem") {
+			foundTypo = true
+			if issue.Severity != types.ValidationError {
+				t.Errorf("typo reported at %v, want an error", issue.Severity)
+			}
+		}
+		if strings.Contains(issue.Message, "UserDefined") && issue.Severity == types.ValidationError {
+			t.Errorf("UserDefined reference reported as an error: %s", issue.Message)
+		}
+	}
+	if !foundTypo {
+		t.Errorf("no diagnostic names .User.hoem; issues: %+v", results.Issues)
+	}
+}

--- a/openspec/changes/add-convert-command/proposal.md
+++ b/openspec/changes/add-convert-command/proposal.md
@@ -1,0 +1,35 @@
+# Change: `rwr convert` — format conversion and tree migration
+
+Depends on: `add-format-registry` (decode/encode dispatch),
+`unify-blueprint-semantics` (defines the "current state" trees migrate to).
+Status: stub — requested alongside the decision to drop init-file inline
+sections; needs fleshing out before implementation.
+
+## Why
+
+Two recurring needs with no tool today:
+
+- **Format conversion**: a tree written in YAML has no path to TOML/JSON/CUE
+  short of hand-rewriting every file, even though all four formats decode to
+  identical values.
+- **Migration to current state**: schema evolution (dropped init-file inline
+  sections, future schema_version bumps) leaves working-but-deprecated trees
+  behind, with only release notes to guide the move.
+
+## What Changes (sketch)
+
+- `rwr convert --to <format> [path]`: re-encode every blueprint, init, and
+  bootstrap file in a tree to the target format, preserving comments where the
+  target supports them and template placeholders byte-identical.
+- `rwr convert --migrate [path]`: rewrite deprecated constructs to their
+  current equivalents — starting with init-file inline resource sections moved
+  into blueprint files under the tree.
+- Dry-run by default with a diff; `--write` applies.
+
+## Breakage
+
+None — a new command; it only writes with `--write`.
+
+## Impact
+
+- Affected specs: `cli` (new command), possibly `initialization`.

--- a/openspec/changes/add-convert-command/tasks.md
+++ b/openspec/changes/add-convert-command/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [ ] 1. Flesh out the proposal: comment preservation limits per format,
+      template-placeholder round-tripping, CUE export style.
+- [ ] 2. Design doc for `--migrate` rule registry (one rule per deprecation).
+- [ ] 3. Implement `--to <format>`.
+- [ ] 4. Implement `--migrate` with the init-inline-sections rule.
+- [ ] 5. Docs + examples.

--- a/openspec/changes/unify-blueprint-semantics/proposal.md
+++ b/openspec/changes/unify-blueprint-semantics/proposal.md
@@ -1,0 +1,77 @@
+# Change: Unify blueprint semantics and close the download-integrity schema gaps
+
+Depends on: `add-format-registry` (per-file formats; content detection decodes
+through the registry). Carries the schema half of the 2026-08 security review's
+HIGH finding and every cross-processor inconsistency it catalogued.
+
+## Why
+
+Six semantics questions have two answers each in today's code — import base
+directories, name/names precedence, template strictness at validate, dead
+init-file sections, path-only type dispatch — and the blueprint schema cannot
+express a content digest for the two most security-sensitive downloads it
+causes: repository signing keys and `files:` sources. Each inconsistency is a
+blueprint that behaves differently depending on which processor reads it.
+
+## What Changes
+
+**Download-integrity schema (completes the review's HIGH):**
+
+- `types.Repository` gains `key_sha256`: the digest of the signing key at
+  `key_url`. Wired into the apt/dnf key-download steps as the step `sha256`.
+  Policy: a repository with `key_url` but no `key_sha256` logs a prominent
+  warning ("unpinned signing key") now; a later major refuses.
+- `types.File` gains `sha256`: URL sources are verified before install
+  (`files.go` currently hard-codes an empty digest). Same warn-now policy for
+  URL sources without one.
+
+**Semantics unification (each is a current two-answer inconsistency):**
+
+- Import resolution is file-relative everywhere. Six processors (packages,
+  git, ssh_keys, services, users, repositories) resolve top-level imports
+  against the tree root while files/scripts/fonts/configuration are
+  file-relative — the blueprint-processing spec already mandates
+  file-relative, so this also closes the open code-violates-spec item.
+- `names` wins over `name` when both are set, everywhere. files/fonts already
+  do this; packages had it backwards. Declaring both is a validate warning.
+- Init-file inline resource sections (`repositories`, `packages`, `services`,
+  `files`, `templates`, `directories`, `configuration`) are REMOVED from the
+  schema. They were decoded, validated, profile-counted, and never applied at
+  runtime — a declaration that silently does nothing. (Decision: drop rather
+  than apply; blueprints stay the single declaration path. A `rwr convert`
+  /migration tool is a planned follow-up change for moving old trees forward.)
+- Content-based blueprint-type detection: a file whose path names no processor
+  directory is decoded shallowly and typed by its top-level keys
+  (`packages:` → packages, …). This makes the shipped
+  `examples/alternative_layouts/` (flattened, minimal_files) actually execute —
+  today they exit 0 having run nothing — and honors the README's promise.
+  Ambiguous or unrecognized content keeps the loud unrouted-file warning.
+- Validate template strictness matches the spec: `missingkey=zero` only for
+  the `UserDefined` namespace; `User`/`System`/`Flags` references that do not
+  exist are validate errors.
+
+**Riders:** tautological tests deleted as encountered (roadmap item);
+`alternative_layouts` READMEs corrected (`rwr run` is not a command).
+
+## Breakage
+
+- Init-file inline resource sections now fail strict decode (unknown keys).
+  They never did anything; a tree using them was already not getting what it
+  wrote. Migration: move the entries into blueprint files (future `rwr
+  convert` automates this).
+- A packages entry declaring BOTH `name` and `names` now installs the `names`
+  list (was: only `name`). Declaring both also warns at validate.
+- Validate becomes stricter about unknown `.User/.System/.Flags` template
+  references — previously silently zero-valued. Runs were already strict;
+  this only moves the failure earlier.
+- Everything else is additive (`key_sha256`, `files[].sha256`, content
+  detection for previously dead layouts).
+
+## Impact
+
+- Affected specs: `blueprint-processing`, `blueprint-validation`,
+  `initialization`.
+- Affected code: `internal/types` (Repository, File, initialize),
+  `internal/processors` (six import sites, packages precedence, blueprints
+  dispatch, repository step data), `internal/validate`, provider TOMLs
+  (apt/dnf key steps), `examples/alternative_layouts/`, docs.

--- a/openspec/changes/unify-blueprint-semantics/proposal.md
+++ b/openspec/changes/unify-blueprint-semantics/proposal.md
@@ -50,8 +50,10 @@ blueprint that behaves differently depending on which processor reads it.
   the `UserDefined` namespace; `User`/`System`/`Flags` references that do not
   exist are validate errors.
 
-**Riders:** tautological tests deleted as encountered (roadmap item);
-`alternative_layouts` READMEs corrected (`rwr run` is not a command).
+**Riders:** tautological tests deleted as encountered (roadmap item); bare
+`rwr run` now runs the whole tree (the landing command, mise-run style — the
+READMEs always said `rwr run`; the code printed help and errored), with
+`rwr all` delegating to the same path.
 
 ## Breakage
 

--- a/openspec/changes/unify-blueprint-semantics/specs/blueprint-processing/spec.md
+++ b/openspec/changes/unify-blueprint-semantics/specs/blueprint-processing/spec.md
@@ -1,0 +1,79 @@
+# Blueprint Processing — Deltas
+
+## MODIFIED Requirements
+
+### Requirement: Downloads are validated on every hop, bounded, and pinnable
+
+(Extends the existing requirement with the schema half.)
+
+A repository MAY declare `key_sha256`, the sha256 of the signing key at
+`key_url`; when declared, the provider's key-download step SHALL verify it.
+A `files:` entry with a URL source MAY declare `sha256`; when declared, the
+download SHALL be verified before the file is installed.
+
+A repository with `key_url` and no `key_sha256`, and a files entry with a URL
+source and no `sha256`, SHALL produce a prominent warning naming the unpinned
+download. (A later major version refuses; the policy ratchets, never loosens.)
+
+#### Scenario: Pinned signing key mismatch
+
+- **WHEN** a repository declares `key_url` and `key_sha256` and the downloaded
+  key does not match
+- **THEN** the repository is not added and the failure names the digest
+  mismatch
+
+#### Scenario: Unpinned signing key warns
+
+- **WHEN** a repository declares `key_url` without `key_sha256`
+- **THEN** the run proceeds with a prominent warning naming the repository
+
+### Requirement: Any blueprint entry can import another file
+
+(Modifies base-directory resolution.)
+
+An import path SHALL resolve relative to the file that declares it, in every
+processor. (Previously six processors resolved top-level imports against the
+tree root while four resolved file-relative — the same `import:` string meant
+two different files depending on the blueprint type.)
+
+#### Scenario: Same relative import in two blueprint types
+
+- **GIVEN** `packages/base.yaml` and `files/base.yaml`, each declaring
+  `import: ../shared/common.yaml`
+- **WHEN** both are processed
+- **THEN** both resolve `shared/common.yaml` at the tree root's sibling —
+  the same file, relative to each importing file
+
+### Requirement: `names` wins over `name` everywhere
+
+When an entry declares both `name` and `names`, the `names` list SHALL be
+processed and `name` ignored, for every blueprint type. (packages had it
+backwards relative to files/fonts.)
+
+#### Scenario: Both declared on a packages entry
+
+- **WHEN** a packages entry declares `name: git` and `names: [vim, tmux]`
+- **THEN** vim and tmux are installed and git is not
+
+### Requirement: Blueprint type is derived from content when the path names none
+
+A blueprint file whose path names no processor directory SHALL be typed by its
+top-level keys (`packages:` → packages, `repositories:` → repositories, …).
+A file whose content matches no type — or more than one — SHALL produce the
+loud unrouted-file warning and SHALL NOT execute.
+
+Why: the flattened and minimal_files layouts the examples ship were dead ends —
+path-only dispatch sent every file to a bucket the run loop never reads, and
+the run exited 0 having executed nothing.
+
+#### Scenario: Flattened layout executes
+
+- **GIVEN** a tree with `packages.yaml` at its root declaring packages
+- **WHEN** `rwr all` runs
+- **THEN** the file is dispatched to the packages processor and executes
+
+#### Scenario: Ambiguous content still warns
+
+- **GIVEN** a root-level file declaring both `packages:` and `services:`
+- **WHEN** the run order is computed
+- **THEN** the file is not executed and a warning names it and why

--- a/openspec/changes/unify-blueprint-semantics/specs/blueprint-validation/spec.md
+++ b/openspec/changes/unify-blueprint-semantics/specs/blueprint-validation/spec.md
@@ -1,0 +1,30 @@
+# Blueprint Validation — Deltas
+
+## MODIFIED Requirements
+
+### Requirement: Template strictness at validate matches the run
+
+`rwr validate` SHALL resolve template references strictly for the `User`,
+`System`, and `Flags` namespaces — a reference that does not exist is a
+validation error — and leniently (`missingkey=zero`) only for `UserDefined`,
+whose values legitimately vary per machine.
+
+Why: validate resolved every namespace leniently, so a typo like
+`{{ .User.hoem }}` validated clean and failed at run time — the exact class of
+error validate exists to catch early.
+
+#### Scenario: Misspelled built-in reference
+
+- **WHEN** a blueprint references `{{ .User.hoem }}`
+- **THEN** `rwr validate` reports it as an error naming the reference
+- **AND** an undefined `{{ .UserDefined.anything }}` still validates
+
+### Requirement: Declaring both name and names is flagged
+
+An entry declaring both `name` and `names` SHALL produce a validation warning
+naming the entry, since only the `names` list will be processed.
+
+#### Scenario: Both declared
+
+- **WHEN** a packages entry declares both `name` and `names`
+- **THEN** validate warns that `name` is ignored

--- a/openspec/changes/unify-blueprint-semantics/specs/initialization/spec.md
+++ b/openspec/changes/unify-blueprint-semantics/specs/initialization/spec.md
@@ -1,0 +1,23 @@
+# Initialization — Deltas
+
+## REMOVED Requirements
+
+### Requirement: Init-file inline resource sections
+
+The init file's inline resource sections (`repositories`, `packages`,
+`services`, `files`, `templates`, `directories`, `configuration`) are removed
+from the schema. They were decoded, validated, and profile-counted but never
+applied at runtime — a declaration that silently did nothing.
+
+Blueprints are the single declaration path. Under strict decode, an init file
+still carrying these keys is now an error naming them, instead of a silent
+no-op.
+
+Migration: move the entries into blueprint files under the tree; a future
+`rwr convert` change automates this.
+
+#### Scenario: Init file with an inline packages section
+
+- **WHEN** an init file declares a top-level `packages:` list
+- **THEN** initialization fails with an error naming `packages` as an
+  unsupported init-file key and pointing at blueprint files

--- a/openspec/changes/unify-blueprint-semantics/tasks.md
+++ b/openspec/changes/unify-blueprint-semantics/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+- [x] 1. `key_sha256` on `types.Repository`, threaded into step data
+      (`KeySha256`) and the apt/dnf key-download steps' `sha256`. Warn on
+      `key_url` without it. Test: pinned mismatch refuses (fails without);
+      unpinned warns.
+- [x] 2. `sha256` on `types.File`; `files.go` URL downloads verify it (the
+      call currently hard-codes ""). Warn on URL source without it. Test:
+      mismatch refuses and installs nothing.
+- [x] 3. File-relative import resolution in the six root-relative processors
+      (packages, git, ssh_keys, services, users, repositories). Test: the
+      same relative import string resolves identically from two blueprint
+      types (fails without).
+- [x] 4. `names` wins over `name` in packages (matching files/fonts); validate
+      warns when both are set. Tests for both.
+- [x] 5. Remove init-file inline resource sections from `types.Init*`,
+      validation, profile counting, and docs (`docs/init-file.md`). Strict
+      decode makes a leftover key an actionable error. Test: init file with
+      `packages:` fails naming the key.
+- [x] 6. Content-based type detection for path-unrouted files in
+      `GetBlueprintFileOrder` (single-type match dispatches; zero or multiple
+      matches keep the loud warning). Un-dead-end
+      `examples/alternative_layouts/` (CI-validated), fix their READMEs'
+      `rwr run` instruction. Test: flattened tree executes its packages file
+      (fails without).
+- [x] 7. Validate template strictness: `missingkey` strict for
+      User/System/Flags, lenient for UserDefined only
+      (`ResolveTemplateForValidation`). Test: `{{ .User.hoem }}` is an error,
+      `{{ .UserDefined.x }}` is not (fails without).
+- [x] 8. Delete tautological tests encountered along the way; `mise run ci`
+      green; examples pass.


### PR DESCRIPTION
Implements **unify-blueprint-semantics** (change authored in this PR: proposal + spec deltas for blueprint-processing/initialization/blueprint-validation + tasks, 8/8 complete). Stacked on #214 → #213; merge in that order and retarget.

This is the Wave-2 schema/semantics batch from REVIEW-PR-PLAN.md — the schema half of the HIGH security finding plus every two-answer inconsistency the review catalogued.

## Download integrity (schema)

- **`key_sha256` on repositories** — pins the signing key at `key_url`; threaded into step data (`KeySha256`) and the shipped apt/dnf key-download steps' `sha256`. Unpinned key ⇒ loud warning now, refusal in a later major. Test: pinned mismatch refuses through the real apt provider template.
- **`sha256` on `files:` entries** — URL sources verified before install (the call hard-coded `""`). Same warn-now policy. Test: mismatch installs nothing.

## Semantics unification

- **File-relative imports everywhere** — six processors resolved top-level imports against the tree root (the open code-violates-spec item); `blueprintDir` is now threaded through their `Process*` signatures. Test: `import: ../shared/common.yaml` from `packages/base.yaml` resolves beside the file.
- **`names` wins over `name`** when both are set, everywhere (packages had it backwards); validate warns on both-declared.
- **Init inline sections dropped** (per decision) — `Initialize` errors naming a leftover key with migration guidance (viper would otherwise silently drop them). Docs trimmed; **`add-convert-command`** stubbed as the follow-up that automates migration.
- **Content-based type detection** — path-unrouted files are typed by top-level keys; multi-type files (minimal_files' `all_in_one.yaml`) route to every declared type and the dispatch subsets per processor, keeping strict decode for single-type files. The flattened/minimal_files layouts go from exit-0-doing-nothing to executing; READMEs' `rwr run` corrected.
- **Validate template strictness** — unknown `.User/.System/.Flags` references are errors; `UserDefined` stays lenient.

## Breaking-change statement (from the proposal)

- Init files still carrying inline resource sections now **error with guidance** (they never did anything).
- A packages entry declaring both `name` and `names` now processes the names list.
- Validate is stricter about fixed-namespace template typos (runs already were).
- Everything else is additive.

All gates green: `-race` suite, lint, gosec (G703 sites annotated with the standing PR8-containment justification), `TestExamples_`, and `rwr validate` over all 33 example trees (incl. the newly-alive alternative_layouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)