### PR TITLE
feat(tui): user themes, hover, per-item lane progress

### DIFF
--- a/cmd/tui_run.go
+++ b/cmd/tui_run.go
@@ -47,7 +47,10 @@ func runWithTUI(app *AppConfig, order []string) error {
 		}
 	}
 
-	theme := tui.ResolveTheme(app.Theme, viper.GetString("rwr.theme"), app.ASCII, app.Unicode)
+	theme, unknownTheme := tui.ResolveTheme(app.ConfigLocation, app.Theme, viper.GetString("rwr.theme"), app.ASCII, app.Unicode)
+	if unknownTheme != "" {
+		log.Warnf("Unknown theme %q (no built-in and no %s/themes/%s.toml); using %q", unknownTheme, app.ConfigLocation, unknownTheme, theme.Name)
+	}
 	model := tui.New(theme, plan, store, system.IsDryRun(), runLogPath)
 	program := tea.NewProgram(model)
 

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.6.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.4.0 // indirect
+	github.com/lrstanley/bubblezone/v2 v2.0.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-runewidth v0.0.27 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lrstanley/bubblezone/v2 v2.0.0 h1:pMb9fHKs0slJF6OrzQ2hEgWusqyl9VU/S0UZ5hyh7ZA=
+github.com/lrstanley/bubblezone/v2 v2.0.0/go.mod h1:yV/QTjcm4Zu5cqvGvdHi7xVUfnB36w/SafOuDp57dgY=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=
 github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-runewidth v0.0.27 h1:Feg/Oou5zI/wnpgDF6omIU0OokC9GxLC/WRknhVlIR0=

--- a/internal/processors/bootstrap.go
+++ b/internal/processors/bootstrap.go
@@ -72,9 +72,14 @@ func ProcessBootstrap(blueprintFile string, initConfig *types.InitConfig, osInfo
 		return err
 	}
 
+	// Bootstrap runs the shared per-type loops, so it carries its own progress
+	// trackers keyed to the lanes those loops fill.
+	filesTrack := newProgress(types.BlueprintTypeFiles)
+	usersTrack := newProgress(types.BlueprintTypeUsers)
+
 	// Process directories
 	log.Debugf("Processing directories from %s", blueprintFile)
-	err = processDirectories(bootstrapData.Directories, blueprintDir, initConfig)
+	err = processDirectories(bootstrapData.Directories, blueprintDir, initConfig, filesTrack)
 	if err != nil {
 		log.Errorf("Error processing directories: %v", err)
 		return err
@@ -82,7 +87,7 @@ func ProcessBootstrap(blueprintFile string, initConfig *types.InitConfig, osInfo
 
 	// Process Files
 	log.Debugf("Processing files from %s", blueprintFile)
-	err = processFiles(bootstrapData.Files, blueprintDir, osInfo)
+	err = processFiles(bootstrapData.Files, blueprintDir, osInfo, filesTrack)
 	if err != nil {
 		log.Errorf("Error processing directories: %v", err)
 		return err
@@ -114,7 +119,7 @@ func ProcessBootstrap(blueprintFile string, initConfig *types.InitConfig, osInfo
 
 	// Process users/groups
 	log.Debugf("Processing users/groups from %s", blueprintFile)
-	err = processUsers(bootstrapData.Users, initConfig)
+	err = processUsers(bootstrapData.Users, initConfig, usersTrack)
 	if err != nil {
 		log.Errorf("Error processing groups: %v", err)
 		return err
@@ -122,7 +127,7 @@ func ProcessBootstrap(blueprintFile string, initConfig *types.InitConfig, osInfo
 
 	// Process groups
 	log.Debugf("Processing groups from %s", blueprintFile)
-	err = processGroups(bootstrapData.Groups, initConfig)
+	err = processGroups(bootstrapData.Groups, initConfig, usersTrack)
 	if err != nil {
 		log.Errorf("Error processing groups: %v", err)
 		return err

--- a/internal/processors/configuration.go
+++ b/internal/processors/configuration.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf16"
 
 	"charm.land/log/v2"
@@ -32,9 +33,13 @@ func ProcessConfiguration(blueprintData []byte, blueprintDir string, format stri
 
 	configurations := helpers.FilterByProfiles(configData.Configurations, initConfig.Variables.Flags.Profiles)
 
+	track := newProgress(types.BlueprintTypeConfiguration)
+	track.expect("", len(configurations))
+
 	for _, config := range configurations {
 		if system.IsDryRun() {
 			log.Infof("[DRY-RUN] Would apply %s configuration: %s", config.Tool, config.Name)
+			track.item("", config.Name, "configure", types.StatusPlanned, "dry-run", 0)
 			continue
 		}
 		// `set` is the only action any of these tools implement. The field was
@@ -42,9 +47,11 @@ func ProcessConfiguration(blueprintData []byte, blueprintDir string, format stri
 		if config.Action != "" && config.Action != types.ConfigurationActionSet {
 			recordFailure("configuration", config.Name,
 				fmt.Errorf("unsupported action %q: the only supported action is %q", config.Action, types.ConfigurationActionSet))
+			track.item("", config.Name, "configure", types.StatusFailed, "unsupported action", 0)
 			continue
 		}
 
+		started := time.Now()
 		var err error
 		switch config.Tool {
 		case "dconf":
@@ -61,7 +68,15 @@ func ProcessConfiguration(blueprintData []byte, blueprintDir string, format stri
 
 		if err != nil {
 			log.Errorf("Error processing configuration %s: %v", config.Name, err)
+			track.item("", config.Name, "configure", types.StatusFailed, err.Error(), time.Since(started))
 			return fmt.Errorf("error processing configuration %s: %w", config.Name, err)
+		}
+		if config.Tool == "gsettings" {
+			// processGSettings records per-key failures in the ledger and still
+			// returns nil, so the entry's own outcome is not knowable here.
+			track.item("", config.Name, "configure", types.StatusUnknown, "per-key results recorded in the ledger", time.Since(started))
+		} else {
+			track.item("", config.Name, "configure", types.StatusOK, "", time.Since(started))
 		}
 	}
 

--- a/internal/processors/files.go
+++ b/internal/processors/files.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/types"
@@ -39,15 +40,20 @@ func ProcessFiles(blueprintData []byte, blueprintDir string, format string, osIn
 		return err
 	}
 
-	if err := processFiles(files, blueprintDir, osInfo); err != nil {
+	// One tracker across all three loops: files, directories, and templates
+	// share the processor's single lane, and a second tracker would reset its
+	// done/total counts.
+	track := newProgress(types.BlueprintTypeFiles)
+
+	if err := processFiles(files, blueprintDir, osInfo, track); err != nil {
 		return fmt.Errorf("error processing files: %w", err)
 	}
 
-	if err := processDirectories(dirs, blueprintDir, initConfig); err != nil {
+	if err := processDirectories(dirs, blueprintDir, initConfig, track); err != nil {
 		return fmt.Errorf("error processing directories: %w", err)
 	}
 
-	if err := processTemplates(templates, blueprintDir, osInfo, initConfig); err != nil {
+	if err := processTemplates(templates, blueprintDir, osInfo, initConfig, track); err != nil {
 		return fmt.Errorf("error processing templates: %w", err)
 	}
 
@@ -94,20 +100,39 @@ func resolveAndFilterFileData(blueprintData []byte, blueprintDir string, format 
 
 // One file failing does not stop the rest: the failure goes to the ledger,
 // which puts it in the run's exit code, and processing continues.
-func processFiles(files []types.File, blueprintDir string, osInfo *types.OSInfo) error {
+func processFiles(files []types.File, blueprintDir string, osInfo *types.OSInfo, track *progress) error {
+	total := 0
+	for _, file := range files {
+		if len(file.Names) > 0 {
+			total += len(file.Names)
+		} else {
+			total++
+		}
+	}
+	track.expect("", total)
+
+	run := func(file types.File) {
+		started := time.Now()
+		switch err := processFile(file, blueprintDir, osInfo); {
+		case err != nil:
+			recordFailure("files", file.Name, err)
+			track.item("", file.Name, file.Action, types.StatusFailed, err.Error(), time.Since(started))
+		case system.IsDryRun():
+			track.item("", file.Name, file.Action, types.StatusPlanned, "dry-run", 0)
+		default:
+			track.item("", file.Name, file.Action, types.StatusOK, "", time.Since(started))
+		}
+	}
+
 	for _, file := range files {
 		if len(file.Names) > 0 {
 			for _, name := range file.Names {
 				fileWithName := file
 				fileWithName.Name = name
-				if err := processFile(fileWithName, blueprintDir, osInfo); err != nil {
-					recordFailure("files", name, err)
-				}
+				run(fileWithName)
 			}
 		} else {
-			if err := processFile(file, blueprintDir, osInfo); err != nil {
-				recordFailure("files", file.Name, err)
-			}
+			run(file)
 		}
 	}
 	return nil
@@ -230,8 +255,36 @@ func processFile(file types.File, blueprintDir string, osInfo *types.OSInfo) err
 	}
 }
 
-func processTemplates(templates []types.File, blueprintDir string, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
+func processTemplates(templates []types.File, blueprintDir string, osInfo *types.OSInfo, initConfig *types.InitConfig, track *progress) error {
 	log.Info("Starting to process templates")
+
+	total := 0
+	for _, tmpl := range templates {
+		if len(tmpl.Names) > 0 {
+			total += len(tmpl.Names)
+		} else if tmpl.Name != "" {
+			total++
+		}
+	}
+	track.expect("", total)
+
+	run := func(tmpl types.File) {
+		started := time.Now()
+		switch err := processTemplate(tmpl, blueprintDir, osInfo, initConfig); {
+		case err != nil:
+			recordFailure("templates", tmpl.Name, err)
+			track.item("", tmpl.Name, "template", types.StatusFailed, err.Error(), time.Since(started))
+		case system.IsDryRun():
+			track.item("", tmpl.Name, "template", types.StatusPlanned, "dry-run", 0)
+		case tmpl.Source == "" || tmpl.Target == "":
+			// processTemplate warns and returns nil for these; mirror that as a
+			// skip rather than a success.
+			track.item("", tmpl.Name, "template", types.StatusSkipped, "missing required fields", 0)
+		default:
+			track.item("", tmpl.Name, "template", types.StatusOK, "", time.Since(started))
+		}
+	}
+
 	for i, tmpl := range templates {
 		log.Debugf("Processing template %d: %+v", i, tmpl)
 		if tmpl.Name == "" && len(tmpl.Names) == 0 {
@@ -244,17 +297,11 @@ func processTemplates(templates []types.File, blueprintDir string, osInfo *types
 				log.Infof("Processing template with name: %s", name)
 				fileWithName := tmpl
 				fileWithName.Name = name
-				err := processTemplate(fileWithName, blueprintDir, osInfo, initConfig)
-				if err != nil {
-					recordFailure("templates", fileWithName.Name, err)
-				}
+				run(fileWithName)
 			}
 		} else {
 			log.Infof("Processing single template: %s", tmpl.Name)
-			err := processTemplate(tmpl, blueprintDir, osInfo, initConfig)
-			if err != nil {
-				recordFailure("templates", tmpl.Name, err)
-			}
+			run(tmpl)
 		}
 	}
 	log.Info("Finished processing all templates")
@@ -327,15 +374,21 @@ func processTemplate(template types.File, blueprintDir string, osInfo *types.OSI
 	return nil
 }
 
-func processDirectories(directories []types.Directory, blueprintDir string, initConfig *types.InitConfig) error {
+func processDirectories(directories []types.Directory, blueprintDir string, initConfig *types.InitConfig, track *progress) error {
+	track.expect("", len(directories))
 	for _, dir := range directories {
 		if system.IsDryRun() {
 			log.Infof("[DRY-RUN] Would %s directory: %s (target: %s)", dir.Action, dir.Name, dir.Target)
+			track.item("", dir.Name, dir.Action, types.StatusPlanned, "dry-run", 0)
 			continue
 		}
+		started := time.Now()
 		if err := processDirectory(dir, blueprintDir, initConfig); err != nil {
 			recordFailure("directories", dir.Name, err)
+			track.item("", dir.Name, dir.Action, types.StatusFailed, err.Error(), time.Since(started))
+			continue
 		}
+		track.item("", dir.Name, dir.Action, types.StatusOK, "", time.Since(started))
 	}
 	return nil
 }

--- a/internal/processors/fonts.go
+++ b/internal/processors/fonts.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/helpers"
@@ -66,14 +67,15 @@ func ProcessFonts(blueprintData []byte, blueprintDir string, format string, osIn
 
 	log.Debugf("Found %d font entries to process", len(fontsData.Fonts))
 
+	track := newProgress(types.BlueprintTypeFonts)
+
 	if system.IsDryRun() {
 		for _, font := range fontsData.Fonts {
-			if len(font.Names) > 0 {
-				for _, name := range font.Names {
-					log.Infof("[DRY-RUN] Would install font: %s", name)
-				}
-			} else if font.Name != "" {
-				log.Infof("[DRY-RUN] Would install font: %s", font.Name)
+			names := fontEntryNames(font)
+			track.expect(font.Provider, len(names))
+			for _, name := range names {
+				log.Infof("[DRY-RUN] Would install font: %s", name)
+				track.item(font.Provider, name, font.Action, types.StatusPlanned, "dry-run", 0)
 			}
 		}
 		return nil
@@ -81,6 +83,10 @@ func ProcessFonts(blueprintData []byte, blueprintDir string, format string, osIn
 
 	if len(fontsData.Fonts) == 0 {
 		return nil
+	}
+
+	for _, font := range fontsData.Fonts {
+		track.expect(font.Provider, len(fontEntryNames(font)))
 	}
 
 	// Resolved after the dry-run and empty-blueprint exits: this is a network call,
@@ -91,27 +97,42 @@ func ProcessFonts(blueprintData []byte, blueprintDir string, format string, osIn
 	releaseURL, err := getLatestReleaseURL()
 	if err != nil {
 		recordFailure("fonts", "nerd-fonts release lookup", err)
+		for _, font := range fontsData.Fonts {
+			for _, name := range fontEntryNames(font) {
+				track.item(font.Provider, name, font.Action, types.StatusFailed, "nerd-fonts release lookup failed", 0)
+			}
+		}
 		return nil
 	}
 
 	// One font failing does not stop the rest: the failure goes to the ledger,
 	// which puts it in the run's exit code, and processing continues.
 	for _, font := range fontsData.Fonts {
-		if len(font.Names) > 0 {
-			for _, name := range font.Names {
-				fontWithName := font
-				fontWithName.Name = name
-				if err := processFont(fontWithName, osInfo, releaseURL); err != nil {
-					recordFailure("fonts", name, err)
-				}
+		for _, name := range fontEntryNames(font) {
+			fontWithName := font
+			fontWithName.Name = name
+			started := time.Now()
+			if err := processFont(fontWithName, osInfo, releaseURL); err != nil {
+				recordFailure("fonts", name, err)
+				track.item(font.Provider, name, font.Action, types.StatusFailed, err.Error(), time.Since(started))
+				continue
 			}
-		} else if font.Name != "" {
-			if err := processFont(font, osInfo, releaseURL); err != nil {
-				recordFailure("fonts", font.Name, err)
-			}
+			track.item(font.Provider, name, font.Action, types.StatusOK, "", time.Since(started))
 		}
 	}
 
+	return nil
+}
+
+// fontEntryNames lists the font names one blueprint entry declares: `names`
+// wins over `name`, matching the processing loops and the planner.
+func fontEntryNames(font types.Font) []string {
+	if len(font.Names) > 0 {
+		return font.Names
+	}
+	if font.Name != "" {
+		return []string{font.Name}
+	}
 	return nil
 }
 

--- a/internal/processors/git.go
+++ b/internal/processors/git.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/helpers"
@@ -49,9 +50,13 @@ func ProcessGitRepositories(blueprintData []byte, blueprintDir string, format st
 }
 
 func processGitRepositories(gitRepos []types.Git, initConfig *types.InitConfig) error {
+	track := newProgress(types.BlueprintTypeGit)
+	track.expect("", len(gitRepos))
 	for _, repo := range gitRepos {
+		started := time.Now()
 		if system.IsDryRun() {
 			log.Infof("[DRY-RUN] Would clone/update git repository: %s -> %s", repo.URL, repo.Path)
+			track.item("", repo.Name, repo.Action, types.StatusPlanned, "dry-run", 0)
 			continue
 		}
 		// The action field was decoded and never read, so `action: pull` cloned and
@@ -62,6 +67,7 @@ func processGitRepositories(gitRepos []types.Git, initConfig *types.InitConfig) 
 		default:
 			recordFailure("git", repo.Name,
 				fmt.Errorf("unsupported action %q: use %q or %q", repo.Action, types.GitActionClone, types.GitActionPull))
+			track.item("", repo.Name, repo.Action, types.StatusFailed, "unsupported action", 0)
 			continue
 		}
 
@@ -79,6 +85,7 @@ func processGitRepositories(gitRepos []types.Git, initConfig *types.InitConfig) 
 			err = helpers.CheckAndUpdateRemoteURL(gitOpts.Target, gitOpts.URL)
 			if err != nil {
 				recordFailure("git", repo.Name, fmt.Errorf("checking/updating remote URL: %w", err))
+				track.item("", repo.Name, repo.Action, types.StatusFailed, err.Error(), time.Since(started))
 				continue
 			}
 
@@ -86,25 +93,31 @@ func processGitRepositories(gitRepos []types.Git, initConfig *types.InitConfig) 
 			err = helpers.HandleGitPull(gitOpts, initConfig)
 			if err != nil {
 				recordFailure("git", repo.Name, fmt.Errorf("pulling latest changes: %w", err))
+				track.item("", repo.Name, repo.Action, types.StatusFailed, err.Error(), time.Since(started))
 				continue
 			}
 			log.Infof("Git repository %s updated successfully", repo.Name)
+			track.item("", repo.Name, repo.Action, types.StatusOK, "", time.Since(started))
 		} else if os.IsNotExist(err) {
 			if repo.Action == types.GitActionPull {
 				recordFailure("git", repo.Name,
 					fmt.Errorf("action is %q but nothing is checked out at %s", types.GitActionPull, gitOpts.Target))
+				track.item("", repo.Name, repo.Action, types.StatusFailed, "nothing checked out at target", time.Since(started))
 				continue
 			}
 			// Repository doesn't exist, clone it
 			err = helpers.HandleGitClone(gitOpts, initConfig)
 			if err != nil {
 				recordFailure("git", repo.Name, fmt.Errorf("cloning: %w", err))
+				track.item("", repo.Name, repo.Action, types.StatusFailed, err.Error(), time.Since(started))
 				continue
 			}
 			log.Infof("Git repository %s cloned successfully", repo.Name)
+			track.item("", repo.Name, repo.Action, types.StatusOK, "", time.Since(started))
 		} else {
 			// Some other error occurred
 			recordFailure("git", repo.Name, fmt.Errorf("checking repository path: %w", err))
+			track.item("", repo.Name, repo.Action, types.StatusFailed, err.Error(), time.Since(started))
 			continue
 		}
 	}

--- a/internal/processors/packages.go
+++ b/internal/processors/packages.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/helpers"
@@ -74,7 +75,15 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 	log.Debugf("Filtering packages: %d total, %d matching active profiles %v",
 		len(packages.Packages), len(filteredPackages), initConfig.Variables.Flags.Profiles)
 
-	// Process each filtered package
+	// Resolve each package's provider and names up front so the lanes know
+	// their denominators before the first install runs.
+	type packageUnit struct {
+		pkg      types.Package
+		provider *types.Provider
+		names    []string
+	}
+	var units []packageUnit
+	track := newProgress(types.BlueprintTypePackages)
 	for _, pkg := range filteredPackages {
 		// Get provider
 		var provider *types.Provider
@@ -85,12 +94,14 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 			provider, exists = system.GetProvider(pkg.PackageManager)
 			if !exists {
 				log.Warnf("Specified package manager %s not available, skipping package %s", pkg.PackageManager, pkg.Name)
+				track.item(pkg.PackageManager, pkg.Name, pkg.Action, types.StatusSkipped, "package manager not available", 0)
 				continue
 			}
 		} else {
 			provider, exists = defaultProviderFor(osInfo, available)
 			if !exists {
 				log.Warnf("No package manager available for package %s, skipping", pkg.Name)
+				track.item("", pkg.Name, pkg.Action, types.StatusSkipped, "no package manager available", 0)
 				continue
 			}
 		}
@@ -108,8 +119,15 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 			names = []string{pkg.Name}
 		}
 
+		units = append(units, packageUnit{pkg: pkg, provider: provider, names: names})
+		track.expect(provider.Name, len(names))
+	}
+
+	for _, unit := range units {
+		pkg, provider := unit.pkg, unit.provider
+
 		// Process each package
-		for _, name := range names {
+		for _, name := range unit.names {
 			// Build command arguments
 			var args []string
 			switch pkg.Action {
@@ -119,6 +137,7 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 				args = append(args, strings.Fields(provider.Commands.Remove)...)
 			default:
 				recordFailure("packages", name, fmt.Errorf("unknown action %q", pkg.Action))
+				track.item(provider.Name, name, pkg.Action, types.StatusFailed, "unknown action", 0)
 				continue
 			}
 
@@ -128,6 +147,7 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 			// blueprint change what the elevated package manager does.
 			if strings.HasPrefix(name, "-") {
 				recordFailure("packages", name, errors.New("package name may not begin with '-'; it would be read as an option by the package manager"))
+				track.item(provider.Name, name, pkg.Action, types.StatusFailed, "name begins with '-'", 0)
 				continue
 			}
 
@@ -149,11 +169,14 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 				Variables:   provider.Environment,
 				Interactive: helpers.ResolveInteractive(pkg.Interactive, initConfig.Variables.Flags.Interactive),
 			}
+			started := time.Now()
 			if err := system.RunCommand(cmd, initConfig.Variables.Flags.Debug); err != nil {
 				recordFailure("packages", name, fmt.Errorf("%s failed: %w", pkg.Action, err))
+				track.item(provider.Name, name, pkg.Action, types.StatusFailed, err.Error(), time.Since(started))
 				continue
 			}
 
+			track.item(provider.Name, name, pkg.Action, types.StatusOK, "", time.Since(started))
 			log.Infof("Successfully %s package %s via %s", pastTense(pkg.Action), name, provider.Name)
 		}
 	}

--- a/internal/processors/progress.go
+++ b/internal/processors/progress.go
@@ -1,0 +1,78 @@
+package processors
+
+import (
+	"time"
+
+	"github.com/fynxlabs/rwr/internal/reporting"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// progress tracks per-provider lane counts for one processor and emits the
+// events the TUI's lanes fill from: one ResourceDone per completed unit of
+// work plus a LaneUpdate carrying the lane's running done/total. Headless
+// runs are unaffected — LogReporter ignores both events.
+//
+// The lane provider key is "" for processors without providers (files,
+// services, git, scripts, …); the display layer names that lane.
+type progress struct {
+	processor string
+	done      map[string]int
+	total     map[string]int
+	failed    map[string]bool
+}
+
+func newProgress(processor string) *progress {
+	return &progress{
+		processor: processor,
+		done:      map[string]int{},
+		total:     map[string]int{},
+		failed:    map[string]bool{},
+	}
+}
+
+// expect raises a lane's denominator before its items run, so the lane
+// renders 0/N instead of growing its total as items complete.
+func (p *progress) expect(provider string, n int) {
+	if n <= 0 {
+		return
+	}
+	p.total[provider] += n
+	p.emitLane(provider)
+}
+
+// item reports one completed unit of work. A done count past the expected
+// total (imports, entries resolved at run time) grows the total: the lane
+// never shows 7/5.
+func (p *progress) item(provider, name, action string, status types.Status, detail string, dur time.Duration) {
+	p.done[provider]++
+	if p.done[provider] > p.total[provider] {
+		p.total[provider] = p.done[provider]
+	}
+	if status == types.StatusFailed {
+		p.failed[provider] = true
+	}
+	reporting.Emit(reporting.ResourceDone{Resource: types.Resource{
+		Processor: p.processor,
+		Provider:  provider,
+		Name:      name,
+		Action:    action,
+		Status:    status,
+		Detail:    detail,
+		Dur:       dur,
+	}})
+	p.emitLane(provider)
+}
+
+func (p *progress) emitLane(provider string) {
+	status := types.StatusOK
+	if p.failed[provider] {
+		status = types.StatusFailed
+	}
+	reporting.Emit(reporting.LaneUpdate{
+		Processor: p.processor,
+		Provider:  provider,
+		Done:      p.done[provider],
+		Total:     p.total[provider],
+		Status:    status,
+	})
+}

--- a/internal/processors/repository.go
+++ b/internal/processors/repository.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"text/template"
+	"time"
 
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/helpers"
@@ -60,14 +61,25 @@ func processRepositories(repositories []types.Repository, osInfo *types.OSInfo, 
 
 	// One repository failing does not stop the rest: the failure goes to the
 	// ledger, which puts it in the run's exit code, and processing continues.
+	track := newProgress(types.BlueprintTypeRepositories)
+	for _, repo := range repositories {
+		track.expect(repo.PackageManager, 1)
+	}
 	declared := make(map[string]bool, len(repositories))
 	for _, repo := range repositories {
 		log.Infof("Processing repository %s", repo.Name)
 		log.Debugf("Repository definition: %s", repo.LogString())
 		declared[repo.PackageManager] = true
 
-		if err := processRepository(repo, osInfo, initConfig); err != nil {
+		started := time.Now()
+		switch err := processRepository(repo, osInfo, initConfig); {
+		case err != nil:
 			recordFailure("repositories", repo.Name, err)
+			track.item(repo.PackageManager, repo.Name, repo.Action, types.StatusFailed, err.Error(), time.Since(started))
+		case system.IsDryRun():
+			track.item(repo.PackageManager, repo.Name, repo.Action, types.StatusPlanned, "dry-run", 0)
+		default:
+			track.item(repo.PackageManager, repo.Name, repo.Action, types.StatusOK, "", time.Since(started))
 		}
 	}
 

--- a/internal/processors/scripts.go
+++ b/internal/processors/scripts.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fynxlabs/rwr/internal/helpers"
 	"github.com/fynxlabs/rwr/internal/types"
@@ -51,23 +52,30 @@ func ProcessScripts(blueprintData []byte, blueprintDir string, format string, os
 }
 
 func processScripts(scripts []types.Script, osInfo *types.OSInfo, initConfig *types.InitConfig, blueprintDir string) error {
+	track := newProgress(types.BlueprintTypeScripts)
+	track.expect("", len(scripts))
 	for _, script := range scripts {
 		log.Debugf("Processing script: %+v", script)
 
 		if system.IsDryRun() {
 			log.Infof("[DRY-RUN] Would run script: %s (exec: %s)", script.Name, script.Exec)
+			track.item("", script.Name, script.Action, types.StatusPlanned, "dry-run", 0)
 			continue
 		}
 
 		if script.Action == "run" {
+			started := time.Now()
 			err := runScript(script, osInfo, initConfig, blueprintDir)
 			if err != nil {
 				log.Errorf("Error running script %s: %v", script.Name, err)
+				track.item("", script.Name, script.Action, types.StatusFailed, err.Error(), time.Since(started))
 				return fmt.Errorf("error running script %s: %w", script.Name, err)
 			}
 			log.Infof("Script %s executed successfully", script.Name)
+			track.item("", script.Name, script.Action, types.StatusOK, "", time.Since(started))
 		} else {
 			log.Errorf("Unsupported action for script %s: %s", script.Name, script.Action)
+			track.item("", script.Name, script.Action, types.StatusFailed, "unsupported action", 0)
 			return fmt.Errorf("unsupported action for script %s: %s", script.Name, script.Action)
 		}
 	}

--- a/internal/processors/services.go
+++ b/internal/processors/services.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/types"
@@ -50,7 +51,10 @@ func ProcessServices(blueprintData []byte, blueprintDir string, format string, o
 // One service failing does not stop the rest: the failure goes to the ledger,
 // which puts it in the run's exit code, and processing continues.
 func processServices(services []types.Service, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
+	track := newProgress(types.BlueprintTypeServices)
+	track.expect("", len(services))
 	for _, service := range services {
+		started := time.Now()
 		var err error
 		switch runtime.GOOS {
 		case "linux":
@@ -62,8 +66,14 @@ func processServices(services []types.Service, osInfo *types.OSInfo, initConfig 
 		default:
 			return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
 		}
-		if err != nil {
+		switch {
+		case err != nil:
 			recordFailure("services", service.Name, err)
+			track.item("", service.Name, service.Action, types.StatusFailed, err.Error(), time.Since(started))
+		case system.IsDryRun():
+			track.item("", service.Name, service.Action, types.StatusPlanned, "dry-run", 0)
+		default:
+			track.item("", service.Name, service.Action, types.StatusOK, "", time.Since(started))
 		}
 	}
 	return nil

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -113,6 +113,8 @@ func ProcessSSHKeys(blueprintData []byte, blueprintDir string, format string, os
 }
 
 func processSSHKeys(sshKeys []types.SSHKey, osInfo *types.OSInfo, initConfig *types.InitConfig) error {
+	track := newProgress(types.BlueprintTypeSSHKeys)
+	track.expect("", len(sshKeys))
 	// Process the SSH keys
 	for _, sshKey := range sshKeys {
 		if system.IsDryRun() {
@@ -123,12 +125,16 @@ func processSSHKeys(sshKeys []types.SSHKey, osInfo *types.OSInfo, initConfig *ty
 			if sshKey.SetAsRWRSSHKey {
 				log.Infof("[DRY-RUN] Would set as RWR SSH key")
 			}
+			track.item("", sshKey.Name, "ssh_key", types.StatusPlanned, "dry-run", 0)
 			continue
 		}
+
+		started := time.Now()
 
 		// Ensure required packages are installed
 		err := ensureSSHPackages(osInfo, initConfig)
 		if err != nil {
+			track.item("", sshKey.Name, "ssh_key", types.StatusFailed, err.Error(), time.Since(started))
 			return fmt.Errorf("error ensuring SSH packages: %v", err)
 		}
 
@@ -136,6 +142,7 @@ func processSSHKeys(sshKeys []types.SSHKey, osInfo *types.OSInfo, initConfig *ty
 		keyPath, err := generateSSHKey(sshKey, initConfig)
 		if err != nil {
 			recordFailure("ssh_keys", sshKey.Name, fmt.Errorf("generating key: %w", err))
+			track.item("", sshKey.Name, "ssh_key", types.StatusFailed, err.Error(), time.Since(started))
 			continue
 		}
 
@@ -144,6 +151,7 @@ func processSSHKeys(sshKeys []types.SSHKey, osInfo *types.OSInfo, initConfig *ty
 			err = copySSHKeyToGitHub(sshKey, initConfig)
 			if err != nil {
 				recordFailure("ssh_keys", sshKey.Name, fmt.Errorf("copying public key to GitHub: %w", err))
+				track.item("", sshKey.Name, "ssh_key", types.StatusFailed, err.Error(), time.Since(started))
 				continue
 			}
 		}
@@ -153,9 +161,12 @@ func processSSHKeys(sshKeys []types.SSHKey, osInfo *types.OSInfo, initConfig *ty
 			err = setAsRWRSSHKey(keyPath)
 			if err != nil {
 				recordFailure("ssh_keys", sshKey.Name, fmt.Errorf("setting as RWR SSH key: %w", err))
+				track.item("", sshKey.Name, "ssh_key", types.StatusFailed, err.Error(), time.Since(started))
 				continue
 			}
 		}
+
+		track.item("", sshKey.Name, "ssh_key", types.StatusOK, "", time.Since(started))
 	}
 
 	return nil

--- a/internal/processors/user.go
+++ b/internal/processors/user.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/helpers"
@@ -75,15 +76,19 @@ func ProcessUsers(blueprintData []byte, blueprintDir string, format string, init
 	log.Debugf("Filtering users: %d total, %d matching active profiles %v",
 		len(usersData.Users), len(filteredUsers), initConfig.Variables.Flags.Profiles)
 
+	// One tracker across both loops: users and groups share the processor's
+	// single lane, and a second tracker would reset its done/total counts.
+	track := newProgress(types.BlueprintTypeUsers)
+
 	// Process the filtered groups
-	err = processGroups(filteredGroups, initConfig)
+	err = processGroups(filteredGroups, initConfig, track)
 	if err != nil {
 		log.Errorf("Error processing groups: %v", err)
 		return fmt.Errorf("error processing groups: %w", err)
 	}
 
 	// Process the filtered users
-	err = processUsers(filteredUsers, initConfig)
+	err = processUsers(filteredUsers, initConfig, track)
 	if err != nil {
 		log.Errorf("Error processing users: %v", err)
 		return fmt.Errorf("error processing users: %w", err)
@@ -92,17 +97,21 @@ func ProcessUsers(blueprintData []byte, blueprintDir string, format string, init
 	return nil
 }
 
-func processGroups(groups []types.Group, initConfig *types.InitConfig) error {
+func processGroups(groups []types.Group, initConfig *types.InitConfig, track *progress) error {
+	track.expect("", len(groups))
 	for _, group := range groups {
 		if system.IsDryRun() {
 			log.Infof("[DRY-RUN] Would %s group: %s", group.Action, group.Name)
+			track.item("", group.Name, group.Action, types.StatusPlanned, "dry-run", 0)
 			continue
 		}
+		started := time.Now()
 		switch group.Action {
 		case types.UserActionCreate:
 			err := createGroup(group, initConfig)
 			if err != nil {
 				log.Errorf("Error creating group %s: %v", group.Name, err)
+				track.item("", group.Name, group.Action, types.StatusFailed, err.Error(), time.Since(started))
 				return fmt.Errorf("error creating group %s: %w", group.Name, err)
 			}
 			log.Infof("Group %s processed successfully", group.Name)
@@ -110,6 +119,7 @@ func processGroups(groups []types.Group, initConfig *types.InitConfig) error {
 			err := modifyGroup(group, initConfig)
 			if err != nil {
 				log.Errorf("Error modifying group %s: %v", group.Name, err)
+				track.item("", group.Name, group.Action, types.StatusFailed, err.Error(), time.Since(started))
 				return fmt.Errorf("error modifying group %s: %w", group.Name, err)
 			}
 			log.Infof("Group %s modified successfully", group.Name)
@@ -117,28 +127,40 @@ func processGroups(groups []types.Group, initConfig *types.InitConfig) error {
 			err := removeGroup(group, initConfig)
 			if err != nil {
 				log.Errorf("Error removing group %s: %v", group.Name, err)
+				track.item("", group.Name, group.Action, types.StatusFailed, err.Error(), time.Since(started))
 				return fmt.Errorf("error removing group %s: %w", group.Name, err)
 			}
 			log.Infof("Group %s removed successfully", group.Name)
 		default:
 			log.Errorf("Unsupported action for group %s: %s", group.Name, group.Action)
+			track.item("", group.Name, group.Action, types.StatusFailed, "unsupported action", 0)
 			return fmt.Errorf("unsupported action for group %s: %s", group.Name, group.Action)
+		}
+		if userGOOS == "windows" {
+			// The per-action helpers warn and no-op on Windows.
+			track.item("", group.Name, group.Action, types.StatusSkipped, "not supported on Windows", 0)
+		} else {
+			track.item("", group.Name, group.Action, types.StatusOK, "", time.Since(started))
 		}
 	}
 	return nil
 }
 
-func processUsers(users []types.User, initConfig *types.InitConfig) error {
+func processUsers(users []types.User, initConfig *types.InitConfig, track *progress) error {
+	track.expect("", len(users))
 	for _, user := range users {
 		if system.IsDryRun() {
 			log.Infof("[DRY-RUN] Would %s user: %s", user.Action, user.Name)
+			track.item("", user.Name, user.Action, types.StatusPlanned, "dry-run", 0)
 			continue
 		}
+		started := time.Now()
 		switch user.Action {
 		case types.UserActionCreate:
 			err := createUser(user, initConfig)
 			if err != nil {
 				log.Errorf("Error creating user %s: %v", user.Name, err)
+				track.item("", user.Name, user.Action, types.StatusFailed, err.Error(), time.Since(started))
 				return fmt.Errorf("error creating user %s: %w", user.Name, err)
 			}
 			log.Infof("User %s created successfully", user.Name)
@@ -146,6 +168,7 @@ func processUsers(users []types.User, initConfig *types.InitConfig) error {
 			err := modifyUser(user, initConfig)
 			if err != nil {
 				log.Errorf("Error modifying user %s: %v", user.Name, err)
+				track.item("", user.Name, user.Action, types.StatusFailed, err.Error(), time.Since(started))
 				return fmt.Errorf("error modifying user %s: %w", user.Name, err)
 			}
 			log.Infof("User %s modified successfully", user.Name)
@@ -153,12 +176,20 @@ func processUsers(users []types.User, initConfig *types.InitConfig) error {
 			err := removeUser(user, initConfig)
 			if err != nil {
 				log.Errorf("Error removing user %s: %v", user.Name, err)
+				track.item("", user.Name, user.Action, types.StatusFailed, err.Error(), time.Since(started))
 				return fmt.Errorf("error removing user %s: %w", user.Name, err)
 			}
 			log.Infof("User %s removed successfully", user.Name)
 		default:
 			log.Errorf("Unsupported action for user %s: %s", user.Name, user.Action)
+			track.item("", user.Name, user.Action, types.StatusFailed, "unsupported action", 0)
 			return fmt.Errorf("unsupported action for user %s: %s", user.Name, user.Action)
+		}
+		if userGOOS == "windows" {
+			// The per-action helpers warn and no-op on Windows.
+			track.item("", user.Name, user.Action, types.StatusSkipped, "not supported on Windows", 0)
+		} else {
+			track.item("", user.Name, user.Action, types.StatusOK, "", time.Since(started))
 		}
 	}
 	return nil

--- a/internal/processors/user_test.go
+++ b/internal/processors/user_test.go
@@ -507,7 +507,7 @@ func TestProcessGroups_UnsupportedAction(t *testing.T) {
 		{Name: "badgroup", Action: "destroy"},
 	}
 
-	err := processGroups(groups, newTestInitConfig())
+	err := processGroups(groups, newTestInitConfig(), newProgress(types.BlueprintTypeUsers))
 	if err == nil {
 		t.Error("Expected error for unsupported group action 'destroy'")
 	}
@@ -524,21 +524,21 @@ func TestProcessUsers_UnsupportedAction(t *testing.T) {
 		{Name: "baduser", Action: "destroy"},
 	}
 
-	err := processUsers(users, newTestInitConfig())
+	err := processUsers(users, newTestInitConfig(), newProgress(types.BlueprintTypeUsers))
 	if err == nil {
 		t.Error("Expected error for unsupported user action 'destroy'")
 	}
 }
 
 func TestProcessGroups_EmptySlice(t *testing.T) {
-	err := processGroups([]types.Group{}, newTestInitConfig())
+	err := processGroups([]types.Group{}, newTestInitConfig(), newProgress(types.BlueprintTypeUsers))
 	if err != nil {
 		t.Errorf("Expected no error for empty groups, got: %v", err)
 	}
 }
 
 func TestProcessUsers_EmptySlice(t *testing.T) {
-	err := processUsers([]types.User{}, newTestInitConfig())
+	err := processUsers([]types.User{}, newTestInitConfig(), newProgress(types.BlueprintTypeUsers))
 	if err != nil {
 		t.Errorf("Expected no error for empty users, got: %v", err)
 	}
@@ -657,7 +657,7 @@ func TestProcessGroups_DryRunSkipsExecution(t *testing.T) {
 		{Name: "testgroup2", Action: "modify", NewName: "renamed"},
 	}
 
-	err := processGroups(groups, newTestInitConfig())
+	err := processGroups(groups, newTestInitConfig(), newProgress(types.BlueprintTypeUsers))
 	if err != nil {
 		t.Errorf("processGroups should succeed in dry-run mode, got: %v", err)
 	}
@@ -673,7 +673,7 @@ func TestProcessUsers_DryRunSkipsExecution(t *testing.T) {
 		{Name: "user3", Action: "remove"},
 	}
 
-	err := processUsers(users, newTestInitConfig())
+	err := processUsers(users, newTestInitConfig(), newProgress(types.BlueprintTypeUsers))
 	if err != nil {
 		t.Errorf("processUsers should succeed in dry-run mode, got: %v", err)
 	}
@@ -1179,7 +1179,7 @@ func TestProcessUsers_SecondRunDoesNotAbort(t *testing.T) {
 	rec := platform(t, "linux", true, false, "")
 
 	users := []types.User{{Name: "alice", Shell: "/bin/zsh", Action: "create"}}
-	if err := processUsers(users, newTestInitConfig()); err != nil {
+	if err := processUsers(users, newTestInitConfig(), newProgress(types.BlueprintTypeUsers)); err != nil {
 		t.Fatalf("second run aborted: %v", err)
 	}
 	if len(rec.Calls) == 0 || isProbeCall(rec.Calls[len(rec.Calls)-1]) {
@@ -1227,7 +1227,7 @@ func TestLinuxPasswordNeverReachesArgv(t *testing.T) {
 			rec := platform(t, "linux", false, false, "")
 
 			users := []types.User{{Name: "alice", Password: secret, Action: action}}
-			if err := processUsers(users, newTestInitConfig()); err != nil {
+			if err := processUsers(users, newTestInitConfig(), newProgress(types.BlueprintTypeUsers)); err != nil {
 				t.Fatalf("processUsers: %v", err)
 			}
 
@@ -1256,7 +1256,7 @@ func TestLinuxHashedPasswordUsesEncryptedFlag(t *testing.T) {
 	rec := platform(t, "linux", false, false, "")
 
 	users := []types.User{{Name: "alice", Password: testCryptHash, Action: "create"}}
-	if err := processUsers(users, newTestInitConfig()); err != nil {
+	if err := processUsers(users, newTestInitConfig(), newProgress(types.BlueprintTypeUsers)); err != nil {
 		t.Fatalf("processUsers: %v", err)
 	}
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -197,12 +197,34 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 		}
 	case reporting.LaneUpdate:
 		if i, ok := m.order[ev.Processor]; ok {
-			lane, ok := m.procs[i].Lanes[ev.Provider]
+			name := ev.Provider
+			if name == "" {
+				name = "items"
+			}
+			lane, ok := m.procs[i].Lanes[name]
 			if !ok {
-				lane = &Lane{Provider: ev.Provider, spring: harmonica.NewSpring(harmonica.FPS(8), 6.0, 0.9)}
-				m.procs[i].Lanes[ev.Provider] = lane
+				lane = &Lane{Provider: name, spring: harmonica.NewSpring(harmonica.FPS(8), 6.0, 0.9)}
+				m.procs[i].Lanes[name] = lane
 			}
 			lane.Done, lane.Total, lane.Status = ev.Done, ev.Total, ev.Status
+		}
+	case reporting.ResourceDone:
+		// Move the matching planned resource to its outcome so Summary
+		// renders results, not the plan; unplanned work (imports, entries
+		// resolved at run time) is appended.
+		res := ev.Resource
+		matched := false
+		for i := range m.plan.Resources {
+			planned := &m.plan.Resources[i]
+			if planned.Status != types.StatusPlanned || planned.Processor != res.Processor || planned.Name != res.Name {
+				continue
+			}
+			planned.Provider, planned.Status, planned.Detail, planned.Dur = res.Provider, res.Status, res.Detail, res.Dur
+			matched = true
+			break
+		}
+		if !matched {
+			m.plan.Resources = append(m.plan.Resources, res)
 		}
 	case reporting.TerminalReq:
 		m.state = Suspended

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,12 +1,14 @@
 package tui
 
 import (
+	"strconv"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/harmonica"
 	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/types"
+	zone "github.com/lrstanley/bubblezone/v2"
 )
 
 // State is where the run is.
@@ -123,6 +125,11 @@ type Model struct {
 	runLogPath string
 	summaryTab int
 	expanded   bool // collapsed-success line expanded
+
+	// zones maps rendered strip cells and list rows back to processors, so
+	// mouse work survives layout changes instead of hardcoding coordinates.
+	zones   *zone.Manager
+	hovered int // strip index under the pointer; -1 when none
 }
 
 // event wraps a reporting.Event for the tea loop.
@@ -145,6 +152,8 @@ func New(theme Theme, plan *types.Plan, store *reporting.Store, dryRun bool, run
 		order:      map[string]int{},
 		focused:    true,
 		notifyMin:  30 * time.Second,
+		zones:      zone.New(),
+		hovered:    -1,
 	}
 	for i, name := range plan.Order {
 		proc := &Proc{Name: name, State: ProcPending, Lanes: map[string]*Lane{}}
@@ -245,6 +254,23 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 
 type execDone struct{}
 
+// stripZone and rowZone name a processor's strip cell and list row; the ids
+// differ because a Mark of the same id overwrites the earlier zone.
+func stripZone(i int) string { return "strip:" + strconv.Itoa(i) }
+func rowZone(i int) string   { return "row:" + strconv.Itoa(i) }
+
+// procAt maps a mouse message to the processor whose zone contains it, or -1.
+func (m *Model) procAt(msg tea.MouseMsg) int {
+	for i := range m.procs {
+		for _, id := range []string{stripZone(i), rowZone(i)} {
+			if info := m.zones.Get(id); info != nil && !info.IsZero() && info.InBounds(msg) {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
 // Update implements tea.Model.
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
@@ -289,14 +315,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		return m.key(msg)
 	case tea.MouseClickMsg:
-		// A click on the strip row selects that processor's block; any click
-		// pins. Native coordinate mapping — bubblezone targets bubbletea v1
-		// and cannot be wired against v2 (recorded in the change tasks).
+		// A click on a strip cell or a processor row selects that processor's
+		// block; any click pins. Zones map rendered cells back to processors,
+		// so selection survives layout changes.
 		m.pinned = true
-		mouse := msg.Mouse()
-		if mouse.Y == 1 && mouse.X < len(m.procs) {
-			m.cursor = mouse.X
+		if i := m.procAt(msg); i >= 0 {
+			m.cursor = i
 		}
+		return m, nil
+	case tea.MouseMotionMsg:
+		m.hovered = m.procAt(msg)
 		return m, nil
 	case tea.MouseWheelMsg:
 		m.pinned = true

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -28,7 +28,7 @@ func testModel(t *testing.T) *Model {
 		},
 	}
 	store := reporting.NewStore(100)
-	model := New(ResolveTheme("rwr", "", false, false), plan, store, false, "")
+	model := New(mustTheme("rwr"), plan, store, false, "")
 	model.width, model.height = 100, 30
 	return model
 }
@@ -112,7 +112,7 @@ func TestModel_PinningFollowsDesign(t *testing.T) {
 // The ASCII theme renders every frame without unicode glyphs.
 func TestModel_ASCIITheme(t *testing.T) {
 	m := testModel(t)
-	m.theme = ResolveTheme("rwr", "", true, false)
+	m.theme = mustThemeASCII("rwr")
 	m.apply(reporting.ProcFinished{Processor: "packages", Dur: time.Second})
 	out := plain(m.render())
 	for _, glyph := range []string{"✓", "✗", "▰"} {

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -1,0 +1,59 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// stripCellZone waits for the zone scan to register the first strip cell;
+// the zone manager parses marks on Scan but records them asynchronously.
+func stripCellZone(t *testing.T, m *Model) (x, y int) {
+	t.Helper()
+	m.state = Running // the resolving frame has no strip
+	m.View()          // render once so Scan registers the marks
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if info := m.zones.Get(stripZone(0)); info != nil && !info.IsZero() {
+			return info.StartX, info.StartY
+		}
+		time.Sleep(5 * time.Millisecond)
+		m.View()
+	}
+	t.Fatal("strip zone never registered")
+	return 0, 0
+}
+
+func TestMouseHoverHighlightsStripCell(t *testing.T) {
+	m := testModel(t)
+	x, y := stripCellZone(t, m)
+
+	m.Update(tea.MouseMotionMsg{X: x, Y: y})
+	if m.hovered != 0 {
+		t.Fatalf("hovered = %d after motion over the first strip cell, want 0", m.hovered)
+	}
+	if got := plain(m.render()); !strings.Contains(got, "packages") {
+		t.Fatalf("hover hint missing from render:\n%s", got)
+	}
+
+	m.Update(tea.MouseMotionMsg{X: x, Y: y + 20})
+	if m.hovered != -1 {
+		t.Fatalf("hovered = %d after motion away, want -1", m.hovered)
+	}
+}
+
+func TestMouseClickSelectsAndPins(t *testing.T) {
+	m := testModel(t)
+	x, y := stripCellZone(t, m)
+	m.cursor = 1
+
+	m.Update(tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
+	if !m.pinned {
+		t.Fatal("click did not pin")
+	}
+	if m.cursor != 0 {
+		t.Fatalf("cursor = %d after click on the first strip cell, want 0", m.cursor)
+	}
+}

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -131,7 +131,10 @@ func unicodeSafe() bool {
 // ResolveTheme picks the theme: --theme flag, config key, $RWR_THEME, then
 // the default. NO_COLOR overrides all of it (colors drop; glyphs stay per
 // capability). forceASCII/forceUnicode come from --ascii/--unicode.
-func ResolveTheme(flagTheme, configTheme string, forceASCII, forceUnicode bool) Theme {
+// A TOML theme in <configDir>/themes/ overrides a built-in of the same name —
+// the providers pattern. unknown names the requested theme when nothing
+// matched and the default was substituted, so the caller can warn.
+func ResolveTheme(configDir, flagTheme, configTheme string, forceASCII, forceUnicode bool) (resolved Theme, unknown string) {
 	name := flagTheme
 	if name == "" {
 		name = configTheme
@@ -139,10 +142,15 @@ func ResolveTheme(flagTheme, configTheme string, forceASCII, forceUnicode bool) 
 	if name == "" {
 		name = os.Getenv("RWR_THEME")
 	}
-	themes := builtinThemes()
-	theme, ok := themes[name]
+	theme, ok := LoadUserTheme(configDir, name)
 	if !ok {
-		theme = themes["rwr"]
+		theme, ok = builtinThemes()[name]
+	}
+	if !ok {
+		if name != "" {
+			unknown = name
+		}
+		theme = builtinThemes()["rwr"]
 	}
 
 	switch {
@@ -156,9 +164,9 @@ func ResolveTheme(flagTheme, configTheme string, forceASCII, forceUnicode bool) 
 
 	if os.Getenv("NO_COLOR") != "" {
 		blank := Theme{Name: theme.Name + "+no-color", Glyphs: theme.Glyphs}
-		return blank
+		return blank, unknown
 	}
-	return theme
+	return theme, unknown
 }
 
 // style returns a foreground style for a role color; empty color renders

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -1,0 +1,79 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// mustTheme resolves a built-in by name for tests; user-theme lookup is
+// disabled by the empty config dir.
+func mustTheme(name string) Theme {
+	theme, _ := ResolveTheme("", name, "", false, false)
+	return theme
+}
+
+func mustThemeASCII(name string) Theme {
+	theme, _ := ResolveTheme("", name, "", true, false)
+	return theme
+}
+
+func TestResolveThemeBuiltin(t *testing.T) {
+	theme, unknown := ResolveTheme("", "nord", "", false, false)
+	if theme.Name != "nord" || unknown != "" {
+		t.Fatalf("got theme %q, unknown %q", theme.Name, unknown)
+	}
+}
+
+func TestResolveThemeUnknownFallsBackAndReports(t *testing.T) {
+	theme, unknown := ResolveTheme(t.TempDir(), "no-such-theme", "", false, false)
+	if theme.Name != "rwr" {
+		t.Fatalf("fallback theme = %q, want rwr", theme.Name)
+	}
+	if unknown != "no-such-theme" {
+		t.Fatalf("unknown = %q, want the requested name", unknown)
+	}
+}
+
+func TestResolveThemeEmptyNameIsNotUnknown(t *testing.T) {
+	theme, unknown := ResolveTheme("", "", "", false, false)
+	if theme.Name != "rwr" || unknown != "" {
+		t.Fatalf("got theme %q, unknown %q", theme.Name, unknown)
+	}
+}
+
+func TestResolveThemeUserFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "themes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := "accent = \"#123456\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "themes", "mine.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	theme, unknown := ResolveTheme(dir, "mine", "", false, false)
+	if unknown != "" {
+		t.Fatalf("unknown = %q for an existing user theme", unknown)
+	}
+	if theme.Name != "mine" || theme.Accent != "#123456" {
+		t.Fatalf("user theme not loaded: name %q accent %q", theme.Name, theme.Accent)
+	}
+	// Unset fields inherit the rwr defaults.
+	if theme.Success != rwrTheme.Success {
+		t.Fatalf("unset field did not inherit: %q", theme.Success)
+	}
+}
+
+func TestResolveThemeUserOverridesBuiltin(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "themes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "themes", "nord.toml"), []byte("accent = \"#000001\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	theme, _ := ResolveTheme(dir, "nord", "", false, false)
+	if theme.Accent != "#000001" {
+		t.Fatalf("user nord did not override built-in: accent %q", theme.Accent)
+	}
+}

--- a/internal/tui/theme_user.go
+++ b/internal/tui/theme_user.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -13,8 +14,13 @@ func LoadUserTheme(configDir, name string) (Theme, bool) {
 	if configDir == "" || name == "" {
 		return Theme{}, false
 	}
+	// The name reaches us from a flag or environment variable; a theme name
+	// is a bare filename, never a path — anything else stays out of ReadFile.
+	if name != filepath.Base(name) || strings.ContainsAny(name, `/\`) || name == ".." {
+		return Theme{}, false
+	}
 	path := filepath.Join(configDir, "themes", name+".toml")
-	data, err := os.ReadFile(path) // #nosec G304 -- rwr's own config dir
+	data, err := os.ReadFile(path) // #nosec G304 G703 -- rwr's own config dir; name validated as a bare filename above
 	if err != nil {
 		return Theme{}, false
 	}

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -13,7 +13,11 @@ import (
 // View implements tea.Model. Both layouts render from the same model, so a
 // live resize promotes or demotes with no state lost.
 func (m *Model) View() tea.View {
-	return tea.NewView(m.render())
+	// Scan registers the zone marks the renderers injected and strips their
+	// escape sequences; all-motion mouse mode is what delivers hover events.
+	view := tea.NewView(m.zones.Scan(m.render()))
+	view.MouseMode = tea.MouseModeAllMotion
+	return view
 }
 
 func (m *Model) render() string {
@@ -83,16 +87,24 @@ func (m *Model) viewHeader() string {
 	return left + strings.Repeat(" ", pad) + right
 }
 
-// strip: one block per processor, colored by state, one line total.
+// strip: one block per processor, colored by state, one line total. Each
+// cell is a mouse zone; the hovered cell renders reversed so the pointer's
+// target reads before the click.
 func (m *Model) viewStrip() string {
 	var b strings.Builder
-	for _, proc := range m.procs {
+	for i, proc := range m.procs {
 		glyph := m.theme.Glyphs.StripFilled
 		if m.dryRun || proc.State == ProcPending {
 			glyph = m.theme.Glyphs.StripEmpty
 		}
 		_, st := m.glyphFor(proc.State)
-		b.WriteString(st.Render(glyph))
+		if i == m.hovered {
+			st = st.Reverse(true)
+		}
+		b.WriteString(m.zones.Mark(stripZone(i), st.Render(glyph)))
+	}
+	if m.hovered >= 0 && m.hovered < len(m.procs) {
+		b.WriteString(" " + style(m.theme.Subtext).Render(m.procs[m.hovered].Name))
 	}
 	return b.String()
 }
@@ -103,12 +115,16 @@ func (m *Model) viewCollapsed() []string {
 	var lines []string
 	var done []string
 	var doneDur time.Duration
-	for _, proc := range m.procs {
+	for i, proc := range m.procs {
+		nameStyle := style(m.theme.Text)
+		if i == m.hovered {
+			nameStyle = nameStyle.Underline(true)
+		}
 		switch proc.State {
 		case ProcDone:
 			if m.expanded {
 				glyph, st := m.glyphFor(proc.State)
-				lines = append(lines, fmt.Sprintf(" %s %-16s %s", st.Render(glyph), proc.Name, style(m.theme.Muted).Render(proc.Dur.Round(time.Millisecond*100).String())))
+				lines = append(lines, m.zones.Mark(rowZone(i), fmt.Sprintf(" %s %s %s", st.Render(glyph), nameStyle.Render(fmt.Sprintf("%-16s", proc.Name)), style(m.theme.Muted).Render(proc.Dur.Round(time.Millisecond*100).String()))))
 			} else {
 				done = append(done, proc.Name)
 				doneDur += proc.Dur
@@ -119,7 +135,7 @@ func (m *Model) viewCollapsed() []string {
 			if proc.Err != nil {
 				reason = proc.Err.Error()
 			}
-			lines = append(lines, fmt.Sprintf(" %s %-16s %s", st.Render(glyph), proc.Name, style(m.theme.Danger).Render(truncate(reason, m.width-24))))
+			lines = append(lines, m.zones.Mark(rowZone(i), fmt.Sprintf(" %s %s %s", st.Render(glyph), nameStyle.Render(fmt.Sprintf("%-16s", proc.Name)), style(m.theme.Danger).Render(truncate(reason, m.width-24)))))
 		}
 	}
 	if len(done) > 0 && !m.expanded {

--- a/openspec/changes/add-tui/tasks.md
+++ b/openspec/changes/add-tui/tasks.md
@@ -17,11 +17,11 @@ Steps 1–5 are prerequisites and carry the risk; 6+ are additive.
 - [x] 8. Filters, search, pinning.
 - [x] 9. Summary + dry-run frames.
 - [x] 10. Theming + glyph fallback (`NO_COLOR=1`, `TERM=xterm`, conhost ASCII).
-- [ ] 11. Mouse + hover (bubblezone). PARTIAL: native click-to-select on the
-      strip and wheel/click pinning are in; bubblezone hover is NOT — the
-      released bubblezone targets bubbletea v1 (github.com module path) and
-      cannot be imported against the charm.land v2 stack. Needs bubblezone v2
-      or a fork.
+- [x] 11. Mouse + hover (bubblezone). bubblezone v2
+      (github.com/lrstanley/bubblezone/v2, charm.land v2 deps) shipped;
+      strip cells and list rows are zones, hover reverses the cell and names
+      the processor, click selection goes through the zones instead of
+      hardcoded coordinates, all-motion mouse mode set on the view.
 - [x] 12. Animation (harmonica; kill ticks when springs settle).
 - [x] 13. Compact mode + live resize.
 - [x] 14. OSC 9 notification (unfocused, >30s, recognized terminal only).

--- a/openspec/changes/add-tui/tasks.md
+++ b/openspec/changes/add-tui/tasks.md
@@ -25,7 +25,7 @@ Steps 1–5 are prerequisites and carry the risk; 6+ are additive.
 - [x] 12. Animation (harmonica; kill ticks when springs settle).
 - [x] 13. Compact mode + live resize.
 - [x] 14. OSC 9 notification (unfocused, >30s, recognized terminal only).
-- [ ] 15. Full test checklist from design.md §18. REMAINING: per-item
-      ResourceDone/LaneUpdate emission from the ten Process* functions
-      (mechanical, design §5) so lanes fill live; manual sudo-prompt handoff
-      check on a real TTY; NO_COLOR/TERM=xterm/conhost visual passes.
+- [ ] 15. Full test checklist from design.md §18. Per-item
+      ResourceDone/LaneUpdate emission from all ten Process* functions is DONE.
+      REMAINING: manual terminal checks only — sudo-prompt handoff on a real
+      TTY; NO_COLOR/TERM=xterm/conhost visual passes.


### PR DESCRIPTION
Closes the three open add-tui gaps.

## User themes (dead code → wired)
`ResolveTheme` now consults `<configdir>/themes/<name>.toml` before the built-ins (the providers pattern: filesystem overrides embedded), and reports an unknown theme name so `rwr` warns instead of silently falling back to the default. Theme names are validated as bare filenames before the file read (gosec G703 caught the taint path when the wiring made it reachable).

## Task 11 — mouse + hover
The blocker was stale: bubblezone v2 ships against the charm.land v2 stack. Strip cells and collapsed-list rows are zones; hover reverses the cell and names the processor beside the strip; clicks select through zones instead of the hardcoded `Y==1` mapping. The view requests all-motion mouse mode — which is what delivers hover (and click) events at all.

## Task 15 — per-item progress from all ten processors
A `progress` helper emits one `ResourceDone` + an absolute `LaneUpdate` per completed unit; `expect()` raises lane denominators before items run so lanes render `0/N` up front. All ten Process* functions instrumented (packages sets the pattern; git, scripts, services, repositories, files/templates/directories, fonts, ssh_keys, users/groups, configuration follow). Status vocabulary: OK/Failed/Skipped, Planned in dry-run, Unknown where the loop can't know (gsettings). The model consumes `ResourceDone` to move planned Summary resources to their outcomes; name/action fields mirror `enumerateResources` so the matching holds. `files` and `users` thread one shared tracker through their sub-loops so a second tracker can't reset a lane.

Remaining in add-tui task 15 is now only the manual terminal checklist (sudo handoff on a real TTY, NO_COLOR/TERM visual passes) — it needs a human at a terminal.

Gates: `go build ./...`, `go test ./...`, `golangci-lint run` 0 issues, gosec clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)