### PR TITLE
docs: fix the drift #168 missed

### DIFF
--- a/docs/blueprints/common-fields.md
+++ b/docs/blueprints/common-fields.md
@@ -59,9 +59,27 @@ silently ignored one.
 `interactive: true` or `interactive: false` overrides the global `--interactive`
 flag for a single entry. Omit it to follow the flag.
 
-Supported by `files`, `templates`, `directories`, `packages`, `repositories`,
-`git`, `scripts`, `services`, `ssh_keys` and `users`. Not supported by `fonts`,
-`groups` or `configurations`.
+Read per entry by `directories`, `packages`, `repositories`, `scripts`,
+`services`, `ssh_keys` and `users`. `files`, `templates` and `git` accept the
+key but do **not** read it — those processors follow only the global flag. Not
+supported at all by `fonts`, `groups` or `configurations`.
+
+## `schema_version`
+
+Every blueprint file may declare a `schema_version` at the top level, next to
+its entry list:
+
+```yaml
+schema_version: 1
+packages:
+  - name: git
+    action: install
+```
+
+A file's declaration overrides the tree-wide version from the init file, which
+is how a single blueprint can move to a newer schema while the rest of the tree
+stays put. Today every blueprint type supports only version `1`; declaring a
+version a type does not support is an error.
 
 ## `name` and `names`
 

--- a/docs/blueprints/configuration.md
+++ b/docs/blueprints/configuration.md
@@ -30,7 +30,7 @@ The following settings are available for every entry, whichever tool it uses:
 | `profiles` | No | Profiles this entry belongs to. Empty means it is always applied |
 | `elevated` | No | Whether to run the configuration with elevated privileges (default: false) |
 | `run_once` | No | dconf only: create a marker file and skip the entry on later runs (default: false) |
-| `action` | No | Accepted by the schema but **not read**. The `tool` decides what happens; there is nothing to select |
+| `action` | No | `set` is the only supported action; leaving it out means the same thing. Any other value is recorded as a failure for that entry |
 | `names` | No | Accepted by the schema but **not read**. One entry is one operation |
 
 The tool-specific settings are `file`, `schema`, `key`, `settings`, `value`,

--- a/docs/blueprints/files.md
+++ b/docs/blueprints/files.md
@@ -53,7 +53,7 @@ The following settings are available for the Files Blueprint:
 | `mode` | No | The permission mode. Applied by `create` and `chmod` only. See [File modes](#file-modes). |
 | `elevated` | No | Only the `copy` action reads this. With `true`, the copy is staged through a temporary file and installed with elevation. Every other file action is performed by rwr's own process and ignores the field. Defaults to `false`. |
 | `variables` | No | A map of variables and their values to be used for template rendering. Only applicable to the `templates` section. |
-| `interactive` | No | Override global interactive mode for this file (`true`/`false`). If omitted, uses the global `--interactive` flag. Controls whether diffs are shown before overwriting existing files. |
+| `interactive` | No | Accepted by the schema but **not read** by the files processor: file operations run the same way whatever it is set to. Only the global `--interactive` flag has any effect here. |
 
 ## Blueprint Imports
 

--- a/docs/blueprints/git.md
+++ b/docs/blueprints/git.md
@@ -33,13 +33,13 @@ The following settings are available for each repository in the Git blueprint:
 |---------|----------|-------------|
 | `name` | Yes, if `import` is not provided | A unique name for the repository |
 | `import` | Yes, if `name` is not provided | Path to import git repository definitions from another file (relative to blueprint directory) |
-| `action` | No | Accepted by the schema but **not read**. Each entry is cloned if `path` does not exist and pulled if it does |
+| `action` | No | `clone` or `pull`. Empty or `clone` clones when `path` does not exist and pulls when it does; `pull` requires something to already be checked out at `path`. Any other value is an error |
 | `url` | Yes | The URL of the Git repository to clone |
 | `branch` | No | The branch to clone (defaults to the repository's default branch) |
 | `path` | Yes | The local path where the repository should be cloned |
 | `private` | No | Indicates whether the repository is private (defaults to `false`) |
 | `profiles` | No | List of profiles this repository belongs to. If empty, repository is always cloned (base item) |
-| `interactive` | No | Override global interactive mode for this git repository (`true`/`false`). If omitted, uses the global `--interactive` flag |
+| `interactive` | No | Accepted by the schema but **not read** by the git processor: clones and pulls run the same way whatever it is set to |
 
 ## Blueprint Imports
 

--- a/docs/blueprints/packages.md
+++ b/docs/blueprints/packages.md
@@ -47,12 +47,12 @@ The Packages Blueprint supports the following settings:
 | `import` | Yes, if `name` or `names` is not provided | Path to import package definitions from another file (relative to blueprint directory) |
 | `action` | Yes | `install` or `remove`. See [Actions](#actions) |
 | `package_manager` | No | The package manager to use (e.g., `apt`, `brew`, `chocolatey`) |
-| `elevated` | No | Accepted by the schema but **not read**. Whether the package manager is run with elevation comes from the provider definition, not from the entry |
+| `elevated` | No | Ask for elevation on top of what the provider declares. The provider decides whether its package manager needs elevation; an entry may add it (a user-scoped manager invoked against a system path) but may not take it away |
 | `args` | No | Additional arguments to pass to the package manager (as a list of strings), appended after the package name |
 | `profiles` | No | List of profiles this package belongs to. If empty, package is always installed (base item) |
 | `interactive` | No | Override global interactive mode for this package (`true`/`false`). If omitted, uses the global `--interactive` flag |
 
-Note that you must provide either `name`, `names`, or `import` for each package entry. If both `name` and `names` are given, `name` wins and `names` is ignored.
+Note that you must provide either `name`, `names`, or `import` for each package entry. If both `name` and `names` are given, the `names` list is processed and `name` is ignored (with a warning), matching how `files` and `fonts` behave.
 
 ### Package names may not begin with `-`
 
@@ -65,12 +65,10 @@ elevated package manager does.
 
 ### Actions
 
-`install` and `remove` are implemented.
-
-`update` is accepted by `rwr validate` but **not implemented by the packages
-processor**: an entry declaring it is recorded as a failure with "unknown
-action" at run time. To refresh package lists, run a repositories blueprint —
-RWR runs each available provider's update command after processing it.
+`install` and `remove` are implemented. Any other value — including `update` —
+is reported by `rwr validate` and recorded as a failure with "unknown action"
+at run time. To refresh package lists, run a repositories blueprint — RWR runs
+each available provider's update command after processing it.
 
 ## Blueprint Imports
 

--- a/docs/blueprints/repositories.md
+++ b/docs/blueprints/repositories.md
@@ -30,6 +30,7 @@ blueprint did not supply is an error naming the repository, not a blank.
 | `action` | Yes | `add` or `remove` |
 | `url` | Yes for `add` | The repository URL. A value with no scheme, or a `file://` URL, is treated as a local path — that is what selects the sideload steps for `snap` and `gnome-extensions` |
 | `key_url` | No | URL of the repository's signing key, downloaded to the provider's key directory (apt, dnf, zypper, apk, xbps, eopkg, slackpkg) |
+| `key_sha256` | No | SHA-256 digest of the signing key at `key_url`; the key download is verified against it |
 | `key_id` | No | Key ID to import or delete rather than a URL (pacman family, and the `rpm --erase gpg-pubkey-<id>` step in dnf/zypper removal) |
 | `arch` | No | Architecture written into an apt source line |
 | `channel` | No | Suite/channel written into an apt source line |
@@ -42,6 +43,9 @@ blueprint did not supply is an error naming the repository, not a blank.
 | `proxy_url` | No | Proxy snapd should route through; setting it adds the `snap set system proxy.*` steps |
 | `uuid` | No | GNOME extension UUID, used to enable, disable and uninstall the extension |
 | `extension_id` | No | GNOME extension ID, used when installing from extensions.gnome.org |
+| `interface` | No | Snap interface to connect after install (`snap connect <name>:<interface> <slot>`) |
+| `slot` | No | The slot the snap interface plugs into |
+| `reset_settings` | No | GNOME extensions only: also reset the extension's settings when removing it (default `false`) |
 | `username` | No | Username for a private source (chocolatey). See the warning below |
 | `password` | No | Password for a private source (chocolatey). See the warning below |
 | `token` | No | Registry token (`cargo login`). See the warning below |
@@ -64,17 +68,14 @@ rendered, so the settings above take effect.
 
 ## Actions and what actually works
 
-Every shipped provider defines both `add` and `remove` steps. Two of them do not
-work, and are documented here rather than left to fail on your machine:
-
-| Provider | State |
-|----------|-------|
-| `snap`, `action: add` | **Broken.** The provider's last add step is gated on a `HasInterfaces` predicate RWR does not derive, and an unknown predicate is an error rather than a silent skip, so every snap repository add fails. Snap removal works |
-| `gnome-extensions`, `action: remove` | **Broken.** The final step is gated on a `ResetSettings` predicate RWR does not derive, so removal fails after the disable and uninstall steps have already run. Installing works |
-
-Everything else — apt, dnf, zypper, pacman/yay/paru/aura/pamac/trizen, apk,
-xbps, eopkg, emerge, slackpkg, brew, macports, nix, flatpak, cargo, chocolatey,
-scoop, winget, mas — supports both `add` and `remove`.
+Every shipped provider — apt, dnf, zypper, pacman/yay/paru/aura/pamac/trizen,
+apk, xbps, eopkg, emerge, slackpkg, brew, macports, nix, flatpak, snap, cargo,
+chocolatey, scoop, winget, mas, gnome-extensions — defines both `add` and
+`remove` steps, and both work. Provider steps may be gated on predicates RWR
+derives from the entry (`HasKey`, `HasInterfaces`, `ResetSettings`, …), so a
+step for a feature you did not ask for is simply skipped: a snap add without
+`interface` does not run `snap connect`, and a GNOME extension remove resets
+the extension's settings only when `reset_settings: true`.
 
 Two more things worth knowing:
 

--- a/docs/blueprints/services.md
+++ b/docs/blueprints/services.md
@@ -69,11 +69,7 @@ The Services Blueprint supports the following actions:
 - `create`: Create a new service file
 - `delete`: Delete an existing service file
 
-> [!NOTE]
-> `rwr validate` currently accepts only `enable`, `disable`, `start`, `stop` and
-> `restart`, and reports the other four as invalid. The processor runs all nine.
-> If you use `reload`, `status`, `create` or `delete`, expect a validation error
-> you can ignore.
+`rwr validate` accepts all nine actions.
 
 ## Platform-Specific Considerations
 

--- a/docs/blueprints/ssh-keys.md
+++ b/docs/blueprints/ssh-keys.md
@@ -79,7 +79,7 @@ If `copy_to_github` is set to `true`, RWR will attempt to copy the public key to
 
 RWR supports three methods for GitHub authentication (in priority order):
 
-1. **`--gh-api-key` / `--gh-key` flag** - Provide an explicit GitHub token
+1. **`--gh-api-key` flag** - Provide an explicit GitHub token (`--gh-key` is a deprecated alias)
 2. **`--gh-auth` flag** - Authenticate using OAuth device flow (recommended for first-time setup)
 3. **`GITHUB_TOKEN` environment variable** - For CI/CD environments
 
@@ -99,12 +99,6 @@ This will:
 After this initial setup, future runs won't require `--gh-auth` as the token is saved in your config.
 
 #### Using an Explicit Token
-
-```bash
-rwr run ssh_keys --gh-key ghp_your_token_here
-```
-
-Or use the longer form:
 
 ```bash
 rwr run ssh_keys --gh-api-key ghp_your_token_here
@@ -130,7 +124,7 @@ If `github_title` is provided, it will be used as the title for the SSH key on G
 #### GitHub token not found
 
 - Use `--gh-auth` to authenticate via OAuth
-- Or use `--gh-key` flag with your token
+- Or use the `--gh-api-key` flag with your token
 - Or set `GITHUB_TOKEN` environment variable
 
 #### Authentication timeout

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -100,8 +100,8 @@ The Bootstrap Process executes the sections in the following order:
 4. `ssh_keys`
 5. `git`
 6. `services`
-7. `groups`
-8. `users`
+7. `users`
+8. `groups`
 
 This order ensures that the necessary dependencies and prerequisites are in place before proceeding with other tasks.
 
@@ -116,6 +116,14 @@ rwr all --force-bootstrap
 ```
 
 This flag will ensure that the Bootstrap Process is executed even if it has been run previously.
+
+The "has run" state is a marker file in the RWR configuration directory. A
+`--dry-run` execution does **not** write the marker, so a real run after a
+dry-run still performs the bootstrap.
+
+Like every other blueprint file, the bootstrap file may declare a
+`schema_version` at the top level to override the tree-wide version from the
+init file.
 
 ## New Features and Enhancements
 
@@ -133,6 +141,7 @@ This flag will ensure that the Bootstrap Process is executed even if it has been
 
 - The `ssh_keys` section has been added to generate and manage SSH keys during the bootstrap process.
 - The `set_as_rwr_ssh_key` option allows setting a generated key as the default RWR SSH key for operations.
+- With `copy_to_github: true`, the optional `github_title` field names the key on GitHub; without it, the machine's hostname is used.
 
 ## Best Practices
 

--- a/docs/cli/command-and-flags.md
+++ b/docs/cli/command-and-flags.md
@@ -19,7 +19,7 @@ The following flags are available for all commands:
 | `--dry-run` | Simulate operations without making changes (no-op mode) |
 | `--no-op` | Alias for `--dry-run` |
 | `--interactive`, `-I` | Enable interactive mode (default: true). Use `--interactive=false` to disable |
-| `--gh-key` | Another name for `--gh-api-key` |
+| `--gh-key` | Deprecated alias for `--gh-api-key`; use `--gh-api-key` |
 | `--gh-auth` | Get a GitHub token with the OAuth device flow. Only `rwr all` and `rwr run ssh_keys` act on it |
 | `--profile`, `-p` | Make a profile active. Repeat the flag, or give a comma-separated list |
 | `--force-bootstrap` | Run the bootstrap process again |

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -41,11 +41,7 @@ The `rwr` section contains general settings for the RWR tool.
 | Option | Description |
 |--------|-------------|
 | `configdir` | The config directory: where `config.yaml` is looked up, where `rwr config --create` writes it, and where the `bootstrap` marker lives. The default is `$HOME/.config/rwr`. Because it decides where the config file is, it only takes effect from the environment (`RWR_RWR_CONFIGDIR`) — a config file cannot name its own directory. `--config` overrides it |
-
-> [!NOTE]
-> There is no working `rwr.skipVersionCheck` option. The key is written by
-> `rwr config --create`, but nothing reads it back: only the
-> `--skip-version-check` flag turns the version check off.
+| `skipVersionCheck` | Set to `true` to turn off the startup check for a newer release. The `--skip-version-check` flag does the same for a single run |
 
 ### `repository` Section
 
@@ -82,8 +78,7 @@ log:
   level: info
 ```
 
-RWR reads only the keys listed above. `rwr config --create` also writes
-`rwr.skipVersionCheck`, which nothing reads.
+RWR reads only the keys listed above.
 
 ## Modifying the Configuration File
 
@@ -104,9 +99,8 @@ The settings in the `config.yaml` file have precedence over the default values u
 RWR reads the same options from the environment. An environment variable takes
 precedence over `config.yaml` but is overridden by a command-line flag.
 
-The name is `RWR_` followed by the option's full key in upper case, with each dot
-replaced by an underscore. **A hyphen in the key is kept as a hyphen** — it is
-not turned into an underscore.
+The name is `RWR_` followed by the option's full key in upper case, with each
+dot **and each hyphen** replaced by an underscore.
 
 | Config key | Environment variable |
 |---|---|
@@ -115,22 +109,18 @@ not turned into an underscore.
 | `repository.ssh_private_key` | `RWR_REPOSITORY_SSH_PRIVATE_KEY` |
 | `repository.init-file` | `RWR_REPOSITORY_INIT_FILE` |
 | `rwr.configdir` | `RWR_RWR_CONFIGDIR` |
+| `rwr.skipVersionCheck` | `RWR_RWR_SKIPVERSIONCHECK` |
 
 ```bash
 RWR_LOG_LEVEL=debug rwr all
 RWR_REPOSITORY_GH_API_TOKEN=your_token rwr all
+RWR_REPOSITORY_INIT_FILE=/path/to/init.yaml rwr all
 ```
 
 > [!NOTE]
-> `RWR_REPOSITORY_INIT-FILE` contains a hyphen, so most shells will not accept it
-> in the `NAME=value command` form. Use `env` instead, or pass `--init-file`:
->
-> ```bash
-> env "RWR_REPOSITORY_INIT-FILE=/path/to/init.yaml" rwr all
-> ```
->
-> `RWR_REPOSITORY_INIT_FILE`, with an underscore, is a different name and is
-> ignored.
+> The hyphen in `repository.init-file` becomes an underscore in the environment
+> name. `RWR_REPOSITORY_INIT-FILE`, with a literal hyphen, is a different name
+> and is ignored.
 
 ## Notes
 

--- a/docs/cli/validate.md
+++ b/docs/cli/validate.md
@@ -77,12 +77,17 @@ Provider validation checks your provider configuration files for structural and 
 
 The provider validation process includes:
 
-* **File Type**: A provider configuration must be a `.toml` file
-* **Required Fields**: `provider.name`, the detection `binary` and
-  `distributions`, and the `install`, `update` and `remove` commands must all be
-  present
-* **Steps**: Each install step must name an action
-* **Paths**: A declared repository sources path must exist
+* **File Type**: A provider configuration must be a `.toml` or `.json` file
+  (an error otherwise)
+* **Required Fields**: A missing `provider.name` is an **error**. A missing
+  detection `binary` or `distributions` list, or a missing `install`, `update`
+  or `remove` command, is a **warning**
+* **Steps**: Each install, remove and repository step must name an action the
+  processor implements, and carry the fields that action needs (`exec` for
+  `command`, `source`/`dest` for `download` and `copy`, and so on) — errors.
+  Empty `content` on a `write` or `append` step is a warning
+* **Paths**: A declared repository sources path that does not exist on this
+  system is a warning
 
 ## Error Reporting
 
@@ -148,14 +153,19 @@ rwr validate path/to/file --providers
 
 ### Provider Errors
 
-| Message | Meaning |
-|---------|---------|
-| `Not a TOML file` | Provider configurations must be `.toml` |
-| `Missing required field 'provider.name'` | The `[provider]` section has no `name` |
-| `Missing binary in detection section` | The provider does not say which binary to look for |
-| `No distributions specified in detection section` | The provider does not say which distributions it supports |
-| `Missing install command` / `Missing update command` / `Missing remove command` | A required command is absent from `[commands]` |
-| `No providers available for the current system` | Nothing was detected on this machine |
+| Message | Severity | Meaning |
+|---------|----------|---------|
+| `Not a provider file` | Error | Provider configurations must be `.toml` or `.json` |
+| `Missing required field 'provider.name'` | Error | The `[provider]` section has no `name` |
+| `Missing binary in detection section` | Warning | The provider does not say which binary to look for |
+| `No distributions specified in detection section` | Warning | The provider does not say which distributions it supports |
+| `Missing install command` / `Missing update command` / `Missing remove command` | Warning | A command is absent from `[commands]` |
+| `Unsupported action "…" in … step` | Error | A step names an action the processor does not implement |
+| `Missing exec/source/dest/path/… in … step` | Error | A step lacks a field its action needs |
+| `No providers available for the current system` | Warning | Nothing was detected on this machine |
+
+Only errors make the exit code non-zero; a run that produces warnings alone
+still exits `0`.
 
 ## Best Practices
 

--- a/docs/init-file.md
+++ b/docs/init-file.md
@@ -168,23 +168,8 @@ For Arch Linux:
 - Yay (yay)
 - Paru (paru)
 - Trizen (trizen)
-- Yaourt (yaourt)
 - Pamac (pamac)
 - Aura (aura)
-
-#### Node.js Package Managers
-
-- npm (npm)
-- pnpm (pnpm)
-- Yarn (yarn)
-
-#### Pip (pip)
-
-Python package manager.
-
-#### RubyGems (gem)
-
-Ruby package manager.
 
 #### Cargo (cargo)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,12 +1,50 @@
 # Package Manager Providers
 
-The Providers system is a flexible and extensible way to manage package managers across different platforms. It uses TOML configuration files to define how package managers work, making it easy for anyone to add support for new package managers without needing to write Go code.
+The Providers system is a flexible and extensible way to manage package managers across different platforms. A provider is a declarative description of a package manager: the binary that identifies it, the files that prove it is in use, the command templates for install/remove/update, and the steps that add or remove a repository. Blueprints say `action: install`; the provider decides what that means on this machine.
+
+## Where providers live
+
+The providers shipped with RWR are authored in **CUE** under `providers/cue/` in
+the source tree. At build time they are exported to JSON
+(`mise run providers:export`), the JSON is committed under
+`internal/system/definitions/providers/`, and that JSON is embedded into the
+binary. The CUE toolchain never ships in RWR: it is a build-time check that
+rejects an invalid provider at export time (wrong action name, missing
+`commands.install`, a `/tmp/` staging path) instead of at runtime on a user's
+machine. CI fails when the committed JSON differs from a fresh export of the
+CUE sources.
+
+You do **not** need CUE to override a provider. RWR also loads provider
+definitions from the filesystem, as either **TOML** (the historical
+`[provider]` layout) or **JSON** (the same shape as the exported files — copy
+one from `internal/system/definitions/providers/` and edit it). A filesystem
+provider replaces an embedded provider of the same name.
+
+### Search paths
+
+RWR looks for a `providers/` directory in these locations, in order, and uses
+the first one that exists:
+
+1. Next to the `rwr` executable
+2. `/usr/local/share/rwr/providers`
+3. `/usr/share/rwr/providers`
+4. `~/.config/rwr/providers`
+5. macOS only: `/opt/homebrew/share/rwr/providers`,
+   `/usr/local/Cellar/rwr/providers`, `/Applications/rwr/providers`
+
+The current working directory is deliberately **not** searched. A provider file
+declares `exec`, `args` and `elevated = true` and those run verbatim, so
+honouring `./providers` would hand root-level execution to any directory rwr
+happens to be run from — a cloned blueprint repo, `/tmp`, a shared downloads
+folder.
+
+For the same reason, a provider file (or its directory) that is group- or
+world-writable is skipped with a warning; the rest of the directory still
+loads.
 
 ## Provider Configuration
 
-Providers are configured using TOML files in the `internal/system/definitions/providers/` directory. For example, `internal/system/definitions/providers/apt.toml` defines the configuration for the APT package manager.
-
-### Basic Structure
+A filesystem override in TOML looks like this:
 
 ```toml
 [provider]
@@ -25,12 +63,23 @@ distributions = [      # Where this provider is available
 ]
 
 [provider.commands]
-install = "install"   # Package installation command
+install = "install"   # Package installation command (required)
 update = "update"    # System update command
 remove = "remove"    # Package removal command
 list = "list"       # List installed packages
 search = "search"    # Search for packages
 clean = "clean"     # Clean package cache
+```
+
+`install` is the only required command. A provider that declares no `clean`
+command is simply not invoked during end-of-run cache cleaning.
+
+`environment` is an optional table of environment variables set for every
+package command the provider runs:
+
+```toml
+[provider.environment]
+SOME_FLAG = "1"
 ```
 
 ## How RWR finds a provider
@@ -89,74 +138,122 @@ config = "/etc/apt/apt.conf.d"       # Configuration
 action = "download"              # Download GPG key
 source = "{{ .KeyURL }}"
 dest = "{{ .KeyPath }}"
+sha256 = "{{ .KeySha256 }}"
+condition = "{{ .HasKey }}"
 
 [[provider.repository.add.steps]]
 action = "command"              # Import GPG key
 exec = "gpg"
 args = ["--import", "{{ .KeyPath }}"]
+condition = "{{ .HasKey }}"
 ```
+
+`remove` steps are declared the same way under
+`[[provider.repository.remove.steps]]`. A `remove` step that deletes a file is
+confined to the directories the provider declares as its repository paths.
 
 ### Installation Steps
 
-Define how to install the provider itself:
+Define how to install (or remove) the provider itself:
 
 ```toml
 [[provider.install.steps]]
-action = "command"              # Install dependencies
-exec = "package-manager"
-args = ["install", "dependency1"]
+action = "download"             # Download an installer
+source = "https://example.com/provider-install.sh"
+dest = "{{ .TempDir }}/provider-install.sh"
 
 [[provider.install.steps]]
-action = "mkdir"                # Create directories
-path = "/path/to/create"
-mode = "0755"
-
-[[provider.install.steps]]
-action = "download"             # Download provider
-source = "https://example.com/provider.tar.gz"
-dest = "/tmp/provider.tar.gz"
+action = "command"              # Run it
+exec = "sh"
+args = ["{{ .TempDir }}/provider-install.sh"]
 ```
+
+`[[provider.remove.steps]]` uses the same three actions to uninstall the
+provider.
+
+Do not stage files at fixed `/tmp/` paths — any local user can pre-create or
+rewrite such a path between the download and the elevated step that executes
+it. `{{ .TempDir }}` renders to a per-run `0700` directory other users cannot
+reach, and the CUE schema refuses to export a shipped provider whose install
+steps mention `/tmp/`.
 
 ## Available Actions
 
-RWR reads these actions in the installation steps of a provider:
+Install and remove steps of a provider accept these actions:
 
-- `command` - Run a command
-- `download` - Get a file from a URL
-- `write` - Write content to a file
+- `command` - Run a command (`exec` + `args`)
+- `download` - Get a file from a URL (`source` → `dest`, optional `sha256`)
+- `write` - Write `content` to a file at `dest`
 
-RWR reads these actions in the repository steps of a provider:
+Repository `add`/`remove` steps accept these actions:
 
-- `command` - Run a command
-- `write` - Write content to a file
-- `copy` - Copy a file
+- `command` (or `exec`) - Run a command
+- `download` - Get a file from a URL, verified against `sha256` when given
+- `write` - Write `content` to a file at `dest`
+- `copy` - Copy a file from `source` to `dest`
+- `append` - Append `content` to the file at `path`
+- `remove` - Delete the file at `path` (confined to the provider's repository
+  paths)
+- `remove_line` - Delete the lines matching `match` from the file at `path`
+- `remove_section` - Delete the named `section` from the file at `path`
 
-CAUTION: Use only the actions in these two lists. RWR stops with an error when a
-step gives a different action. Some provider files in this repository contain
-other actions, and those steps do not operate.
+A step with any other action stops the run with an error, and `rwr validate
+--providers` reports it beforehand.
+
+### Step fields
+
+Each step may carry: `action`, `exec`, `args`, `source`, `dest`, `content`,
+`path`, `match`, `section`, `sha256` and `condition`.
+
+`condition` is a template that gates the step: only a step whose condition
+renders truthy runs. Conditions may reference the derived predicates —
+`HasKey`, `HasInterfaces`, `HasSlot`, `HasProxy`, `HasToken`,
+`HasAuthentication`, `RequiresAuth`, `IsCustomRegistry`, `IsOverlay`,
+`IsMainRepo`, `IsLocalFile`, `IsLocalSnap`, `IsSnapStore`, `UserMode` — plus
+the step-data fields `ResetSettings` and `URL`. A condition naming anything
+else is an error at the point the step would have run.
 
 ## Template Variables
 
-These variables are in the repository steps of the provider files:
+Every templated field of a step is rendered — `source`, `dest`, `exec`,
+`content`, `path`, `match`, `section`, `sha256` and each entry of `args` — with
+`missingkey=error`, so a placeholder rwr cannot fill is reported rather than
+written to disk as literal text.
 
-- `{{ .Name }}` - Name of the repository or package
+Repository steps render against the repository entry being processed:
+
+- `{{ .Name }}` - Name of the repository (also used to derive
+  `{{ .KeyPath }}` = `<keys dir>/<name>.gpg`)
 - `{{ .URL }}` - URL of the repository
-- `{{ .KeyURL }}` - URL of the GPG key
+- `{{ .KeyURL }}` / `{{ .KeyID }}` / `{{ .KeySha256 }}` - The signing key: its
+  URL, its ID, and the digest the key download is verified against
 - `{{ .KeyPath }}` - Path of the key on the machine
-- `{{ .SourcesPath }}` - Path of the repository configuration
-- `{{ .Arch }}` - Architecture of the system
-- `{{ .Channel }}` - Channel of the repository
-- `{{ .Component }}` - Component of the repository
+- `{{ .TempKeyPath }}` - Per-run private staging path for the key
+- `{{ .SourcesPath }}` / `{{ .KeysPath }}` / `{{ .ConfigPath }}` - The
+  provider's declared repository paths
+- `{{ .Arch }}`, `{{ .Channel }}`, `{{ .Component }}`, `{{ .Repository }}`,
+  `{{ .Description }}` - Fields written into source lines and `.repo` files
+- `{{ .PackageManager }}`, `{{ .Action }}` - The entry's own manager and action
+- `{{ .OverlayPath }}`, `{{ .SyncType }}`, `{{ .SHA256 }}` - Portage/nix
+  overlay fields
+- `{{ .ProxyURL }}` - Proxy snapd should route through
+- `{{ .UUID }}`, `{{ .ExtensionID }}` - GNOME extension identifiers
+- `{{ .Interface }}`, `{{ .Slot }}`, `{{ .ResetSettings }}` - Snap interface
+  wiring and GNOME extension settings reset
+- `{{ .Path }}` - The local file a sideloaded snap or extension is installed
+  from
+- `{{ .Username }}`, `{{ .Password }}`, `{{ .Token }}` - Credentials for a
+  private source (kept out of rwr's own logs)
 
-CAUTION: RWR replaces only `{{ .URL }}`, and only in the `args` of a step. RWR
-does not replace the other variables. RWR does not replace a variable in the
-`dest` or `content` of a step. A step that uses one of those variables writes the
-text of the variable to the file.
-
-This is a known fault. Do not write a new provider that depends on these
-variables until the fault is corrected.
+Install and remove steps render against a single variable: `{{ .TempDir }}`,
+the run's private staging directory. Blueprint variables (`.UserDefined`,
+`.System`, …) are **not** in scope inside provider steps — provider steps
+describe the machine's package manager, not the blueprint.
 
 ## Supported Providers
+
+These are the definitions shipped in the binary (one per file under
+`providers/cue/`):
 
 ### Linux Package Managers
 
@@ -199,27 +296,34 @@ variables until the fault is corrected.
 ### Language Package Managers
 
 - cargo - Rust packages
-- npm/pnpm/yarn - Node.js packages
-- pip - Python packages
-- gem - Ruby packages
 
 ### Desktop Environment
 
 - gnome-extensions - GNOME Shell extensions
 
+There are no shipped definitions for npm, pnpm, yarn, pip or gem. To manage
+packages from those ecosystems today, install them with a `scripts` blueprint
+or add your own provider definition.
+
 ## Creating New Providers
 
-To add support for a new package manager:
+To change a shipped provider or add support for a new package manager without
+touching the source tree:
 
-1. Copy `internal/system/definitions/provider_template.toml` to `internal/system/definitions/providers/<name>.toml`
-2. Configure the provider sections:
-   - Basic information (name, elevation)
-   - Detection rules (binary, files, distros)
-   - Standard commands
-   - Core package requirements
-   - Repository management
-   - Installation/removal steps
-3. Test the provider with example blueprints
+1. Copy an exported JSON definition from
+   `internal/system/definitions/providers/` (or write a TOML file in the shape
+   shown above) into one of the search paths — `~/.config/rwr/providers/` for
+   a per-user override.
+2. Make sure the file is not group- or world-writable, or it will be skipped.
+3. Configure the provider sections: basic information, detection rules,
+   commands, core packages, repository management, install/remove steps.
+4. Check it with `rwr validate <file> --providers` and test with example
+   blueprints.
+
+To contribute a provider to RWR itself, author it in CUE under
+`providers/cue/` (the schema in `providers/cue/schema.cue` documents every
+field and rejects invalid definitions at export time) and run
+`mise run providers:export` to regenerate the committed JSON.
 
 ## Best Practices
 
@@ -228,8 +332,9 @@ To add support for a new package manager:
 - Document command flags in comments
 - Use consistent repository paths
 - Break complex operations into clear steps
+- Stage downloads under `{{ .TempDir }}`, never at fixed `/tmp` paths
+- Pin downloaded content with `sha256` where the upstream publishes digests
 - Validate repository configurations
-- Handle errors gracefully
 - Test on supported platforms
 
 ## Distribution-Specific Alternatives
@@ -284,7 +389,6 @@ This allows OpenMandriva users to use RWR with the DNF provider while automatica
 
 - Support for more package managers
 - Better dependency resolution
-- Package verification/signing
 - Repository mirroring
 - Version pinning
 - Rollback support

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -81,7 +81,9 @@ To run your first blueprint, follow these steps:
     rwr all
     ```
 
-    RWR installs only the base packages: git, curl, wget, and htop.
+    With no `--profile` flag, RWR installs **everything** — the base packages
+    (git, curl, wget, htop) and the profiled ones too. Profiles only start
+    filtering once at least one is active.
 
 3. To install packages for specific profiles, use the `--profile` flag:
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -52,6 +52,16 @@ environment overwrites a key of exactly the same name from `userDefined`.
 > options](cli/configuration.md), so `RWR_LOG_LEVEL=debug` both sets the log
 > level and appears as `{{ .UserDefined.LOG_LEVEL }}`.
 
+#### To the environment
+
+The flow also works in the other direction: RWR exports its resolved
+configuration values into the environment of every command it spawns, as
+`RWR_VAR_<KEY>` with dots turned into underscores — `log.level` becomes
+`RWR_VAR_LOG_LEVEL`. A script run by a `scripts` blueprint can read them.
+Credentials (the GitHub token, the SSH private key) are **not** exported unless
+the init file names them under `exposeCredentials`; see
+[credentials](credentials.md).
+
 ### Built-in Variables
 
 RWR provides a set of built-in variables that can be used in your blueprints. These variables are automatically populated based on the current system and configuration.
@@ -156,6 +166,27 @@ CAUTION: RWR registers no additional functions. A template that calls `default`,
 
 For the full list of standard functions, read the
 [Go template documentation](https://golang.org/pkg/text/template/).
+
+### Missing variables: strict at run time, lenient at validate
+
+At **run time** a reference to a variable that does not exist is an error that
+stops the run. Nothing is ever rendered as `<no value>` and then used as a file
+path or a package name.
+
+`rwr validate` is more lenient about `UserDefined`: it cannot know which
+`RWR_*` variables you will export when you actually run, so a reference to a
+missing user-defined key renders empty and is not reported. References into the
+fixed `User`, `System` and `Flags` namespaces have no such excuse — their keys
+are known — so a typo like `{{ .User.hoem }}` is reported by `validate`.
+
+### Provider steps are a different namespace
+
+The four groups above (`UserDefined`, `User`, `System`, `Flags`) are the
+template scope for **blueprint files**. The steps inside a provider definition
+render against a different namespace — the fields of the repository entry being
+processed (`{{ .URL }}`, `{{ .KeyURL }}`, `{{ .Name }}`, …) or, for install
+steps, `{{ .TempDir }}`. Blueprint variables are not visible from provider
+steps, and vice versa. See [Providers](providers.md#template-variables).
 
 ## Best Practices
 


### PR DESCRIPTION
PR-15 from the review plan: docs-only truth restoration. Every claim verified against the code.

- **configuration.md**: env-var hyphen rule was documented backwards — the viper replacer maps `-`→`_`, so `RWR_REPOSITORY_INIT_FILE` is the working form; the "nothing reads `rwr.skipVersionCheck`" note was false (`cmd/version.go:147` reads it) — it's now in the options and env tables.
- **providers.md**: rewritten for the CUE reality (#216–#218): CUE authoring → `mise run providers:export` → committed JSON; TOML+JSON filesystem overrides; search paths and override precedence; the full repo-step action list from the code; the real template namespace (`renderActionStep` renders eight fields + args — the "only {{ .URL }} works" caution was wrong); step fields incl. `environment`; `{{ .TempDir }}` documented as install/remove-step-only, `{{ .TempKeyPath }}` for repo steps. Phantom npm/pnpm/yarn/pip/gem providers removed (also from init-file.md).
- **validate.md**: real severities per check (name = error; binary/distributions/commands = warnings; step-shape = errors) and the exit-code implications; JSON provider files now accepted.
- **quick-start.md**: bare `rwr all` includes profiled items (empty active-profile set matches everything).
- **bootstrap.md**: users→groups order matches the code; dry-run doesn't consume the run-once marker; `github_title`, `schema_version` documented.
- **Stale "accepted but not read"/"Broken" claims**: git/configuration actions now enforced, packages `elevated` OR'd in, snap interfaces / gnome-extensions reset now derived — tables updated; packages name/names precedence corrected to "`names` wins" (#215).
- **Per-entry `interactive`**: still unread for file/template/git entries — docs now say so; common-fields lists the types that actually read it.
- **New**: repository `key_sha256`/`interface`/`slot`/`reset_settings` rows, `schema_version` in common-fields, variables.md strict-vs-lenient rendering + `RWR_VAR_*` export + provider-step namespace.
- `--gh-key` no longer recommended anywhere (deprecated alias noted once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)