### PR TITLE
docs(openspec): Wave-4 change proposals — managed-auth, uninstall/status, bootstrap command, CLI shorthands

### DIFF
--- a/openspec/changes/add-bootstrap-command/proposal.md
+++ b/openspec/changes/add-bootstrap-command/proposal.md
@@ -1,0 +1,52 @@
+# Change: `rwr bootstrap` as a standalone command
+
+## Why
+
+Bootstrap is the one processor you cannot run by itself. It runs first inside
+`rwr all` when a bootstrap file exists (`internal/processors/all.go:123-129`),
+gated by a run-once marker: `ProcessBootstrap` skips unless
+`--force-bootstrap` is set or the marker is absent
+(`internal/processors/bootstrap.go:18-21`; the marker is the empty file
+`<configdir>/bootstrap`, `internal/helpers/bootstrap.go:13-32`). It is
+deliberately absent from the `runProcessors` table (`cmd/run.go:112-123`), so
+neither `rwr run bootstrap` nor the root shorthand `rwr bootstrap` exists.
+
+The result: re-running just the bootstrap after editing `bootstrap.yaml`
+requires `rwr all --force-bootstrap` — which also re-runs every other
+processor. That is both slow and surprising ("I asked to redo bootstrap, why
+is it reinstalling packages?").
+
+## What Changes
+
+- `rwr run bootstrap` joins the processor table, and therefore the root
+  shorthand `rwr bootstrap` works too — same mechanism as every other
+  processor, no special-casing in `cmd/`.
+- Semantics of an explicit invocation: asking for bootstrap by name implies
+  wanting it to run, so the standalone command ignores the run-once marker
+  (equivalent to `--force-bootstrap`) — the marker exists to keep `all`
+  idempotent, not to refuse an explicit request. It still writes/refreshes the
+  marker on success and still honors `--dry-run`.
+- No bootstrap file in the tree → clear error naming the candidate filenames
+  looked for (reusing `findBootstrapFile`'s candidates,
+  `internal/processors/all.go:20-31`), rather than a silent no-op.
+- `rwr all --force-bootstrap` keeps working unchanged.
+
+## Breakage
+
+Nothing breaks. New subcommand and shorthand; `all`'s gating, the marker file,
+and `--force-bootstrap` are untouched. The only new name claimed at the root
+is `bootstrap`, which was previously an unknown-command error.
+
+## What this is not
+
+Not a redesign of the run-once mechanism (the marker stays an empty file in
+the config dir; a richer record is `add-uninstall-status`'s territory), and
+not a change to bootstrap's contents or ordering inside `all`.
+
+## Impact
+
+- Affected specs: `cli`.
+- Affected code: `cmd/run.go` (one `runProcessorSpec` entry + a dispatch that
+  calls `ProcessBootstrap` instead of `processors.All`),
+  `internal/processors/bootstrap.go` (accept an explicit-run flag or the
+  caller passes force), docs `commands/` page.

--- a/openspec/changes/add-bootstrap-command/specs/cli/spec.md
+++ b/openspec/changes/add-bootstrap-command/specs/cli/spec.md
@@ -1,0 +1,24 @@
+# CLI — Deltas
+
+## ADDED Requirements
+
+### Requirement: Bootstrap runs standalone
+
+RWR SHALL provide `rwr run bootstrap` (and the root shorthand `rwr bootstrap`)
+to run the bootstrap processor by itself. An explicit invocation SHALL run the
+bootstrap even when the run-once marker exists, SHALL refresh the marker on
+success, and SHALL fail with an error naming the candidate filenames when the
+tree has no bootstrap file. The gating of bootstrap inside `rwr all` — skipped
+when the marker exists unless `--force-bootstrap` is given — is unchanged.
+
+#### Scenario: Re-running bootstrap after editing it
+
+- **WHEN** the run-once marker exists and the operator runs `rwr bootstrap`
+- **THEN** the bootstrap processor runs, and no other processor does
+
+#### Scenario: No bootstrap file in the tree
+
+- **WHEN** `rwr bootstrap` runs against a tree with no bootstrap file in any
+  supported format
+- **THEN** the command exits non-zero with an error naming the filenames it
+  looked for

--- a/openspec/changes/add-bootstrap-command/tasks.md
+++ b/openspec/changes/add-bootstrap-command/tasks.md
@@ -1,0 +1,18 @@
+# Tasks
+
+- [ ] 1. Add `bootstrap` to the `runProcessors` table with a dedicated
+      dispatch to `ProcessBootstrap` (the generic `processors.All` path
+      doesn't run bootstrap). Test: `rwr run bootstrap` and root shorthand
+      `rwr bootstrap` both resolve (fails without the entry).
+- [ ] 2. Explicit invocation bypasses the run-once marker: standalone
+      bootstrap runs even when `<configdir>/bootstrap` exists, and refreshes
+      the marker on success. Test: marker present, standalone run still
+      processes; `rwr all` without `--force-bootstrap` still skips (fails if
+      gating leaks).
+- [ ] 3. Missing bootstrap file errors, naming the candidate filenames
+      searched. Test: tree without a bootstrap file → non-zero exit and the
+      candidates in the message.
+- [ ] 4. `--dry-run` respected end to end (no marker write, no mutations);
+      test via the central dry-run path.
+- [ ] 5. Docs: commands page for `rwr bootstrap`; note the relationship to
+      `--force-bootstrap` on `all`.

--- a/openspec/changes/add-managed-auth/design.md
+++ b/openspec/changes/add-managed-auth/design.md
@@ -1,0 +1,110 @@
+# Design: Managed auth
+
+## Context
+
+Today's secret handling is a fixed two-key list (`internal/types/secrets.go`)
+with three behaviors attached: template-scope withholding, `RWR_VAR_*` export
+gating, and log redaction. The design generalizes the *list* while keeping the
+three behaviors exactly as specified in `credential-handling` — they are
+already right, they just apply to too few things.
+
+## Goals
+
+- One declared path for every secret a tree needs; the declared path is the
+  safe path.
+- No plaintext secrets at rest, ever, for managed credentials.
+- The trust model is unchanged: init file declares, operator exposes,
+  blueprints only consume.
+
+## Non-goals
+
+- Secret *management* (rotation, expiry, vault backends). Sources are local:
+  env, OS keyring, prompt. A future `exec:` source could shell out to
+  `pass`/`op`/`vault` — out of scope here, but the sources list is ordered and
+  extensible precisely so that can land without schema change.
+- Per-blueprint scoping. Scope is per-processor at most; anything finer needs
+  provenance tracking rwr does not have.
+
+## Decisions
+
+### Declaration shape
+
+```yaml
+credentials:
+  - name: cachix_token
+    description: "Cachix auth token for the nix cache"
+    sources: [env:CACHIX_AUTH_TOKEN, keyring, prompt]
+    scope: [scripts]        # optional; default: wherever exposeCredentials reaches
+```
+
+- `name` is the identity everywhere: in `exposeCredentials`, in template scope
+  (`{{ .Credentials.cachix_token }}`), in the exported env name
+  (`RWR_CRED_CACHIX_TOKEN`), in the keyring entry.
+- Built-ins `gh_api_token` and `ssh_private_key` are implicit declarations with
+  sources `[flag, config, env, keyring, prompt]` so existing behavior is a
+  special case, not a parallel system. `types.SecretConfigKeys` stays as the
+  bridge from viper keys to credential names.
+
+### Source precedence
+
+Ordered, first hit wins, per credential (the declaration's order is the
+precedence). Default when `sources` is omitted: `[env:RWR_CRED_<NAME>, keyring,
+prompt]`. Rationale: env first so CI can inject without prompting; keyring
+before prompt so an interactive answer given once (and saved) is not re-asked.
+
+`prompt`:
+- masked input (same huh machinery as `PromptGitHubToken`,
+  `internal/prompts/github.go`)
+- skipped when not a TTY or `--interactive=false`; the resolution error then
+  names the sources that were actually tried
+- after a successful prompt, offer (interactive, default yes) to save to the
+  keyring so next run doesn't ask
+
+### Resolution timing
+
+A single resolution phase in `ProcessInitialization` after `SetExposedCredentials`
+(`internal/processors/initialize.go:156`) and before
+`setUserDefinedAndEnvVariables`, so the export gate sees the full credential
+set. All declared credentials resolve up front — failing at minute 20 inside a
+script is worse than failing at second 1 — except credentials scoped to
+processors not selected for this run, which are skipped.
+
+### Storage
+
+- Keyring only, via the OS-native store (service `rwr`, account = credential
+  name). Candidate library: `zalando/go-keyring` (no cgo, covers Secret
+  Service, macOS Keychain, Windows Credential Manager). Headless Linux without
+  a Secret Service provider: `keyring` source resolves to "unavailable" and
+  precedence moves on — never an error on read, loud error on an explicit save.
+- Hard rule: rwr never writes a managed credential to a plaintext file. The
+  one existing violation — the GitHub token in the viper config file
+  (`SaveGitHubTokenToConfig`) — is grandfathered for reads; the device flow's
+  save path prefers the keyring when available and only falls back to the
+  config file with a warning naming the file.
+
+### Redaction
+
+Managed credential values register with the existing redaction machinery at
+resolution time, so every value is behind `types.RedactedPlaceholder` in logs
+and `--show-secrets` (`cmd/root.go:178`) reveals them uniformly. Values must
+never appear in argv (readable via `ps`, per `openspec/config.yaml`): the
+export surface is env (opt-in via `exposeCredentials`) and template scope
+(same opt-in) only.
+
+### Scope
+
+`scope` limits which processors see the credential even after exposure:
+`scripts`, `templates` (files/templates rendering), or a processor name.
+Enforcement point is the same gate that today checks `IsCredentialExposed` —
+the check becomes (exposed AND in scope for the consuming processor). Default
+scope is everything `exposeCredentials` reaches today, so omitting `scope`
+reproduces current semantics.
+
+## Risks
+
+- Keyring behavior varies wildly across desktop environments; mitigation:
+  keyring is never load-bearing (always another source in the chain) and the
+  test suite fakes the keyring interface.
+- Two names for one secret (viper key vs credential name) during transition;
+  mitigation: `normaliseCredentialKey` already collapses these
+  (`internal/types/secrets.go:70-77`), keep it the single normalizer.

--- a/openspec/changes/add-managed-auth/proposal.md
+++ b/openspec/changes/add-managed-auth/proposal.md
@@ -1,0 +1,78 @@
+# Change: Managed auth — declared credentials, sourced and redacted
+
+## Why
+
+rwr's credential story is two hardcoded secrets and ad-hoc plumbing around one
+of them. `types.SecretConfigKeys` (`internal/types/secrets.go:15-18`) names
+exactly `repository.gh_api_token` and `repository.ssh_private_key`; everything
+downstream — withholding from template scope, the `RWR_VAR_*` export gate
+(`internal/processors/initialize.go:239-244`), log redaction — keys off that
+fixed list. A blueprint that needs any *other* secret (a registry token, an API
+key a script writes into a `.netrc`, a license key) has no declared path at
+all: the operator smuggles it in as an `RWR_*` environment variable, which
+lands in `Variables.UserDefined` (`initialize.go:227-233`) with none of the
+secret handling — unredacted in debug logs, exported to every spawned command.
+
+The GitHub token shows what the pieces look like when hand-built: `--gh-auth`
+runs an OAuth device flow (`internal/processors/ssh_key.go:278`,
+`AuthenticateWithGitHub`), `--gh-api-key` takes it on the command line
+(`cmd/root.go:145`), and the result persists via `viper.WriteConfig` into the
+config file — plaintext at rest, guarded only by 0600 permissions
+(`internal/prompts/github.go`, `SaveGitHubTokenToConfig`). None of that
+machinery is reusable for a second credential; the ssh_keys processor is the
+only one that gets device-flow pre-work (`cmd/run.go:110-123`).
+
+`exposeCredentials` (`internal/types/initialize.go:67-70`) already gives trees
+an opt-in vocabulary for *sharing* credentials with blueprints. What is missing
+is the other half: a way for a tree to *declare* the credentials it needs, and
+for rwr to *source* them — so the declared path is also the safe path.
+
+## What Changes
+
+- A `credentials:` section in the init file. Each entry declares a named
+  credential the tree's blueprints need:
+  - `name` — the identifier blueprints reference (e.g. `cachix_token`)
+  - `sources` — ordered list of places to look: `env:<VAR>`, `keyring`,
+    `prompt` (interactive input, masked), with a documented default order
+  - `description` — shown when prompting
+  - optional `scope` — which processors may read it (default: templates and
+    scripts, same surface `exposeCredentials` governs today)
+- Resolution at init time, after config load and before any processor runs:
+  first source that yields a value wins; a declared credential that resolves
+  nowhere is an error naming the credential and the sources tried (non-TTY
+  runs cannot prompt, so `prompt` is skipped there and the error says so).
+- Every managed credential gets the full secret treatment that today only the
+  two hardcoded keys get: withheld from template scope and `RWR_VAR_*` export
+  unless named in `exposeCredentials`, redacted in logs behind
+  `types.RedactedPlaceholder`, never placed in argv (stdin or file at 0600
+  only, matching the existing convention in `openspec/config.yaml`).
+- Storage: opt-in `keyring` persistence via the OS keychain (Secret Service /
+  macOS Keychain / Windows Credential Manager). rwr SHALL never write a
+  managed credential to a plaintext file at rest. The existing GitHub-token
+  config-file write is grandfathered but the device flow learns to prefer the
+  keyring when available.
+- The GitHub token becomes the first managed credential: `--gh-auth` /
+  `--gh-api-key` become sugar for sourcing `gh_api_token`, keeping their flags
+  and behavior. `exposeCredentials` keeps its exact semantics, now applying to
+  the whole declared set instead of a two-entry hardcoded list.
+
+## Breakage
+
+Nothing breaks for existing blueprints and init files. `credentials:` is a new
+optional section; trees without it behave exactly as today, including the two
+built-in secrets, `exposeCredentials`, `--gh-auth`, and `--gh-api-key`. The
+device flow preferring the keyring changes where a *new* token is persisted;
+an existing config-file token keeps being read.
+
+## Impact
+
+- Affected specs: `credential-handling` (the bulk), `initialization` (new init
+  section), `cli` (flag semantics folded into sourcing).
+- Affected code: `internal/types/secrets.go` (dynamic secret set),
+  `internal/processors/initialize.go` (resolution phase),
+  `internal/prompts/github.go` / `internal/processors/ssh_key.go` (device flow
+  re-pointed at the credential store), new keyring package.
+- Security posture: blueprints remain untrusted; a blueprint can *reference* a
+  declared credential but never *declare* one — declarations live only in the
+  init file the operator points rwr at, and exposure still requires the
+  operator's `exposeCredentials` opt-in.

--- a/openspec/changes/add-managed-auth/specs/credential-handling/spec.md
+++ b/openspec/changes/add-managed-auth/specs/credential-handling/spec.md
@@ -1,0 +1,46 @@
+# Credential Handling — Deltas
+
+## ADDED Requirements
+
+### Requirement: Trees declare the credentials they need
+
+RWR SHALL accept a `credentials` section in the init file declaring named
+credentials, each with an ordered list of sources (`env:<VAR>`, `keyring`,
+`prompt`), and SHALL resolve every declared credential before any processor
+runs, taking the first source that yields a value. A declared credential that
+resolves from no source SHALL fail the run with an error naming the credential
+and the sources tried.
+
+Declared credentials receive the same handling as the built-in GitHub token and
+SSH private key: withheld from template scope and spawned-command environments
+unless named in `exposeCredentials`, and redacted in logs.
+
+#### Scenario: Declared credential resolves from the environment
+
+- **WHEN** an init file declares `cachix_token` with sources
+  `[env:CACHIX_AUTH_TOKEN, prompt]` and `CACHIX_AUTH_TOKEN` is set
+- **THEN** the credential resolves without prompting
+- **AND** its value is absent from spawned-command environments unless
+  `exposeCredentials` names it
+
+#### Scenario: Unresolvable credential fails up front
+
+- **WHEN** a declared credential yields no value from any source in a non-TTY
+  run
+- **THEN** the run fails before any processor executes, with an error naming
+  the credential and noting that `prompt` was skipped
+
+### Requirement: Managed credentials are never stored in plaintext
+
+RWR SHALL NOT write a managed credential's value to a plaintext file at rest.
+Persistence SHALL use the operating system keyring, and only with the
+operator's consent. When no keyring backend is available, RWR SHALL decline to
+persist and say so, rather than fall back to a plaintext file — except the
+pre-existing GitHub-token config-file path, which SHALL warn with the file
+path when used.
+
+#### Scenario: Device-flow token persisted with a keyring available
+
+- **WHEN** `--gh-auth` completes and an OS keyring backend is available
+- **THEN** the token is saved to the keyring and no plaintext file gains the
+  token value

--- a/openspec/changes/add-managed-auth/tasks.md
+++ b/openspec/changes/add-managed-auth/tasks.md
@@ -1,0 +1,34 @@
+# Tasks
+
+- [ ] 1. Types: `credentials:` init-file section (strict decode; unknown keys
+      error), credential registry replacing the fixed `SecretConfigKeys` list
+      while keeping the two built-ins implicitly declared. Test: a tree
+      declaring `cachix_token` gets it withheld/redacted exactly like
+      `gh_api_token`; fails without the registry.
+- [ ] 2. Source resolvers: `env:<VAR>`, `keyring`, `prompt` behind one
+      interface; ordered first-hit-wins resolution. Table tests per source and
+      per precedence order, keyring faked.
+- [ ] 3. Resolution phase in `ProcessInitialization` (after
+      `SetExposedCredentials`, before `setUserDefinedAndEnvVariables`).
+      Tests: unresolvable credential errors up front naming sources tried;
+      non-TTY skips `prompt` and the error says so; out-of-scope credentials
+      for the selected processors are not resolved.
+- [ ] 4. Keyring store (zalando/go-keyring or equivalent): read source +
+      explicit save; unavailable backend degrades silently on read, errors on
+      save. Interface-level tests with a fake; no CI dependency on a real
+      keyring.
+- [ ] 5. Redaction + export: resolved values registered for redaction; env
+      export as `RWR_CRED_<NAME>` gated by `exposeCredentials` and `scope`;
+      template scope under `.Credentials.<name>` behind the same gate. Tests:
+      value absent from spawned env and rendered templates without opt-in,
+      present with; debug logs show `[redacted]` (fails without redaction
+      registration); value never in argv.
+- [ ] 6. Fold the GitHub token in: `--gh-auth` / `--gh-api-key` populate the
+      `gh_api_token` credential; device-flow save prefers keyring, config-file
+      fallback warns with the path. Tests: existing config-file token still
+      read; keyring-available path writes no plaintext.
+- [ ] 7. Prompt UX: masked huh input with `description`, post-prompt
+      save-to-keyring offer, honored `--interactive=false`.
+- [ ] 8. Docs (`configuration.md`, new credentials page) + `examples/` init
+      files covering `credentials:` in all formats; validate covers the
+      section.

--- a/openspec/changes/add-uninstall-status/design.md
+++ b/openspec/changes/add-uninstall-status/design.md
@@ -1,0 +1,91 @@
+# Design: Run records, status, uninstall
+
+## Context
+
+rwr is convergence-oriented (`openspec/config.yaml`: running `rwr all` twice
+is the normal case) but write-only: nothing records what a run did. This
+design adds an observation journal and two consumers of it. It deliberately
+does NOT turn rwr into a state-enforcing system like Terraform — blueprints
+remain the source of desired state; the record is evidence of past applies,
+never an input to `all`.
+
+## Goals
+
+- `rwr all` leaves a truthful record of what it changed.
+- `rwr status` answers "does this machine match the tree" without applying.
+- `rwr uninstall` reverses what is honestly reversible and enumerates what is
+  not, before touching anything.
+
+## Non-goals
+
+- Rollback of file *contents* (no prior-value capture; that is a backup tool).
+- Reversing scripts, configuration writes, users/groups, or uploaded SSH keys.
+- Using the record to skip work during `all` (convergence already handles it).
+- Cross-machine or remote state.
+
+## Decisions
+
+### Record format and location
+
+- `<configdir>/state/runs/<timestamp>-<shortid>.json`, plus `latest` pointer.
+  JSON, versioned (`recordVersion: 1`), written incrementally during the run
+  (crash leaves a truthful partial record, marked unfinalized).
+- Per-resource entry: `{processor, action, identity, detail, ok}` where
+  `identity` is enough to find the thing again: `{provider, name}` for
+  packages, `{dest, sha256}` for files/templates, `{name, action}` for
+  services, `{name}` for repositories/fonts, `{target}` for git.
+- Only *applies* are recorded (dry-run writes nothing). Removal runs append
+  removal entries; `uninstall` finalizes by marking entries reversed rather
+  than deleting records — the journal is append-only history.
+- Emission point: the processors already funnel failures through the ledger
+  (`internal/processors/failures.go`); record emission rides the same
+  per-item points, so coverage is per-item, not per-processor-exit.
+
+### `rwr status`
+
+- Desired side: reuse blueprint resolution (the `ResolveStage1` /
+  `plan_stage2` machinery, `internal/processors/plan.go`) — no new parser.
+- Actual side: a new optional per-processor `Query` capability:
+  - packages: provider `list` command output (already defined per provider,
+    e.g. apt's `dpkg --get-selections`) parsed for presence
+  - files/templates: dest exists + sha256 comparison against rendered content
+  - services: platform query (`systemctl is-enabled/is-active`, launchctl,
+    sc.exe)
+  - repositories: source-file presence at the provider's `paths`
+  - fonts/git: recorded-path existence
+  - scripts, configuration, users, ssh_keys: report `unknown` — a query that
+    cannot be honest is worse than none
+- Output rows: `in-sync | missing | modified | unknown`; with a record
+  available, an extra class `stale` (recorded but no longer in the tree).
+  Exit code 0 when everything in-sync/unknown, 1 on drift — scriptable.
+- Never elevates and never mutates: queries run unelevated, read-only.
+
+### `rwr uninstall`
+
+- Input is the record (union of unreversed entries across runs), not the
+  blueprint tree — uninstall after editing or deleting the tree still works.
+  No record → refuse with an explanation (guessing at removals from a tree
+  that may have changed is how you delete the wrong file).
+- Reverse application order (the inverse of the `all` processor order,
+  `internal/processors/all.go`), per-item within each processor.
+- Safety rails:
+  - files/dirs/git: delete only when the recorded sha256 still matches the
+    disk content; modified files are skipped and listed
+  - packages: provider `remove` verb; a package the record shows applied but
+    `status` shows absent is skipped silently (already gone)
+  - never touch anything without a record entry
+  - the not-reversible list (scripts, configuration, users, ssh uploads) is
+    printed up front; `--dry-run` shows the full plan via the existing
+    central dry-run path in `system.RunCommand`
+  - interactive confirm by default; `--yes` bypasses
+- Partial failure: keep going per-item, ledger the failures, exit non-zero,
+  leave failed entries unreversed so a re-run retries them.
+
+## Risks
+
+- Provider `list` output parsing differs per provider; scope: presence only,
+  not versions, and add per-provider parse fixtures.
+- Record/actual divergence (operator removed things by hand): `status` is the
+  honest surface for that; `uninstall` skips already-gone items.
+- Elevation: removal needs the same elevation the apply needed; entries record
+  whether the apply was elevated so uninstall can request it up front.

--- a/openspec/changes/add-uninstall-status/proposal.md
+++ b/openspec/changes/add-uninstall-status/proposal.md
@@ -1,0 +1,77 @@
+# Change: Run records, `rwr status`, and `rwr uninstall`
+
+## Why
+
+`rwr all` is a one-way door. There is no inverse operation, no record of what
+a run applied, and no desired-vs-actual view short of reading `--dry-run`
+logs. Concretely, today:
+
+- The only persisted trace of a run is the empty bootstrap marker file
+  (`internal/helpers/bootstrap.go:36-49` creates `<configdir>/bootstrap` with
+  no content). Nothing records which packages were installed, which files were
+  written, which services were enabled, when, or from which blueprint tree.
+- The removal machinery exists but is blueprint-driven, not inverse-driven:
+  packages honor `action: remove` (`internal/processors/packages.go:118`) and
+  every provider defines a `remove` command (e.g.
+  `internal/system/definitions/providers/apt.json` `"remove": "remove -y"`)
+  plus `repository.remove` step lists — but the operator must hand-edit
+  blueprints to `remove` and re-run, which also loses the declaration.
+- Desired state is already resolvable without applying (the TUI's
+  `ResolveStage1`, `internal/processors/plan.go:17`, and dry-run centralized
+  in `system.RunCommand`), but nothing compares it to the actual machine.
+
+Without a record, "what did rwr do to this machine" and "take it back off"
+are both unanswerable — a real cost for the trying-it-out user and for anyone
+provisioning short-lived machines.
+
+## What Changes
+
+- **Run record**: every non-dry-run applies get journaled to a state file
+  (`<configdir>/state/`, one record per run): timestamp, blueprint tree
+  identity (URL/path + commit when git), and per-resource entries — what was
+  applied, by which processor, with enough identity to check or reverse it
+  (package name + provider, file dest + content hash, service name + action,
+  repo name, font name, git target). Recording is best-effort observation:
+  a failed run still records what it did apply.
+- **`rwr status`**: desired-vs-actual. Resolves the tree (reusing the plan
+  machinery), queries actuals per processor — package present via the
+  provider's `list`/`search`, file dest exists and hash matches, service
+  enabled/running, repo file present — and prints a drift table: in-sync,
+  missing, modified, unmanaged-but-recorded. Requires new read-only query
+  support per processor; processors that cannot be queried (scripts,
+  configuration) report `unknown` honestly rather than guessing.
+- **`rwr uninstall`**: reverse of `all`, driven by the run record (not by
+  re-reading blueprints, so it works after the tree changed). Reverses in
+  reverse application order, per-processor where a true inverse exists:
+  - packages → provider `remove`
+  - repositories → provider `remove` steps
+  - fonts → delete recorded files
+  - services → disable/stop units the record created
+  - files/directories/git → delete recorded dests, only when the recorded
+    content hash still matches (modified files are skipped and listed)
+  - **not reversible, and said so**: scripts (arbitrary side effects),
+    configuration writes (dconf/plist/registry have no recorded prior value),
+    users/groups (destructive; out of scope), ssh keys uploaded to GitHub.
+    `rwr uninstall` prints exactly what it will not undo, before doing
+    anything.
+  - honors `--dry-run`; interactive confirmation by default, `--yes` for
+    scripts.
+
+## Breakage
+
+Nothing breaks for existing blueprints. The state file is new and additive;
+`rwr all` behavior is unchanged apart from writing the record. Machines
+provisioned by older rwr have no record: `rwr status` falls back to
+desired-vs-actual only (no "recorded" column) and `rwr uninstall` refuses
+with an explanation rather than guessing.
+
+## Impact
+
+- Affected specs: `cli` (two new commands), new capability `state-tracking`
+  (run record format and guarantees), touches per-processor specs for the
+  query/remove surfaces as they gain them.
+- Affected code: new `internal/state` package; `internal/processors/*` gain
+  record emission and query hooks; provider definitions already carry the
+  remove verbs.
+- The record contains resource identities and hashes, no secrets; it lives
+  under the config dir with user-only permissions.

--- a/openspec/changes/add-uninstall-status/specs/state-tracking/spec.md
+++ b/openspec/changes/add-uninstall-status/specs/state-tracking/spec.md
@@ -1,0 +1,43 @@
+# State Tracking — Deltas
+
+## ADDED Requirements
+
+### Requirement: Applies are journaled to a run record
+
+RWR SHALL record every resource it applies during a non-dry-run to a versioned,
+append-only run record under the configuration directory, with per-resource
+identity sufficient to check or reverse the apply (package name and provider,
+file destination and content hash, service name and action, repository name,
+font name, git target). The record SHALL be written incrementally so an
+interrupted run still leaves a truthful partial record, and SHALL contain no
+secret values.
+
+#### Scenario: A run journals what it applied
+
+- **WHEN** `rwr all` installs a package and writes a file
+- **THEN** the run record contains an entry for each, identifying the package
+  by name and provider and the file by destination and content hash
+
+#### Scenario: Dry-run leaves no record
+
+- **WHEN** `rwr all --dry-run` completes
+- **THEN** no run record is written
+
+### Requirement: Uninstall reverses only what is honestly reversible
+
+RWR SHALL drive `rwr uninstall` from the run record, in reverse application
+order, and SHALL enumerate the recorded actions it cannot reverse (scripts,
+configuration writes, users and groups, uploaded SSH keys) before making any
+change. RWR SHALL delete a recorded file only when its content hash still
+matches the record, and SHALL refuse to uninstall when no run record exists.
+
+#### Scenario: Modified file is not deleted
+
+- **WHEN** a recorded file's content no longer matches its recorded hash
+- **THEN** `rwr uninstall` skips it and lists it as modified
+
+#### Scenario: No record, no guessing
+
+- **WHEN** `rwr uninstall` runs on a machine with no run record
+- **THEN** it exits with an error explaining that nothing was recorded, and
+  changes nothing

--- a/openspec/changes/add-uninstall-status/tasks.md
+++ b/openspec/changes/add-uninstall-status/tasks.md
@@ -1,0 +1,36 @@
+# Tasks
+
+- [ ] 1. `internal/state`: versioned run-record types, incremental writer
+      (`<configdir>/state/runs/`, user-only perms), append-only journal with
+      `latest` pointer. Tests: crash-partial record is readable and marked
+      unfinalized; dry-run writes nothing.
+- [ ] 2. Record emission from the per-item apply points in each processor
+      (ride the existing failure-ledger seams). Tests per processor: applied
+      item appears with correct identity (package name+provider, file
+      dest+sha256, service name, repo name, font name, git target); failed
+      item recorded as not-ok.
+- [ ] 3. Query capability: packages via provider `list` (parse fixtures per
+      provider), files via dest+sha256, services via platform query,
+      repositories via source-file presence, fonts/git via path existence;
+      scripts/configuration/users/ssh_keys return `unknown`. Tests: each
+      query class, plus queries never execute a mutating command (fails
+      without the read-only guard).
+- [ ] 4. `rwr status`: desired via the plan machinery, actuals via queries,
+      drift table (`in-sync/missing/modified/unknown/stale`), exit 1 on
+      drift. Tests: golden output for a synthetic tree; no-record fallback
+      omits the recorded column; command never elevates.
+- [ ] 5. `rwr uninstall`: record-driven reverse-order removal — provider
+      `remove` for packages, provider `remove` steps for repositories,
+      hash-guarded deletes for files/dirs/git/fonts, disable/stop for
+      services. Tests: modified file skipped and listed; already-absent
+      package skipped; reverse ordering asserted.
+- [ ] 6. Uninstall safety UX: up-front not-reversible list (scripts,
+      configuration, users, ssh uploads), interactive confirm, `--yes`,
+      `--dry-run` through `system.RunCommand`. Tests: refusal with no record;
+      confirm declined → nothing runs; dry-run mutates nothing.
+- [ ] 7. Partial-failure semantics: per-item continue + ledger + non-zero
+      exit; failed entries stay unreversed and a re-run retries them (test
+      fails without re-run coverage).
+- [ ] 8. Docs: new commands page, state-file format doc; examples unaffected
+      (no blueprint schema change) — verify `examples/` validation still
+      green.

--- a/openspec/changes/refine-cli-shorthands/proposal.md
+++ b/openspec/changes/refine-cli-shorthands/proposal.md
@@ -1,0 +1,64 @@
+# Change: CLI polish — config view/edit, shorthand rationalization
+
+## Why
+
+Two leftover roughnesses after the fossil-kill batch (#209 landed the rest):
+
+**`rwr config` is create-only.** The command's own help admits it: "there is
+no config view or edit mode yet" (`cmd/config.go:16-18`). `--create`/`-c` is
+the single flag (`cmd/config.go:34`); anything else prints help. There is no
+way to see the effective config (which matters — it merges file, env, and
+flags via viper) or to open it in an editor, and the config file can contain
+the GitHub token, so "just cat it" is the wrong answer to teach.
+
+**The shorthand table is sparse and lopsided.** Current shorts on root
+persistent flags (`cmd/root.go:121-186`): `-d` debug (`:125`), `-I`
+interactive (`:131`), `-i` init-file (`:138`), `-p` profile (`:181`). That is
+the complete list. The two flags people type most in day-to-day use have no
+short: `--dry-run` (`:128`, plus its `--no-op` alias `:129`) and `--log-level`
+(`:126`). Meanwhile `-i`/`-I` is a trap: the same letter in two cases means
+two unrelated things ("init file" vs "interactive"), and `-I` is a bool
+defaulting to *true*, so `-I` alone is a no-op and the useful spelling is
+`--interactive=false`.
+
+## What Changes
+
+- **`rwr config` grows subcommands** (bare `rwr config` keeps printing help):
+  - `rwr config view` — the effective merged config, secret values shown as
+    `[redacted]` (reusing `types.RedactedPlaceholder`; `--show-secrets`
+    reveals, matching the existing log convention at `cmd/root.go:178`), each
+    key annotated with its source (default/file/env/flag) where viper can say.
+  - `rwr config edit` — open the config file in `$EDITOR` (fallback
+    `$VISUAL`, then a platform default), creating it via the existing
+    `CreateDefaultConfig` path if absent; re-validate after the editor exits
+    and warn on parse errors rather than leaving them to the next run.
+  - `rwr config create` — subcommand form of today's `--create`. The
+    `--create`/`-c` flag stays as a deprecated alias (cobra
+    `MarkDeprecated`, the `--gh-key` pattern at `cmd/root.go:150-154`).
+- **New shorthands, additive only**:
+  - `-n` for `--dry-run` (the `make -n` convention; `--no-op` alias remains
+    flagged-only)
+  - `-l` for `--log-level`
+- **`-i`/`-I` stays as-is, documented as a decision.** Reassigning either
+  letter breaks existing scripts and muscle memory for marginal gain. Instead:
+  help text for the pair cross-references the other, and `--interactive`
+  gains the explicit guidance that `--interactive=false` is the operative
+  spelling. If a future breaking window opens (e.g. a 2.0), revisit.
+- Verify no collisions: `-n`, `-l`, and `-c` (config-local) are unclaimed
+  today across root and subcommand flag sets.
+
+## Breakage
+
+Nothing breaks. All new shorts are additions on previously short-less flags;
+`rwr config --create` keeps working (deprecated, with a message naming
+`rwr config create`); no existing flag, short, default, or command is removed
+or re-meaninged.
+
+## Impact
+
+- Affected specs: `cli`.
+- Affected code: `cmd/config.go` (subcommands), `cmd/root.go` (two
+  `BoolVarP`/`StringVarP` swaps), docs `commands/config.md` and the flag
+  tables.
+- `config view` must go through the redaction path — it is a new place a
+  secret could leak; the test for that is the load-bearing one.

--- a/openspec/changes/refine-cli-shorthands/specs/cli/spec.md
+++ b/openspec/changes/refine-cli-shorthands/specs/cli/spec.md
@@ -1,0 +1,35 @@
+# CLI — Deltas
+
+## ADDED Requirements
+
+### Requirement: Config is viewable and editable, with secrets redacted
+
+RWR SHALL provide `rwr config view` showing the effective merged
+configuration with credential values redacted unless `--show-secrets` is
+given, `rwr config edit` opening the config file in the operator's editor
+(creating a default config first when none exists, and warning when the
+edited file no longer parses), and `rwr config create` as the subcommand form
+of `--create`, which SHALL remain as a deprecated alias.
+
+#### Scenario: Viewing a config that holds a token
+
+- **WHEN** the config file contains `repository.gh_api_token` and the
+  operator runs `rwr config view`
+- **THEN** the token's value appears as `[redacted]`
+- **AND** appears in clear only with `--show-secrets`
+
+#### Scenario: Editing with no config file
+
+- **WHEN** `rwr config edit` runs and no config file exists
+- **THEN** a default config is created and the editor opens it
+
+### Requirement: Common flags have single-letter shorts
+
+RWR SHALL accept `-n` as the short form of `--dry-run` and `-l` as the short
+form of `--log-level`. Existing shorts (`-d` debug, `-i` init-file, `-I`
+interactive, `-p` profile) SHALL keep their current meanings.
+
+#### Scenario: Short-form dry run
+
+- **WHEN** the operator runs `rwr all -n`
+- **THEN** the run behaves exactly as with `--dry-run`

--- a/openspec/changes/refine-cli-shorthands/tasks.md
+++ b/openspec/changes/refine-cli-shorthands/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+- [ ] 1. `rwr config view`: effective merged config with per-key source
+      annotation; secrets rendered as `[redacted]`, `--show-secrets`
+      reveals. Tests: token set in config → output shows `[redacted]`
+      (fails without redaction wiring); with `--show-secrets` shows value;
+      bare `rwr config` still prints help.
+- [ ] 2. `rwr config edit`: `$EDITOR`/`$VISUAL`/platform fallback; absent
+      file created via `CreateDefaultConfig` first; post-edit re-parse warns
+      on invalid config. Tests: editor invoked with the config path (fake
+      editor script); parse-error warning fires.
+- [ ] 3. `rwr config create` subcommand; `--create`/`-c` marked deprecated
+      pointing at it. Tests: both forms create; deprecated message names the
+      subcommand.
+- [ ] 4. Shorthands: `-n` → `--dry-run`, `-l` → `--log-level`. Tests: `-n`
+      sets dry-run, `-l debug` sets the level; assert no shorthand collision
+      across root + subcommand flag sets (fails if a future flag claims one).
+- [ ] 5. Help-text pass: `-i`/`-I` cross-reference, `--interactive=false`
+      guidance; regenerate/update docs flag tables and `commands/config.md`.


### PR DESCRIPTION
Spec-first proposals for the four Wave-4 features from the review plan. Proposals only — no implementation; each carries a minimal spec delta (the validator requires at least one) capturing the headline requirements. Every "today" claim is verified against the code with file:line citations in the Why sections.

- **add-managed-auth** (+ design): a `credentials:` init section — declared, named credentials sourced env→keyring→prompt, resolved up front, with the full withhold/redact treatment today's two hardcoded keys get; keyring-only persistence (no more plaintext token via `viper.WriteConfig`); the GitHub token becomes the first managed credential.
- **add-uninstall-status** (+ design): an append-only per-run journal, `rwr status` (desired-vs-actual with honest `unknown` for the unqueryable processors), and record-driven `rwr uninstall` in reverse order with hash-guarded file deletes. The non-reversibles (scripts, configuration writes, users/groups, uploaded keys) are enumerated and scoped out rather than hand-waved.
- **add-bootstrap-command**: bootstrap joins the processor table (`rwr run bootstrap` + root shorthand); explicit invocation bypasses the run-once marker — the marker keeps `all` idempotent, it doesn't refuse an explicit request. Deliberately no design doc; it's one table entry plus semantics.
- **refine-cli-shorthands**: `rwr config view` (redaction-gated) / `edit` / `create`, `--create` deprecated via the `--gh-key` pattern; additive `-n`/`-l` shorts; `-i`/`-I` left alone deliberately (reassigning breaks scripts) with the rationale recorded.

All four pass `openspec validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)