### PR TITLE
feat(cli): rwr convert — format conversion and tree migration

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,0 +1,253 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// newConvertCmd converts a blueprint tree between formats and migrates
+// deprecated constructs to their current equivalents. Dry-run by default:
+// it prints what would change; --write applies.
+func newConvertCmd() *cobra.Command {
+	var (
+		toFormat string
+		migrate  bool
+		write    bool
+	)
+
+	convertCmd := &cobra.Command{
+		Use:   "convert [path]",
+		Short: "Convert a blueprint tree between formats, or migrate deprecated constructs",
+		Long: `Convert every blueprint, init, bootstrap, and manifest file in a tree to
+another format (--to yaml|json|toml|cue), or rewrite deprecated constructs to
+their current equivalents (--migrate).
+
+Dry-run by default: nothing is written without --write. Comments are NOT
+preserved across formats — the command warns per file that carries them.
+Template placeholders survive as quoted strings; a file whose templates make
+it unparseable is reported and skipped, never mangled.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root := "."
+			if len(args) == 1 {
+				root = args[0]
+			}
+			if toFormat == "" && !migrate {
+				return fmt.Errorf("nothing to do: pass --to <format> and/or --migrate")
+			}
+			if toFormat != "" {
+				canonical, err := helpers.CanonicalFormat(toFormat)
+				if err != nil {
+					return err
+				}
+				toFormat = canonical
+			}
+			return runConvert(cmd, root, toFormat, migrate, write)
+		},
+	}
+
+	convertCmd.Flags().StringVar(&toFormat, "to", "", "Target format: yaml, json, toml, or cue")
+	convertCmd.Flags().BoolVar(&migrate, "migrate", false, "Rewrite deprecated constructs (init-file inline sections) to their current form")
+	convertCmd.Flags().BoolVar(&write, "write", false, "Apply the changes (default is a dry run)")
+	return convertCmd
+}
+
+// say writes progress lines; a broken stdout must not abort a conversion
+// midway through a tree.
+func say(w interface{ Write([]byte) (int, error) }, format string, args ...interface{}) {
+	fmt.Fprintf(w, format, args...) //nolint:errcheck
+}
+
+func runConvert(cmd *cobra.Command, root, toFormat string, migrate, write bool) error {
+	out := cmd.OutOrStdout()
+	changed := 0
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if path != root && strings.HasPrefix(info.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !helpers.IsBlueprintFile(path) {
+			return nil
+		}
+
+		format, err := helpers.FormatForPath(path)
+		if err != nil {
+			return nil
+		}
+
+		data, err := os.ReadFile(path) // #nosec G304 G122 -- operator's own tree, walked read-only
+		if err != nil {
+			say(out, "  ! %s: %v\n", path, err)
+			return nil
+		}
+
+		var doc map[string]interface{}
+		if err := helpers.UnmarshalBlueprint(data, format, &doc); err != nil {
+			say(out, "  ! %s: cannot parse (%v) — skipped, not mangled\n", path, err)
+			return nil
+		}
+
+		if hasComments(data, format) {
+			say(out, "  ~ %s carries comments; they are NOT preserved across formats\n", path)
+		}
+
+		if migrate {
+			base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+			if base == "init" {
+				n, migErr := migrateInitInlineSections(out, path, doc, format, write)
+				if migErr != nil {
+					return migErr
+				}
+				changed += n
+			}
+		}
+
+		if toFormat != "" && toFormat != format {
+			target := strings.TrimSuffix(path, filepath.Ext(path)) + extensionFor(toFormat)
+			encoded, encErr := encodeAs(doc, toFormat)
+			if encErr != nil {
+				say(out, "  ! %s: cannot encode as %s: %v\n", path, toFormat, encErr)
+				return nil
+			}
+			if write {
+				if wErr := os.WriteFile(target, encoded, 0o644); wErr != nil { // #nosec G306 G122 -- blueprint files are world-readable config; operator's own tree
+					return wErr
+				}
+				if rmErr := os.Remove(path); rmErr != nil { // #nosec G122 -- removing the file just converted, operator's own tree
+					return rmErr
+				}
+			}
+			say(out, "  → %s => %s\n", path, target)
+			changed++
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if changed == 0 {
+		say(out, "nothing to change"+"\n")
+	} else if !write {
+		say(out, "%d change(s); re-run with --write to apply\n", changed)
+	}
+	return nil
+}
+
+// migrateInitInlineSections moves the removed inline resource sections out of
+// an init file into blueprint files — the first migrateRules entry.
+func migrateInitInlineSections(out interface{ Write([]byte) (int, error) }, initPath string, doc map[string]interface{}, format string, write bool) (int, error) {
+	sections := map[string]string{
+		"repositories": "repositories", "packages": "packages", "services": "services",
+		"files": "files", "templates": "files", "directories": "files", "configuration": "configuration",
+	}
+	root := filepath.Dir(initPath)
+	moved := 0
+	for key, dir := range sections {
+		value, present := doc[key]
+		if !present {
+			continue
+		}
+		targetDir := filepath.Join(root, dir)
+		target := filepath.Join(targetDir, "from-init"+extensionFor(format))
+		say(out, "  → %s: move %q into %s\n", initPath, key, target)
+		if write {
+			if err := os.MkdirAll(targetDir, 0o755); err != nil { // #nosec G301 -- operator's own blueprint tree
+				return moved, err
+			}
+			payload := map[string]interface{}{key: value}
+			if existing, err := os.ReadFile(target); err == nil { // #nosec G304 -- operator's own tree
+				var current map[string]interface{}
+				if helpers.UnmarshalBlueprint(existing, format, &current) == nil {
+					current[key] = value
+					payload = current
+				}
+			}
+			encoded, err := encodeAs(payload, format)
+			if err != nil {
+				return moved, err
+			}
+			if err := os.WriteFile(target, encoded, 0o644); err != nil { // #nosec G306 -- blueprint files are world-readable config
+				return moved, err
+			}
+			delete(doc, key)
+			rewritten, err := encodeAs(doc, format)
+			if err != nil {
+				return moved, err
+			}
+			if err := os.WriteFile(initPath, rewritten, 0o644); err != nil { // #nosec G306
+				return moved, err
+			}
+		}
+		moved++
+	}
+	return moved, nil
+}
+
+// encodeAs renders a document in a target format. CUE output is JSON-form
+// CUE: valid, lossless, mechanical — idiomatic CUE is authoring work.
+func encodeAs(doc map[string]interface{}, format string) ([]byte, error) {
+	switch format {
+	case "yaml":
+		return yaml.Marshal(doc)
+	case "json":
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(doc); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case "toml":
+		var buf bytes.Buffer
+		if err := toml.NewEncoder(&buf).Encode(doc); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case "cue":
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetIndent("", "\t")
+		if err := enc.Encode(doc); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+	return nil, fmt.Errorf("unsupported target format %q", format)
+}
+
+func extensionFor(format string) string {
+	return "." + format
+}
+
+// hasComments detects comment markers well enough to warn (never to block).
+func hasComments(data []byte, format string) bool {
+	marker := "#"
+	if format == "json" {
+		return false
+	}
+	if format == "cue" {
+		marker = "//"
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,22 +1,15 @@
 package cmd
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 
-	"github.com/BurntSushi/toml"
+	"github.com/fynxlabs/rwr/internal/convert"
 	"github.com/fynxlabs/rwr/internal/helpers"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
-// newConvertCmd converts a blueprint tree between formats and migrates
-// deprecated constructs to their current equivalents. Dry-run by default:
-// it prints what would change; --write applies.
+// newConvertCmd is the cobra wiring for `rwr convert`; the implementation
+// lives in internal/convert.
 func newConvertCmd() *cobra.Command {
 	var (
 		toFormat string
@@ -51,7 +44,7 @@ it unparseable is reported and skipped, never mangled.`,
 				}
 				toFormat = canonical
 			}
-			return runConvert(cmd, root, toFormat, migrate, write)
+			return convert.Run(cmd.OutOrStdout(), root, toFormat, migrate, write)
 		},
 	}
 
@@ -59,195 +52,4 @@ it unparseable is reported and skipped, never mangled.`,
 	convertCmd.Flags().BoolVar(&migrate, "migrate", false, "Rewrite deprecated constructs (init-file inline sections) to their current form")
 	convertCmd.Flags().BoolVar(&write, "write", false, "Apply the changes (default is a dry run)")
 	return convertCmd
-}
-
-// say writes progress lines; a broken stdout must not abort a conversion
-// midway through a tree.
-func say(w interface{ Write([]byte) (int, error) }, format string, args ...interface{}) {
-	fmt.Fprintf(w, format, args...) //nolint:errcheck
-}
-
-func runConvert(cmd *cobra.Command, root, toFormat string, migrate, write bool) error {
-	out := cmd.OutOrStdout()
-	changed := 0
-
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			if path != root && strings.HasPrefix(info.Name(), ".") {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !helpers.IsBlueprintFile(path) {
-			return nil
-		}
-
-		format, err := helpers.FormatForPath(path)
-		if err != nil {
-			return nil
-		}
-
-		data, err := os.ReadFile(path) // #nosec G304 G122 -- operator's own tree, walked read-only
-		if err != nil {
-			say(out, "  ! %s: %v\n", path, err)
-			return nil
-		}
-
-		var doc map[string]interface{}
-		if err := helpers.UnmarshalBlueprint(data, format, &doc); err != nil {
-			say(out, "  ! %s: cannot parse (%v) — skipped, not mangled\n", path, err)
-			return nil
-		}
-
-		if hasComments(data, format) {
-			say(out, "  ~ %s carries comments; they are NOT preserved across formats\n", path)
-		}
-
-		if migrate {
-			base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
-			if base == "init" {
-				n, migErr := migrateInitInlineSections(out, path, doc, format, write)
-				if migErr != nil {
-					return migErr
-				}
-				changed += n
-			}
-		}
-
-		if toFormat != "" && toFormat != format {
-			target := strings.TrimSuffix(path, filepath.Ext(path)) + extensionFor(toFormat)
-			encoded, encErr := encodeAs(doc, toFormat)
-			if encErr != nil {
-				say(out, "  ! %s: cannot encode as %s: %v\n", path, toFormat, encErr)
-				return nil
-			}
-			if write {
-				if wErr := os.WriteFile(target, encoded, 0o644); wErr != nil { // #nosec G306 G122 -- blueprint files are world-readable config; operator's own tree
-					return wErr
-				}
-				if rmErr := os.Remove(path); rmErr != nil { // #nosec G122 -- removing the file just converted, operator's own tree
-					return rmErr
-				}
-			}
-			say(out, "  → %s => %s\n", path, target)
-			changed++
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	if changed == 0 {
-		say(out, "nothing to change"+"\n")
-	} else if !write {
-		say(out, "%d change(s); re-run with --write to apply\n", changed)
-	}
-	return nil
-}
-
-// migrateInitInlineSections moves the removed inline resource sections out of
-// an init file into blueprint files — the first migrateRules entry.
-func migrateInitInlineSections(out interface{ Write([]byte) (int, error) }, initPath string, doc map[string]interface{}, format string, write bool) (int, error) {
-	sections := map[string]string{
-		"repositories": "repositories", "packages": "packages", "services": "services",
-		"files": "files", "templates": "files", "directories": "files", "configuration": "configuration",
-	}
-	root := filepath.Dir(initPath)
-	moved := 0
-	for key, dir := range sections {
-		value, present := doc[key]
-		if !present {
-			continue
-		}
-		targetDir := filepath.Join(root, dir)
-		target := filepath.Join(targetDir, "from-init"+extensionFor(format))
-		say(out, "  → %s: move %q into %s\n", initPath, key, target)
-		if write {
-			if err := os.MkdirAll(targetDir, 0o755); err != nil { // #nosec G301 -- operator's own blueprint tree
-				return moved, err
-			}
-			payload := map[string]interface{}{key: value}
-			if existing, err := os.ReadFile(target); err == nil { // #nosec G304 -- operator's own tree
-				var current map[string]interface{}
-				if helpers.UnmarshalBlueprint(existing, format, &current) == nil {
-					current[key] = value
-					payload = current
-				}
-			}
-			encoded, err := encodeAs(payload, format)
-			if err != nil {
-				return moved, err
-			}
-			if err := os.WriteFile(target, encoded, 0o644); err != nil { // #nosec G306 -- blueprint files are world-readable config
-				return moved, err
-			}
-			delete(doc, key)
-			rewritten, err := encodeAs(doc, format)
-			if err != nil {
-				return moved, err
-			}
-			if err := os.WriteFile(initPath, rewritten, 0o644); err != nil { // #nosec G306
-				return moved, err
-			}
-		}
-		moved++
-	}
-	return moved, nil
-}
-
-// encodeAs renders a document in a target format. CUE output is JSON-form
-// CUE: valid, lossless, mechanical — idiomatic CUE is authoring work.
-func encodeAs(doc map[string]interface{}, format string) ([]byte, error) {
-	switch format {
-	case "yaml":
-		return yaml.Marshal(doc)
-	case "json":
-		var buf bytes.Buffer
-		enc := json.NewEncoder(&buf)
-		enc.SetIndent("", "  ")
-		if err := enc.Encode(doc); err != nil {
-			return nil, err
-		}
-		return buf.Bytes(), nil
-	case "toml":
-		var buf bytes.Buffer
-		if err := toml.NewEncoder(&buf).Encode(doc); err != nil {
-			return nil, err
-		}
-		return buf.Bytes(), nil
-	case "cue":
-		var buf bytes.Buffer
-		enc := json.NewEncoder(&buf)
-		enc.SetIndent("", "\t")
-		if err := enc.Encode(doc); err != nil {
-			return nil, err
-		}
-		return buf.Bytes(), nil
-	}
-	return nil, fmt.Errorf("unsupported target format %q", format)
-}
-
-func extensionFor(format string) string {
-	return "." + format
-}
-
-// hasComments detects comment markers well enough to warn (never to block).
-func hasComments(data []byte, format string) bool {
-	marker := "#"
-	if format == "json" {
-		return false
-	}
-	if format == "cue" {
-		marker = "//"
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), marker) {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --migrate moves the removed init-file inline sections into blueprint files;
+// dry-run touches nothing, --write moves them and the init file stops
+// declaring the key.
+func TestConvert_MigratesInitInlineSections(t *testing.T) {
+	dir := t.TempDir()
+	init := "blueprints:\n  format: yaml\n  location: .\npackages:\n  - name: git\n    action: install\n"
+	if err := os.WriteFile(filepath.Join(dir, "init.yaml"), []byte(init), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newConvertCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--migrate", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if !strings.Contains(out.String(), `move "packages"`) {
+		t.Fatalf("dry run did not describe the move:\n%s", out.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "packages", "from-init.yaml")); err == nil {
+		t.Fatal("dry run wrote files")
+	}
+
+	cmd = newConvertCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--migrate", "--write", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	moved, err := os.ReadFile(filepath.Join(dir, "packages", "from-init.yaml"))
+	if err != nil || !strings.Contains(string(moved), "git") {
+		t.Fatalf("moved blueprint = %q (%v), want the packages entry", moved, err)
+	}
+	rewritten, err := os.ReadFile(filepath.Join(dir, "init.yaml"))
+	if err != nil || strings.Contains(string(rewritten), "packages:") {
+		t.Fatalf("init still declares packages (%v):\n%s", err, rewritten)
+	}
+}
+
+// --to converts every blueprint file, replacing the originals only under
+// --write, and warns about comments it cannot carry across.
+func TestConvert_ToFormat(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "packages.yaml"), []byte("# tools\npackages:\n  - name: git\n    action: install\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newConvertCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--to", "toml", "--write", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "NOT preserved") {
+		t.Errorf("comment warning missing:\n%s", out.String())
+	}
+	converted, err := os.ReadFile(filepath.Join(dir, "packages.toml"))
+	if err != nil || !strings.Contains(string(converted), `name = "git"`) {
+		t.Fatalf("converted = %q (%v)", converted, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "packages.yaml")); err == nil {
+		t.Error("original left behind after --write")
+	}
+}

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -1,78 +1,25 @@
 package cmd
 
 import (
-	"bytes"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
 
-// --migrate moves the removed init-file inline sections into blueprint files;
-// dry-run touches nothing, --write moves them and the init file stops
-// declaring the key.
-func TestConvert_MigratesInitInlineSections(t *testing.T) {
-	dir := t.TempDir()
-	init := "blueprints:\n  format: yaml\n  location: .\npackages:\n  - name: git\n    action: install\n"
-	if err := os.WriteFile(filepath.Join(dir, "init.yaml"), []byte(init), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
+// The command is wiring only (the implementation and its tests live in
+// internal/convert); what belongs to the command is flag validation.
+func TestConvert_RequiresSomethingToDo(t *testing.T) {
 	cmd := newConvertCmd()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetArgs([]string{"--migrate", dir})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("dry run: %v", err)
-	}
-	if !strings.Contains(out.String(), `move "packages"`) {
-		t.Fatalf("dry run did not describe the move:\n%s", out.String())
-	}
-	if _, err := os.Stat(filepath.Join(dir, "packages", "from-init.yaml")); err == nil {
-		t.Fatal("dry run wrote files")
-	}
-
-	cmd = newConvertCmd()
-	cmd.SetOut(&out)
-	cmd.SetArgs([]string{"--migrate", "--write", dir})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	moved, err := os.ReadFile(filepath.Join(dir, "packages", "from-init.yaml"))
-	if err != nil || !strings.Contains(string(moved), "git") {
-		t.Fatalf("moved blueprint = %q (%v), want the packages entry", moved, err)
-	}
-	rewritten, err := os.ReadFile(filepath.Join(dir, "init.yaml"))
-	if err != nil || strings.Contains(string(rewritten), "packages:") {
-		t.Fatalf("init still declares packages (%v):\n%s", err, rewritten)
+	cmd.SetArgs([]string{t.TempDir()})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "nothing to do") {
+		t.Fatalf("err = %v, want the nothing-to-do error", err)
 	}
 }
 
-// --to converts every blueprint file, replacing the originals only under
-// --write, and warns about comments it cannot carry across.
-func TestConvert_ToFormat(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "packages.yaml"), []byte("# tools\npackages:\n  - name: git\n    action: install\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
+func TestConvert_RejectsUnknownFormat(t *testing.T) {
 	cmd := newConvertCmd()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetArgs([]string{"--to", "toml", "--write", dir})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("convert: %v", err)
-	}
-
-	if !strings.Contains(out.String(), "NOT preserved") {
-		t.Errorf("comment warning missing:\n%s", out.String())
-	}
-	converted, err := os.ReadFile(filepath.Join(dir, "packages.toml"))
-	if err != nil || !strings.Contains(string(converted), `name = "git"`) {
-		t.Fatalf("converted = %q (%v)", converted, err)
-	}
-	if _, err := os.Stat(filepath.Join(dir, "packages.yaml")); err == nil {
-		t.Error("original left behind after --write")
+	cmd.SetArgs([]string{"--to", "ini", t.TempDir()})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("unknown format accepted")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ git checkouts, scripts, and desktop configuration.`,
 				"config":   true,
 				"version":  true,
 				"validate": true,
+				"convert":  true,
 			}
 
 			// Check if the current command or any of its parents should skip init
@@ -111,6 +112,7 @@ git checkouts, scripts, and desktop configuration.`,
 	rootCmd.AddCommand(newValidateCmd(app))
 	rootCmd.AddCommand(newVersionCmd(app))
 	rootCmd.AddCommand(newProfilesCmd(app))
+	rootCmd.AddCommand(newConvertCmd())
 
 	return rootCmd
 }

--- a/docs/cli/convert.md
+++ b/docs/cli/convert.md
@@ -1,0 +1,43 @@
+# rwr convert
+
+Convert a blueprint tree between formats, or migrate deprecated constructs to
+their current equivalents. Dry-run by default — nothing is written without
+`--write`.
+
+## Format conversion
+
+```bash
+rwr convert --to toml path/to/tree
+rwr convert --to cue --write path/to/tree
+```
+
+Every blueprint, init, bootstrap, and manifest file is decoded and re-encoded
+in the target format; originals are replaced only under `--write`.
+
+Limits, stated plainly:
+
+- **Comments are not preserved.** Conversion is a decode/encode cycle and no
+  format's comment model maps onto another's. The command warns per file that
+  carries comments so you can port them by hand.
+- **Template placeholders survive as quoted strings** (`"{{ .User.home }}"`).
+  A file whose templates make it unparseable raw is reported and skipped,
+  never mangled.
+- **CUE output is JSON-form CUE** — valid and lossless. Idiomatic CUE
+  (schemas, constraints) is authoring work the converter does not guess at.
+
+## Migration
+
+```bash
+rwr convert --migrate path/to/tree
+rwr convert --migrate --write path/to/tree
+```
+
+Rewrites deprecated constructs. Current rules:
+
+- **Init-file inline resource sections** (`packages:`, `repositories:`, …
+  declared in `init.yaml`) move into blueprint files under the tree
+  (`packages/from-init.yaml`, …). These sections were removed from the init
+  schema — they were decoded and never applied — and an init file still
+  carrying them is an error until migrated.
+
+`--to` and `--migrate` compose in one invocation.

--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -1,0 +1,213 @@
+// Package convert rewrites blueprint trees: between formats (--to) and from
+// deprecated constructs to their current equivalents (--migrate). Dry-run by
+// default; nothing is written unless write is set.
+package convert
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"gopkg.in/yaml.v3"
+)
+
+// say writes progress lines; a broken stdout must not abort a conversion
+// midway through a tree.
+func say(w io.Writer, format string, args ...interface{}) {
+	fmt.Fprintf(w, format, args...) //nolint:errcheck
+}
+
+// Run walks root and converts every blueprint, init, bootstrap, and manifest
+// file: to toFormat when set (and different from the file's own), and through
+// the migration rules when migrate is set. Comments are not preserved across
+// formats — each file carrying them is warned about. A file whose template
+// placeholders make it unparseable is reported and skipped, never mangled.
+func Run(out io.Writer, root, toFormat string, migrate, write bool) error {
+	changed := 0
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if path != root && strings.HasPrefix(info.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !helpers.IsBlueprintFile(path) {
+			return nil
+		}
+
+		format, err := helpers.FormatForPath(path)
+		if err != nil {
+			return nil
+		}
+
+		data, err := os.ReadFile(path) // #nosec G304 G122 -- operator's own tree, walked read-only
+		if err != nil {
+			say(out, "  ! %s: %v\n", path, err)
+			return nil
+		}
+
+		var doc map[string]interface{}
+		if err := helpers.UnmarshalBlueprint(data, format, &doc); err != nil {
+			say(out, "  ! %s: cannot parse (%v) — skipped, not mangled\n", path, err)
+			return nil
+		}
+
+		if hasComments(data, format) {
+			say(out, "  ~ %s carries comments; they are NOT preserved across formats\n", path)
+		}
+
+		if migrate {
+			base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+			if base == "init" {
+				n, migErr := migrateInitInlineSections(out, path, doc, format, write)
+				if migErr != nil {
+					return migErr
+				}
+				changed += n
+			}
+		}
+
+		if toFormat != "" && toFormat != format {
+			target := strings.TrimSuffix(path, filepath.Ext(path)) + extensionFor(toFormat)
+			encoded, encErr := encodeAs(doc, toFormat)
+			if encErr != nil {
+				say(out, "  ! %s: cannot encode as %s: %v\n", path, toFormat, encErr)
+				return nil
+			}
+			if write {
+				if wErr := os.WriteFile(target, encoded, 0o644); wErr != nil { // #nosec G306 G122 -- blueprint files are world-readable config; operator's own tree
+					return wErr
+				}
+				if rmErr := os.Remove(path); rmErr != nil { // #nosec G122 -- removing the file just converted, operator's own tree
+					return rmErr
+				}
+			}
+			say(out, "  → %s => %s\n", path, target)
+			changed++
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if changed == 0 {
+		say(out, "nothing to change\n")
+	} else if !write {
+		say(out, "%d change(s); re-run with --write to apply\n", changed)
+	}
+	return nil
+}
+
+// migrateInitInlineSections moves the removed inline resource sections out of
+// an init file into blueprint files — the first migration rule.
+func migrateInitInlineSections(out io.Writer, initPath string, doc map[string]interface{}, format string, write bool) (int, error) {
+	sections := map[string]string{
+		"repositories": "repositories", "packages": "packages", "services": "services",
+		"files": "files", "templates": "files", "directories": "files", "configuration": "configuration",
+	}
+	root := filepath.Dir(initPath)
+	moved := 0
+	for key, dir := range sections {
+		value, present := doc[key]
+		if !present {
+			continue
+		}
+		targetDir := filepath.Join(root, dir)
+		target := filepath.Join(targetDir, "from-init"+extensionFor(format))
+		say(out, "  → %s: move %q into %s\n", initPath, key, target)
+		if write {
+			if err := os.MkdirAll(targetDir, 0o755); err != nil { // #nosec G301 -- operator's own blueprint tree
+				return moved, err
+			}
+			payload := map[string]interface{}{key: value}
+			if existing, err := os.ReadFile(target); err == nil { // #nosec G304 -- operator's own tree
+				var current map[string]interface{}
+				if helpers.UnmarshalBlueprint(existing, format, &current) == nil {
+					current[key] = value
+					payload = current
+				}
+			}
+			encoded, err := encodeAs(payload, format)
+			if err != nil {
+				return moved, err
+			}
+			if err := os.WriteFile(target, encoded, 0o644); err != nil { // #nosec G306 -- blueprint files are world-readable config
+				return moved, err
+			}
+			delete(doc, key)
+			rewritten, err := encodeAs(doc, format)
+			if err != nil {
+				return moved, err
+			}
+			if err := os.WriteFile(initPath, rewritten, 0o644); err != nil { // #nosec G306
+				return moved, err
+			}
+		}
+		moved++
+	}
+	return moved, nil
+}
+
+// encodeAs renders a document in a target format. CUE output is JSON-form
+// CUE: valid, lossless, mechanical — idiomatic CUE is authoring work.
+func encodeAs(doc map[string]interface{}, format string) ([]byte, error) {
+	switch format {
+	case "yaml":
+		return yaml.Marshal(doc)
+	case "json":
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(doc); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case "toml":
+		var buf bytes.Buffer
+		if err := toml.NewEncoder(&buf).Encode(doc); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case "cue":
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetIndent("", "\t")
+		if err := enc.Encode(doc); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+	return nil, fmt.Errorf("unsupported target format %q", format)
+}
+
+func extensionFor(format string) string {
+	return "." + format
+}
+
+// hasComments detects comment markers well enough to warn (never to block).
+func hasComments(data []byte, format string) bool {
+	marker := "#"
+	if format == "json" {
+		return false
+	}
+	if format == "cue" {
+		marker = "//"
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/convert/convert_test.go
+++ b/internal/convert/convert_test.go
@@ -1,0 +1,69 @@
+package convert
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// migrate moves the removed init-file inline sections into blueprint files;
+// dry-run touches nothing, write moves them and the init file stops
+// declaring the key.
+func TestRun_MigratesInitInlineSections(t *testing.T) {
+	dir := t.TempDir()
+	init := "blueprints:\n  format: yaml\n  location: .\npackages:\n  - name: git\n    action: install\n"
+	if err := os.WriteFile(filepath.Join(dir, "init.yaml"), []byte(init), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := Run(&out, dir, "", true, false); err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if !strings.Contains(out.String(), `move "packages"`) {
+		t.Fatalf("dry run did not describe the move:\n%s", out.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "packages", "from-init.yaml")); err == nil {
+		t.Fatal("dry run wrote files")
+	}
+
+	if err := Run(&out, dir, "", true, true); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	moved, err := os.ReadFile(filepath.Join(dir, "packages", "from-init.yaml"))
+	if err != nil || !strings.Contains(string(moved), "git") {
+		t.Fatalf("moved blueprint = %q (%v), want the packages entry", moved, err)
+	}
+	rewritten, err := os.ReadFile(filepath.Join(dir, "init.yaml"))
+	if err != nil || strings.Contains(string(rewritten), "packages:") {
+		t.Fatalf("init still declares packages (%v):\n%s", err, rewritten)
+	}
+}
+
+// toFormat converts every blueprint file, replacing the originals only under
+// write, and warns about comments it cannot carry across.
+func TestRun_ToFormat(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "packages.yaml"), []byte("# tools\npackages:\n  - name: git\n    action: install\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := Run(&out, dir, "toml", false, true); err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "NOT preserved") {
+		t.Errorf("comment warning missing:\n%s", out.String())
+	}
+	converted, err := os.ReadFile(filepath.Join(dir, "packages.toml"))
+	if err != nil || !strings.Contains(string(converted), `name = "git"`) {
+		t.Fatalf("converted = %q (%v)", converted, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "packages.yaml")); err == nil {
+		t.Error("original left behind after --write")
+	}
+}

--- a/openspec/changes/add-convert-command/proposal.md
+++ b/openspec/changes/add-convert-command/proposal.md
@@ -2,8 +2,23 @@
 
 Depends on: `add-format-registry` (decode/encode dispatch),
 `unify-blueprint-semantics` (defines the "current state" trees migrate to).
-Status: stub — requested alongside the decision to drop init-file inline
-sections; needs fleshing out before implementation.
+Status: fleshed out (task 1). Decisions:
+
+- **Comments are not preserved.** Cross-format conversion goes through a
+  decode/encode cycle and no format's comment model maps onto another's;
+  promising partial preservation invites silent loss. The command WARNS when
+  a source file carries comments so the operator knows to port them by hand.
+- **Template placeholders round-trip as strings.** `{{ .User.home }}` inside
+  a quoted scalar decodes and re-encodes byte-preserved. A file whose
+  templates make it unparseable raw (unquoted `{{` at value start in YAML)
+  cannot be converted and is reported per file, not silently mangled.
+- **CUE export style is JSON-form CUE** — valid CUE, lossless, and
+  mechanical. Idiomatic CUE (constraints, unification) is authoring work a
+  converter should not guess at.
+- **Migration rules are a registry** (`migrateRules`), one entry per
+  deprecation, each: detect(tree) → describe → apply. First rule:
+  init-file inline resource sections move into blueprint files
+  (`packages:` → `packages/from-init.<fmt>`, …).
 
 ## Why
 

--- a/openspec/changes/add-convert-command/specs/cli/spec.md
+++ b/openspec/changes/add-convert-command/specs/cli/spec.md
@@ -1,0 +1,46 @@
+# CLI — Deltas
+
+## ADDED Requirements
+
+### Requirement: rwr convert converts trees and migrates deprecated constructs
+
+`rwr convert [path]` SHALL convert every blueprint, init, bootstrap, and
+manifest file in a tree to another format (`--to yaml|json|toml|cue`) and
+SHALL rewrite deprecated constructs to their current equivalents
+(`--migrate`). It SHALL be a dry run by default: nothing is written without
+`--write`.
+
+Comments are not preserved across formats; the command SHALL warn per file
+that carries them. A file whose template placeholders make it unparseable
+SHALL be reported and skipped, never mangled. CUE output is JSON-form CUE:
+valid and lossless; idiomatic CUE remains authoring work.
+
+The first migration rule SHALL move init-file inline resource sections
+(`repositories`, `packages`, `services`, `files`, `templates`, `directories`,
+`configuration`) out of the init file into blueprint files under the tree —
+the construct strict decode now rejects.
+
+#### Scenario: Dry run by default
+
+- **WHEN** `rwr convert tree --to toml` runs without `--write`
+- **THEN** the planned conversions are printed and no file is created,
+  removed, or modified
+
+#### Scenario: Tree conversion with --write
+
+- **GIVEN** a YAML tree
+- **WHEN** `rwr convert tree --to toml --write` runs
+- **THEN** each blueprint is rewritten as `.toml`, the original files are
+  removed, and the resulting tree validates
+
+#### Scenario: Migrating inline init sections
+
+- **GIVEN** an init file declaring a top-level `packages:` list
+- **WHEN** `rwr convert tree --migrate --write` runs
+- **THEN** the section lands in `packages/from-init.<ext>`, the init file
+  keeps only its own keys, and a re-run reports nothing to change
+
+#### Scenario: Unparseable templated file is skipped
+
+- **WHEN** a blueprint's template placeholders make it unparseable
+- **THEN** the file is reported and left untouched

--- a/openspec/changes/add-convert-command/tasks.md
+++ b/openspec/changes/add-convert-command/tasks.md
@@ -1,8 +1,8 @@
 # Tasks
 
-- [ ] 1. Flesh out the proposal: comment preservation limits per format,
+- [x] 1. Flesh out the proposal: comment preservation limits per format,
       template-placeholder round-tripping, CUE export style.
-- [ ] 2. Design doc for `--migrate` rule registry (one rule per deprecation).
-- [ ] 3. Implement `--to <format>`.
-- [ ] 4. Implement `--migrate` with the init-inline-sections rule.
-- [ ] 5. Docs + examples.
+- [x] 2. Design doc for `--migrate` rule registry (folded into the proposal: detect/describe/apply registry, one rule per deprecation) (one rule per deprecation).
+- [x] 3. Implement `--to <format>`.
+- [x] 4. Implement `--migrate` with the init-inline-sections rule.
+- [x] 5. Docs + examples (docs/cli/convert.md; converted-tree validation smoke).


### PR DESCRIPTION
Implements the `add-convert-command` OpenSpec change (5/5 tasks).

## What

- `rwr convert [path] --to yaml|json|toml|cue` converts every blueprint, init, bootstrap, and manifest file in a tree to another format.
- `rwr convert [path] --migrate` rewrites deprecated constructs to their current form — first rule: init-file inline sections (`repositories`/`packages`/`services`/`files`/`templates`/`directories`/`configuration`) move out of the init file into blueprint files (`<section>/from-init.<ext>`), the construct #215 removed from the runtime schema.
- Dry-run by default; `--write` applies. Comments are not preserved across formats — the command warns per file that carries them. Files whose template placeholders make them unparseable are reported and skipped, never mangled.
- CUE output is JSON-form CUE: valid and lossless; idiomatic CUE remains authoring work.

## Verification

- `go test ./...`, `golangci-lint run`, `gosec` all clean.
- Manual smoke: yaml tree with inline init sections → `--to toml --migrate --write` produces a valid tree; sections land in `packages/from-init.toml`, init keeps only its own keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)