### PR TITLE
feat(credentials): managed auth — declared credentials, sourced and redacted

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,7 +79,7 @@ git checkouts, scripts, and desktop configuration.`,
 
 			checkForNewVersion(app)
 
-			return initializeSystemInfo(app)
+			return initializeSystemInfo(app, selectedProcessorsFor(cmd, args)...)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Processor names work straight off the root, task-runner style:
@@ -198,7 +198,7 @@ func registerRootFlags(rootCmd *cobra.Command, app *AppConfig) {
 // It searches for init files in the configured location or current directory,
 // sets up system paths, processes the initialization configuration, retrieves
 // blueprints from Git if configured, and detects the operating system.
-func initializeSystemInfo(app *AppConfig) error {
+func initializeSystemInfo(app *AppConfig, selectedProcessors ...string) error {
 	var err error
 
 	// If no init file is specified via flag, check config
@@ -252,7 +252,7 @@ func initializeSystemInfo(app *AppConfig) error {
 	}
 
 	log.Debugf("Initializing system information with init file: %s", app.InitFilePath)
-	app.InitConfig, err = processors.Initialize(app.InitFilePath, flags)
+	app.InitConfig, err = processors.Initialize(app.InitFilePath, flags, selectedProcessors...)
 	if err != nil {
 		return fmt.Errorf("error initializing system information: %w", err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -93,6 +93,24 @@ func runOneProcessor(app *AppConfig, p runProcessorSpec) error {
 	return processors.All(app.InitConfig, app.OSInfo, []string{p.blueprint})
 }
 
+// selectedProcessorsFor maps the invoked command to the blueprint types this
+// run will execute, so credential resolution can skip credentials scoped to
+// processors that are not running. Nil means all.
+func selectedProcessorsFor(cmd *cobra.Command, args []string) []string {
+	name := cmd.Name()
+	// Root-level shorthand: `rwr packages` resolves at the root with args.
+	if cmd.Parent() == nil && len(args) > 0 {
+		name = args[0]
+	}
+	if p, ok := processorShorthand(name); ok {
+		if p.bootstrap {
+			return []string{"bootstrap"}
+		}
+		return []string{p.blueprint}
+	}
+	return nil
+}
+
 // processorShorthand resolves a root-level argument to a processor, so
 // `rwr packages` works like `rwr run packages` — the processor names are not
 // part of the prime command namespace, exactly like a task runner's tasks.

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,7 +1,8 @@
 # Credentials in blueprints
 
-RWR holds two credentials: your GitHub API token and your SSH private key. By
-default, blueprints cannot read them.
+RWR manages credentials for your blueprints. Two are built in — your GitHub API
+token and your SSH private key — and the init file can declare more. By
+default, blueprints cannot read any of them.
 
 ## Why RWR holds back the credentials
 
@@ -15,6 +16,51 @@ read, the author of that blueprint can read:
 
 This is safe when the blueprint is yours. This is not safe for a blueprint from a
 different author. RWR cannot tell the difference between the two.
+
+## Declare the credentials that a tree needs
+
+A blueprint sometimes needs a secret that is not the GitHub token — a registry
+token, an API key, a license key. Declare it in the init file, and RWR finds
+the value for you:
+
+```yaml
+credentials:
+  - name: cachix_token
+    description: "Cachix auth token for the nix cache"
+    sources: [env:CACHIX_AUTH_TOKEN, keyring, prompt]
+    scope: [scripts]
+```
+
+| Field | Description | Required |
+|---|---|---|
+| `name` | The identity of the credential, everywhere: in `exposeCredentials`, in `{{ .Credentials.<name> }}`, in `RWR_CRED_<NAME>`, and in the keyring. A lowercase identifier. | Yes |
+| `sources` | The ordered places to look: `env:<VAR>`, `keyring`, `prompt`. The first source with a value wins. | No. The default is `[env:RWR_CRED_<NAME>, keyring, prompt]` |
+| `description` | Text that the prompt shows | No |
+| `scope` | Where the credential goes after you expose it: `scripts` (the command environment), `templates` (template rendering), or a processor name (the credential resolves only when that processor runs) | No. The default is everywhere that `exposeCredentials` reaches |
+
+RWR resolves every declared credential at the start of the run, before any
+processor runs. A credential with no value from any source stops the run with
+an error that names the credential and the sources tried. When the run is not
+interactive — no terminal, or `--interactive=false` — RWR skips `prompt` and
+the error says so.
+
+After you answer a prompt, RWR offers to save the value to the OS keyring, so
+the next run does not ask again.
+
+A declared credential gets the same protection as the built-in two: RWR keeps
+it out of template scope and out of the command environment until you name it
+under `exposeCredentials`, and the logs show `[redacted]` instead of the value.
+
+### Where RWR stores a credential
+
+RWR persists a managed credential only in the OS keyring — Secret Service on
+Linux, Keychain on macOS, Credential Manager on Windows — and only when you
+agree. RWR never writes a managed credential to a plaintext file.
+
+One exception is grandfathered: a GitHub token that an earlier RWR saved into
+the config file keeps working. New tokens from `--gh-auth` go to the keyring;
+when no keyring backend is available, RWR falls back to the config file at
+`0600` and warns with the file path.
 
 ## How to permit a credential
 
@@ -48,7 +94,19 @@ always visible.
 
 ## What a permitted credential gives you
 
-In a template:
+A declared credential appears in a template as `{{ .Credentials.<name> }}` and
+in a script as `RWR_CRED_<NAME>`:
+
+```
+cachix authtoken {{ .Credentials.cachix_token }}
+```
+
+```bash
+#!/usr/bin/env bash
+cachix authtoken "$RWR_CRED_CACHIX_TOKEN"
+```
+
+The two built-in credentials keep their original names. In a template:
 
 ```yaml
 templates:

--- a/docs/init-file.md
+++ b/docs/init-file.md
@@ -75,6 +75,24 @@ exposeCredentials:
 
 See [Credentials](credentials.md) for the full description.
 
+### `credentials`
+
+The `credentials` section declares the named credentials that the blueprints in
+this tree need. RWR resolves each one at the start of the run, from the first
+source that has a value.
+
+```yaml
+credentials:
+  - name: cachix_token
+    description: "Cachix auth token for the nix cache"
+    sources: [env:CACHIX_AUTH_TOKEN, keyring, prompt]
+    scope: [scripts]
+```
+
+Declaring a credential does not give it to blueprints — for that, also name it
+under `exposeCredentials`. See [Credentials](credentials.md) for the fields,
+the source order, and where values are stored.
+
 ### `packageManagers`
 
 The `packageManagers` section defines the configuration settings for package managers.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -62,6 +62,10 @@ Credentials (the GitHub token, the SSH private key) are **not** exported unless
 the init file names them under `exposeCredentials`; see
 [credentials](credentials.md).
 
+A credential declared in the init file's `credentials:` section is exported as
+`RWR_CRED_<NAME>` — again only when `exposeCredentials` names it — and appears
+in templates as `{{ .Credentials.<name> }}` under the same opt-in.
+
 ### Built-in Variables
 
 RWR provides a set of built-in variables that can be used in your blueprints. These variables are automatically populated based on the current system and configuration.

--- a/examples/alternative_layouts/flattened/json/init.json
+++ b/examples/alternative_layouts/flattened/json/init.json
@@ -15,5 +15,22 @@
       "project_name": "flattened-setup",
       "repo_url": "https://github.com/user/dotfiles.git"
     }
-  }
+  },
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": [
+        "env:EXAMPLE_API_TOKEN",
+        "keyring",
+        "prompt"
+      ],
+      "scope": [
+        "scripts"
+      ]
+    }
+  ],
+  "exposeCredentials": [
+    "example_api_token"
+  ]
 }

--- a/examples/alternative_layouts/flattened/toml/init.toml
+++ b/examples/alternative_layouts/flattened/toml/init.toml
@@ -1,3 +1,9 @@
+exposeCredentials = ["example_api_token"]
+
+credentials = [
+    { name = "example_api_token", description = "Example API token used by scripts in this tree", sources = ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"], scope = ["scripts"] },
+]
+
 [blueprints]
 format = "toml"
 schema_version = 1

--- a/examples/alternative_layouts/flattened/yaml/init.yaml
+++ b/examples/alternative_layouts/flattened/yaml/init.yaml
@@ -11,3 +11,14 @@ variables:
   userDefined:
     project_name: flattened-setup
     repo_url: https://github.com/user/dotfiles.git
+credentials:
+- name: example_api_token
+  description: Example API token used by scripts in this tree
+  sources:
+  - env:EXAMPLE_API_TOKEN
+  - keyring
+  - prompt
+  scope:
+  - scripts
+exposeCredentials:
+- example_api_token

--- a/examples/alternative_layouts/minimal_files/json/init.json
+++ b/examples/alternative_layouts/minimal_files/json/init.json
@@ -15,5 +15,22 @@
       "project_name": "minimal-setup",
       "repo_url": "https://github.com/user/dotfiles.git"
     }
-  }
+  },
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": [
+        "env:EXAMPLE_API_TOKEN",
+        "keyring",
+        "prompt"
+      ],
+      "scope": [
+        "scripts"
+      ]
+    }
+  ],
+  "exposeCredentials": [
+    "example_api_token"
+  ]
 }

--- a/examples/alternative_layouts/minimal_files/toml/init.toml
+++ b/examples/alternative_layouts/minimal_files/toml/init.toml
@@ -1,3 +1,9 @@
+exposeCredentials = ["example_api_token"]
+
+credentials = [
+    { name = "example_api_token", description = "Example API token used by scripts in this tree", sources = ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"], scope = ["scripts"] },
+]
+
 [blueprints]
 format = "toml"
 schema_version = 1

--- a/examples/alternative_layouts/minimal_files/yaml/init.yaml
+++ b/examples/alternative_layouts/minimal_files/yaml/init.yaml
@@ -11,3 +11,14 @@ variables:
   userDefined:
     project_name: minimal-setup
     repo_url: https://github.com/user/dotfiles.git
+credentials:
+- name: example_api_token
+  description: Example API token used by scripts in this tree
+  sources:
+  - env:EXAMPLE_API_TOKEN
+  - keyring
+  - prompt
+  scope:
+  - scripts
+exposeCredentials:
+- example_api_token

--- a/examples/imports/init.yaml
+++ b/examples/imports/init.yaml
@@ -8,3 +8,14 @@ blueprints:
   location: "."
   order:
     - packages
+credentials:
+- name: example_api_token
+  description: Example API token used by scripts in this tree
+  sources:
+  - env:EXAMPLE_API_TOKEN
+  - keyring
+  - prompt
+  scope:
+  - scripts
+exposeCredentials:
+- example_api_token

--- a/examples/linux/Arch/cue/init.cue
+++ b/examples/linux/Arch/cue/init.cue
@@ -33,5 +33,14 @@
       "editor_theme": "dracula",
       "editor_plugins": "basic"
     }
-  }
+  },
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"],
+      "scope": ["scripts"]
+    }
+  ],
+  "exposeCredentials": ["example_api_token"]
 }

--- a/examples/linux/Arch/json/init.json
+++ b/examples/linux/Arch/json/init.json
@@ -33,5 +33,22 @@
       "editor_theme": "dracula",
       "editor_plugins": "basic"
     }
-  }
+  },
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": [
+        "env:EXAMPLE_API_TOKEN",
+        "keyring",
+        "prompt"
+      ],
+      "scope": [
+        "scripts"
+      ]
+    }
+  ],
+  "exposeCredentials": [
+    "example_api_token"
+  ]
 }

--- a/examples/linux/Arch/toml/init.toml
+++ b/examples/linux/Arch/toml/init.toml
@@ -3,6 +3,12 @@ packageManagers = [
     { name = "brew", action = "install" },
 ]
 
+exposeCredentials = ["example_api_token"]
+
+credentials = [
+    { name = "example_api_token", description = "Example API token used by scripts in this tree", sources = ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"], scope = ["scripts"] },
+]
+
 [blueprints]
 format = "toml"
 schema_version = 1

--- a/examples/linux/Arch/yaml/init.yaml
+++ b/examples/linux/Arch/yaml/init.yaml
@@ -24,3 +24,14 @@ variables:
     department: Engineering
     editor_theme: dracula
     editor_plugins: basic
+credentials:
+- name: example_api_token
+  description: Example API token used by scripts in this tree
+  sources:
+  - env:EXAMPLE_API_TOKEN
+  - keyring
+  - prompt
+  scope:
+  - scripts
+exposeCredentials:
+- example_api_token

--- a/examples/linux/Fedora/cue/init.cue
+++ b/examples/linux/Fedora/cue/init.cue
@@ -25,5 +25,14 @@
       "name": "brew",
       "action": "install"
     }
-  ]
+  ],
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"],
+      "scope": ["scripts"]
+    }
+  ],
+  "exposeCredentials": ["example_api_token"]
 }

--- a/examples/linux/Fedora/json/init.json
+++ b/examples/linux/Fedora/json/init.json
@@ -25,5 +25,22 @@
       "name": "brew",
       "action": "install"
     }
+  ],
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": [
+        "env:EXAMPLE_API_TOKEN",
+        "keyring",
+        "prompt"
+      ],
+      "scope": [
+        "scripts"
+      ]
+    }
+  ],
+  "exposeCredentials": [
+    "example_api_token"
   ]
 }

--- a/examples/linux/Fedora/toml/init.toml
+++ b/examples/linux/Fedora/toml/init.toml
@@ -3,6 +3,12 @@ packageManagers = [
     { name = "brew", action = "install" },
 ]
 
+exposeCredentials = ["example_api_token"]
+
+credentials = [
+    { name = "example_api_token", description = "Example API token used by scripts in this tree", sources = ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"], scope = ["scripts"] },
+]
+
 [blueprints]
 format = "toml"
 schema_version = 1

--- a/examples/linux/Fedora/yaml/init.yaml
+++ b/examples/linux/Fedora/yaml/init.yaml
@@ -18,3 +18,14 @@ packageManagers:
   action: install
 - name: brew
   action: install
+credentials:
+- name: example_api_token
+  description: Example API token used by scripts in this tree
+  sources:
+  - env:EXAMPLE_API_TOKEN
+  - keyring
+  - prompt
+  scope:
+  - scripts
+exposeCredentials:
+- example_api_token

--- a/examples/linux/Ubuntu/cue/init.cue
+++ b/examples/linux/Ubuntu/cue/init.cue
@@ -25,5 +25,14 @@
       "name": "brew",
       "action": "install"
     }
-  ]
+  ],
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"],
+      "scope": ["scripts"]
+    }
+  ],
+  "exposeCredentials": ["example_api_token"]
 }

--- a/examples/linux/Ubuntu/json/init.json
+++ b/examples/linux/Ubuntu/json/init.json
@@ -25,5 +25,22 @@
       "name": "brew",
       "action": "install"
     }
+  ],
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": [
+        "env:EXAMPLE_API_TOKEN",
+        "keyring",
+        "prompt"
+      ],
+      "scope": [
+        "scripts"
+      ]
+    }
+  ],
+  "exposeCredentials": [
+    "example_api_token"
   ]
 }

--- a/examples/linux/Ubuntu/toml/init.toml
+++ b/examples/linux/Ubuntu/toml/init.toml
@@ -3,6 +3,12 @@ packageManagers = [
     { name = "brew", action = "install" },
 ]
 
+exposeCredentials = ["example_api_token"]
+
+credentials = [
+    { name = "example_api_token", description = "Example API token used by scripts in this tree", sources = ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"], scope = ["scripts"] },
+]
+
 [blueprints]
 format = "toml"
 schema_version = 1

--- a/examples/linux/Ubuntu/yaml/init.yaml
+++ b/examples/linux/Ubuntu/yaml/init.yaml
@@ -18,3 +18,14 @@ packageManagers:
   action: install
 - name: brew
   action: install
+credentials:
+- name: example_api_token
+  description: Example API token used by scripts in this tree
+  sources:
+  - env:EXAMPLE_API_TOKEN
+  - keyring
+  - prompt
+  scope:
+  - scripts
+exposeCredentials:
+- example_api_token

--- a/examples/macos/cue/init.cue
+++ b/examples/macos/cue/init.cue
@@ -25,5 +25,14 @@
       "name": "brew",
       "action": "install"
     }
-  ]
+  ],
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"],
+      "scope": ["scripts"]
+    }
+  ],
+  "exposeCredentials": ["example_api_token"]
 }

--- a/examples/macos/json/init.json
+++ b/examples/macos/json/init.json
@@ -25,5 +25,14 @@
       "name": "brew",
       "action": "install"
     }
-  ]
+  ],
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"],
+      "scope": ["scripts"]
+    }
+  ],
+  "exposeCredentials": ["example_api_token"]
 }

--- a/examples/macos/toml/init.toml
+++ b/examples/macos/toml/init.toml
@@ -3,6 +3,12 @@ packageManagers = [
     { name = "brew", action = "install" },
 ]
 
+exposeCredentials = ["example_api_token"]
+
+credentials = [
+    { name = "example_api_token", description = "Example API token used by scripts in this tree", sources = ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"], scope = ["scripts"] },
+]
+
 [blueprints]
 format = "toml"
 schema_version = 1

--- a/examples/macos/yaml/init.yaml
+++ b/examples/macos/yaml/init.yaml
@@ -18,3 +18,14 @@ packageManagers:
   action: install
 - name: brew
   action: install
+credentials:
+- name: example_api_token
+  description: Example API token used by scripts in this tree
+  sources:
+  - env:EXAMPLE_API_TOKEN
+  - keyring
+  - prompt
+  scope:
+  - scripts
+exposeCredentials:
+- example_api_token

--- a/examples/multi-machine/Arch/init.yaml
+++ b/examples/multi-machine/Arch/init.yaml
@@ -2,3 +2,14 @@ blueprints:
   format: yaml
   location: .
 packageManagers: []
+credentials:
+- name: example_api_token
+  description: Example API token used by scripts in this tree
+  sources:
+  - env:EXAMPLE_API_TOKEN
+  - keyring
+  - prompt
+  scope:
+  - scripts
+exposeCredentials:
+- example_api_token

--- a/examples/multi-machine/macOS/init.yaml
+++ b/examples/multi-machine/macOS/init.yaml
@@ -2,3 +2,14 @@ blueprints:
   format: yaml
   location: .
 packageManagers: []
+credentials:
+- name: example_api_token
+  description: Example API token used by scripts in this tree
+  sources:
+  - env:EXAMPLE_API_TOKEN
+  - keyring
+  - prompt
+  scope:
+  - scripts
+exposeCredentials:
+- example_api_token

--- a/examples/windows/cue/init.cue
+++ b/examples/windows/cue/init.cue
@@ -25,5 +25,14 @@
       "name": "chocolatey",
       "action": "install"
     }
-  ]
+  ],
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"],
+      "scope": ["scripts"]
+    }
+  ],
+  "exposeCredentials": ["example_api_token"]
 }

--- a/examples/windows/json/init.json
+++ b/examples/windows/json/init.json
@@ -25,5 +25,22 @@
       "name": "chocolatey",
       "action": "install"
     }
+  ],
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": [
+        "env:EXAMPLE_API_TOKEN",
+        "keyring",
+        "prompt"
+      ],
+      "scope": [
+        "scripts"
+      ]
+    }
+  ],
+  "exposeCredentials": [
+    "example_api_token"
   ]
 }

--- a/examples/windows/toml/init.toml
+++ b/examples/windows/toml/init.toml
@@ -3,6 +3,12 @@ packageManagers = [
     { name = "chocolatey", action = "install" },
 ]
 
+exposeCredentials = ["example_api_token"]
+
+credentials = [
+    { name = "example_api_token", description = "Example API token used by scripts in this tree", sources = ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"], scope = ["scripts"] },
+]
+
 [blueprints]
 format = "toml"
 schema_version = 1

--- a/examples/windows/yaml/init.yaml
+++ b/examples/windows/yaml/init.yaml
@@ -18,3 +18,14 @@ packageManagers:
   action: install
 - name: chocolatey
   action: install
+credentials:
+- name: example_api_token
+  description: Example API token used by scripts in this tree
+  sources:
+  - env:EXAMPLE_API_TOKEN
+  - keyring
+  - prompt
+  scope:
+  - scripts
+exposeCredentials:
+- example_api_token

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/cloudflare/circl v1.6.4 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emicklei/proto v1.14.3 // indirect
@@ -49,6 +50,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.9.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -74,6 +76,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/zalando/go-keyring v0.2.8 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260727155853-b88d891fe743 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/cyphar/filepath-securejoin v0.7.0 h1:s0Y3ITPy6sQn5xt54DuYvTF8hu134ooYLUb58DX/HjE=
 github.com/cyphar/filepath-securejoin v0.7.0/go.mod h1:ymLGms/u3BYaviIiuKFnUx8EkQEZeK6cInNoAPJA3o4=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -103,6 +105,8 @@ github.com/go-quicktest/qt v1.102.0 h1:HSQxCeh5YZH3EL3W39ixjtyaEhcWSXQHtHnMBzSs4
 github.com/go-quicktest/qt v1.102.0/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -193,6 +197,8 @@ github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=

--- a/internal/credentials/keyring.go
+++ b/internal/credentials/keyring.go
@@ -1,0 +1,70 @@
+// Package credentials resolves the credentials an init file declares: each one
+// is looked up through its ordered sources (env:<VAR>, keyring, prompt) before
+// any processor runs, and the resolved values are handed to the types registry,
+// which gates every path out to a blueprint.
+package credentials
+
+import (
+	"errors"
+	"fmt"
+
+	zkeyring "github.com/zalando/go-keyring"
+)
+
+// keyringService namespaces rwr's entries in the OS keyring; the account within
+// the service is the credential name.
+const keyringService = "rwr"
+
+// Keyring is the slice of the OS keyring rwr uses. It is an interface so tests
+// run keyring-less with a fake — CI has no Secret Service, and desktop keyring
+// behavior varies too much to assert against.
+type Keyring interface {
+	// Get returns the stored value, or ErrKeyringNotFound when the entry does
+	// not exist, or another error when the backend is unavailable.
+	Get(name string) (string, error)
+	Set(name, value string) error
+}
+
+// ErrKeyringNotFound reports an entry that does not exist, as distinct from a
+// backend that cannot be reached at all.
+var ErrKeyringNotFound = errors.New("keyring entry not found")
+
+// Ring is the keyring in use. Tests swap in a fake; production keeps the OS
+// keyring (Secret Service / macOS Keychain / Windows Credential Manager).
+var Ring Keyring = osKeyring{}
+
+type osKeyring struct{}
+
+func (osKeyring) Get(name string) (string, error) {
+	value, err := zkeyring.Get(keyringService, name)
+	if errors.Is(err, zkeyring.ErrNotFound) {
+		return "", ErrKeyringNotFound
+	}
+	return value, err
+}
+
+func (osKeyring) Set(name, value string) error {
+	return zkeyring.Set(keyringService, name, value)
+}
+
+// FromKeyring reads a credential from the keyring. A missing entry or an
+// unavailable backend both yield "not found": the keyring is never
+// load-bearing on read — precedence just moves to the next source.
+func FromKeyring(name string) (string, bool) {
+	value, err := Ring.Get(name)
+	if err != nil || value == "" {
+		return "", false
+	}
+	return value, true
+}
+
+// SaveToKeyring persists a credential value. Unlike reads, an explicit save
+// against an unavailable backend fails loudly: silently not persisting is how
+// an operator ends up re-prompted forever, or worse, reaching for a plaintext
+// file.
+func SaveToKeyring(name, value string) error {
+	if err := Ring.Set(name, value); err != nil {
+		return fmt.Errorf("saving %s to the OS keyring: %w", name, err)
+	}
+	return nil
+}

--- a/internal/credentials/prompt.go
+++ b/internal/credentials/prompt.go
@@ -1,0 +1,66 @@
+package credentials
+
+import (
+	"fmt"
+	"os"
+
+	"charm.land/huh/v2"
+	"charm.land/log/v2"
+	"golang.org/x/term"
+)
+
+// stdinIsTerminal is a var so resolution tests can force the non-TTY path
+// without detaching their own stdin.
+var stdinIsTerminal = func() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// promptForCredential asks the operator for a credential value with masked
+// input. The value never echoes; the description says what is being asked for
+// and why.
+var promptForCredential = func(name, description string) (string, error) {
+	var value string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title(fmt.Sprintf("Enter credential %q", name)).
+				Description(description).
+				EchoMode(huh.EchoModePassword).
+				Value(&value).
+				Validate(func(s string) error {
+					if s == "" {
+						return fmt.Errorf("value cannot be empty")
+					}
+					return nil
+				}),
+		),
+	)
+	if err := form.Run(); err != nil {
+		return "", fmt.Errorf("prompt for credential %q failed: %w", name, err)
+	}
+	return value, nil
+}
+
+// offerKeyringSave asks (default yes) whether to keep a just-prompted value in
+// the OS keyring so the next run does not ask again. Declining is fine; a
+// failed save is reported but does not fail the run — the value is already in
+// hand.
+var offerKeyringSave = func(name, value string) {
+	confirm := true
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(fmt.Sprintf("Save %q to the OS keyring?", name)).
+				Description("Next run will read it from the keyring instead of asking.").
+				Affirmative("Yes, save it").
+				Negative("No, ask again next time").
+				Value(&confirm),
+		),
+	)
+	if err := form.Run(); err != nil || !confirm {
+		return
+	}
+	if err := SaveToKeyring(name, value); err != nil {
+		log.Warnf("Could not save %q to the keyring: %v", name, err)
+	}
+}

--- a/internal/credentials/resolve.go
+++ b/internal/credentials/resolve.go
@@ -1,0 +1,148 @@
+package credentials
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// Options carries the run context resolution needs.
+type Options struct {
+	// Interactive mirrors --interactive; prompting also requires a real TTY.
+	Interactive bool
+	// Selected names the blueprint types this run executes; empty means all. A
+	// credential scoped to processors none of which are selected is not
+	// resolved — no point prompting for a value nothing will read.
+	Selected []string
+}
+
+// Resolve resolves every declared credential up front, first source wins, and
+// records the values in the types registry. All of them resolve before any
+// processor runs: failing at minute 20 inside a script is worse than failing
+// at second 1. A credential that resolves from no source fails the run with an
+// error naming it and the sources tried.
+func Resolve(specs []types.CredentialSpec, opts Options) error {
+	for _, spec := range specs {
+		if !scopeSelected(spec.Scope, opts.Selected) {
+			log.Debugf("Not resolving credential %q: its scope %v matches no selected processor", spec.Name, spec.Scope)
+			continue
+		}
+		value, err := resolveOne(spec, opts)
+		if err != nil {
+			return err
+		}
+		types.SetCredentialValue(spec.Name, value)
+	}
+	return nil
+}
+
+// defaultSources is the order used when a declaration omits `sources`: env
+// first so CI can inject without prompting, keyring before prompt so an
+// interactive answer given once (and saved) is not re-asked.
+func defaultSources(name string) []string {
+	return []string{"env:RWR_CRED_" + strings.ToUpper(name), "keyring", "prompt"}
+}
+
+func resolveOne(spec types.CredentialSpec, opts Options) (string, error) {
+	sources := spec.Sources
+	if len(sources) == 0 {
+		sources = defaultSources(spec.Name)
+	}
+
+	var tried, skipped []string
+	for _, source := range sources {
+		switch {
+		case strings.HasPrefix(source, "env:"):
+			envVar := strings.TrimPrefix(source, "env:")
+			if value := os.Getenv(envVar); value != "" {
+				log.Debugf("Credential %q resolved from %s: %s", spec.Name, source, types.Redact(value))
+				return value, nil
+			}
+			tried = append(tried, source)
+
+		case source == "keyring":
+			if value, ok := FromKeyring(spec.Name); ok {
+				log.Debugf("Credential %q resolved from the keyring: %s", spec.Name, types.Redact(value))
+				return value, nil
+			}
+			tried = append(tried, source)
+
+		case source == "prompt":
+			if !opts.Interactive || !stdinIsTerminal() {
+				skipped = append(skipped, "prompt")
+				continue
+			}
+			value, err := promptForCredential(spec.Name, spec.Description)
+			if err != nil {
+				return "", err
+			}
+			offerKeyringSave(spec.Name, value)
+			return value, nil
+
+		default:
+			// Validation rejected unknown sources at decode time; reaching here
+			// means a caller bypassed it.
+			return "", fmt.Errorf("credential %q: unknown source %q", spec.Name, source)
+		}
+	}
+
+	var parts []string
+	if len(tried) > 0 {
+		parts = append(parts, "tried: "+strings.Join(tried, ", "))
+	}
+	if len(skipped) > 0 {
+		parts = append(parts, "prompt skipped: non-interactive run")
+	}
+	return "", fmt.Errorf("credential %q resolved from no source (%s)", spec.Name, strings.Join(parts, "; "))
+}
+
+// scopeSelected reports whether a credential's scope intersects the selected
+// processors. Surface entries (scripts, templates) map to the processors that
+// realize them; an empty scope or an empty selection always matches.
+func scopeSelected(scope, selected []string) bool {
+	if len(scope) == 0 || len(selected) == 0 {
+		return true
+	}
+	for _, entry := range scope {
+		processor := entry
+		// Template rendering is realized by the files processor.
+		if entry == types.CredentialSurfaceTemplates {
+			processor = types.BlueprintTypeFiles
+		}
+		for _, name := range selected {
+			if name == processor {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ResolveBuiltins records the two built-in credentials with the registry so
+// they get the same managed treatment as declared ones. Their sources are the
+// pre-existing ones — flag/config (already merged into Flags by cobra/viper
+// binding), GITHUB_TOKEN, and now the keyring — and unlike declared
+// credentials they are optional: a run that never needs a GitHub token must
+// not fail, or prompt, because none is configured.
+func ResolveBuiltins(flags *types.Flags) {
+	switch {
+	case flags.GHAPIToken != "":
+		types.SetCredentialValue("gh_api_token", flags.GHAPIToken)
+	case os.Getenv("GITHUB_TOKEN") != "":
+		types.SetCredentialValue("gh_api_token", os.Getenv("GITHUB_TOKEN"))
+	default:
+		if value, ok := FromKeyring("gh_api_token"); ok {
+			log.Debugf("GitHub token resolved from the OS keyring")
+			types.SetCredentialValue("gh_api_token", value)
+			// Downstream consumers (git auth, ssh-key upload) read the flag
+			// field, so a keyring token flows through the same path.
+			flags.GHAPIToken = value
+		}
+	}
+	if flags.SSHKey != "" {
+		types.SetCredentialValue("ssh_private_key", flags.SSHKey)
+	}
+}

--- a/internal/credentials/resolve_test.go
+++ b/internal/credentials/resolve_test.go
@@ -1,0 +1,305 @@
+package credentials
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// fakeKeyring stands in for the OS keyring: CI has no Secret Service and
+// desktop keyring behavior is not something to assert against.
+type fakeKeyring struct {
+	entries map[string]string
+	// unavailable simulates a headless machine with no keyring backend.
+	unavailable bool
+}
+
+func (f *fakeKeyring) Get(name string) (string, error) {
+	if f.unavailable {
+		return "", errors.New("no keyring backend")
+	}
+	value, ok := f.entries[name]
+	if !ok {
+		return "", ErrKeyringNotFound
+	}
+	return value, nil
+}
+
+func (f *fakeKeyring) Set(name, value string) error {
+	if f.unavailable {
+		return errors.New("no keyring backend")
+	}
+	if f.entries == nil {
+		f.entries = map[string]string{}
+	}
+	f.entries[name] = value
+	return nil
+}
+
+// withFakes swaps the keyring and prompt seams for a test and restores them.
+func withFakes(t *testing.T, ring Keyring, tty bool, prompt func(name, description string) (string, error)) {
+	t.Helper()
+	origRing, origTTY, origPrompt, origOffer := Ring, stdinIsTerminal, promptForCredential, offerKeyringSave
+	Ring = ring
+	stdinIsTerminal = func() bool { return tty }
+	if prompt != nil {
+		promptForCredential = prompt
+	}
+	offerKeyringSave = func(name, value string) {}
+	t.Cleanup(func() {
+		Ring, stdinIsTerminal, promptForCredential, offerKeyringSave = origRing, origTTY, origPrompt, origOffer
+		types.RegisterCredentials(nil)
+	})
+}
+
+func TestResolveSourcePrecedence(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []string
+		env     map[string]string
+		keyring map[string]string
+		want    string
+	}{
+		{
+			name:    "env wins over keyring",
+			sources: []string{"env:CACHIX_AUTH_TOKEN", "keyring"},
+			env:     map[string]string{"CACHIX_AUTH_TOKEN": "from-env"},
+			keyring: map[string]string{"cachix_token": "from-keyring"},
+			want:    "from-env",
+		},
+		{
+			name:    "keyring when env is empty",
+			sources: []string{"env:CACHIX_AUTH_TOKEN", "keyring"},
+			keyring: map[string]string{"cachix_token": "from-keyring"},
+			want:    "from-keyring",
+		},
+		{
+			name:    "declaration order is the precedence",
+			sources: []string{"keyring", "env:CACHIX_AUTH_TOKEN"},
+			env:     map[string]string{"CACHIX_AUTH_TOKEN": "from-env"},
+			keyring: map[string]string{"cachix_token": "from-keyring"},
+			want:    "from-keyring",
+		},
+		{
+			name:    "default order reads env:RWR_CRED_<NAME> first",
+			sources: nil,
+			env:     map[string]string{"RWR_CRED_CACHIX_TOKEN": "from-default-env"},
+			keyring: map[string]string{"cachix_token": "from-keyring"},
+			want:    "from-default-env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withFakes(t, &fakeKeyring{entries: tt.keyring}, false, nil)
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+
+			spec := types.CredentialSpec{Name: "cachix_token", Sources: tt.sources}
+			if err := Resolve([]types.CredentialSpec{spec}, Options{}); err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if got, _ := types.CredentialValue("cachix_token"); got != tt.want {
+				t.Errorf("resolved %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A declared credential that resolves nowhere fails the run up front, naming
+// the credential and the sources tried — and in a non-TTY run the error says
+// prompt was skipped rather than silently hanging on an invisible form.
+func TestResolveUnresolvableNamesSourcesTried(t *testing.T) {
+	withFakes(t, &fakeKeyring{}, false, nil)
+
+	spec := types.CredentialSpec{
+		Name:    "cachix_token",
+		Sources: []string{"env:CACHIX_AUTH_TOKEN", "keyring", "prompt"},
+	}
+	err := Resolve([]types.CredentialSpec{spec}, Options{Interactive: true})
+	if err == nil {
+		t.Fatal("Resolve = nil, want an up-front error")
+	}
+	for _, want := range []string{`"cachix_token"`, "env:CACHIX_AUTH_TOKEN", "keyring", "prompt skipped: non-interactive run"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+}
+
+// --interactive=false skips prompt even on a TTY.
+func TestResolveInteractiveFalseSkipsPrompt(t *testing.T) {
+	prompted := false
+	withFakes(t, &fakeKeyring{}, true, func(name, description string) (string, error) {
+		prompted = true
+		return "never", nil
+	})
+
+	spec := types.CredentialSpec{Name: "cachix_token", Sources: []string{"prompt"}}
+	err := Resolve([]types.CredentialSpec{spec}, Options{Interactive: false})
+	if prompted {
+		t.Error("prompt ran despite --interactive=false")
+	}
+	if err == nil || !strings.Contains(err.Error(), "prompt skipped") {
+		t.Errorf("error = %v, want it to say prompt was skipped", err)
+	}
+}
+
+// On a TTY the prompt is the last resort, and its answer resolves the credential.
+func TestResolvePromptsOnTTY(t *testing.T) {
+	withFakes(t, &fakeKeyring{}, true, func(name, description string) (string, error) {
+		if name != "cachix_token" || description != "Cachix auth token" {
+			t.Errorf("prompt got (%q, %q)", name, description)
+		}
+		return "typed-in", nil
+	})
+
+	spec := types.CredentialSpec{Name: "cachix_token", Description: "Cachix auth token", Sources: []string{"keyring", "prompt"}}
+	if err := Resolve([]types.CredentialSpec{spec}, Options{Interactive: true}); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got, _ := types.CredentialValue("cachix_token"); got != "typed-in" {
+		t.Errorf("resolved %q, want the prompted value", got)
+	}
+}
+
+// The keyring is never load-bearing on read: an unavailable backend moves
+// precedence along instead of erroring. An explicit save is the opposite.
+func TestKeyringUnavailable(t *testing.T) {
+	withFakes(t, &fakeKeyring{unavailable: true}, false, nil)
+	t.Setenv("CACHIX_AUTH_TOKEN", "from-env")
+
+	spec := types.CredentialSpec{Name: "cachix_token", Sources: []string{"keyring", "env:CACHIX_AUTH_TOKEN"}}
+	if err := Resolve([]types.CredentialSpec{spec}, Options{}); err != nil {
+		t.Fatalf("Resolve with an unavailable keyring: %v", err)
+	}
+	if got, _ := types.CredentialValue("cachix_token"); got != "from-env" {
+		t.Errorf("resolved %q, want the env value", got)
+	}
+
+	if err := SaveToKeyring("cachix_token", "value"); err == nil {
+		t.Error("SaveToKeyring with no backend = nil, want a loud error")
+	}
+}
+
+// A value saved to the keyring is what the next resolution reads back.
+func TestKeyringRoundtrip(t *testing.T) {
+	withFakes(t, &fakeKeyring{}, false, nil)
+
+	if err := SaveToKeyring("cachix_token", "stored-once"); err != nil {
+		t.Fatalf("SaveToKeyring: %v", err)
+	}
+	spec := types.CredentialSpec{Name: "cachix_token", Sources: []string{"keyring"}}
+	if err := Resolve([]types.CredentialSpec{spec}, Options{}); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got, _ := types.CredentialValue("cachix_token"); got != "stored-once" {
+		t.Errorf("resolved %q, want the saved value", got)
+	}
+}
+
+// A credential scoped to processors outside the run is not resolved — no point
+// failing (or prompting) for a value nothing will read.
+func TestResolveSkipsOutOfScopeCredentials(t *testing.T) {
+	withFakes(t, &fakeKeyring{}, false, nil)
+
+	specs := []types.CredentialSpec{
+		{Name: "ssh_token", Sources: []string{"env:NOWHERE"}, Scope: []string{types.BlueprintTypeSSHKeys}},
+	}
+	if err := Resolve(specs, Options{Selected: []string{types.BlueprintTypePackages}}); err != nil {
+		t.Fatalf("out-of-scope credential was resolved (and failed): %v", err)
+	}
+	if _, ok := types.CredentialValue("ssh_token"); ok {
+		t.Error("out-of-scope credential has a value")
+	}
+
+	// The same credential resolves (here: fails loudly) once its processor is in
+	// the run, and the templates surface maps to the files processor.
+	if err := Resolve(specs, Options{Selected: []string{types.BlueprintTypeSSHKeys}}); err == nil {
+		t.Error("in-scope credential was skipped")
+	}
+	templScoped := []types.CredentialSpec{
+		{Name: "tmpl_token", Sources: []string{"env:NOWHERE"}, Scope: []string{types.CredentialSurfaceTemplates}},
+	}
+	if err := Resolve(templScoped, Options{Selected: []string{types.BlueprintTypeFiles}}); err == nil {
+		t.Error("templates-scoped credential was skipped in a files run")
+	}
+}
+
+// Resolution logs values behind the redaction placeholder; the value itself
+// must never reach the log.
+func TestResolveRedactsInDebugLogs(t *testing.T) {
+	withFakes(t, &fakeKeyring{}, false, nil)
+	t.Setenv("CACHIX_AUTH_TOKEN", "cachix-super-secret")
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	origLevel := log.GetLevel()
+	log.SetLevel(log.DebugLevel)
+	t.Cleanup(func() {
+		log.SetOutput(nil)
+		log.SetLevel(origLevel)
+	})
+
+	spec := types.CredentialSpec{Name: "cachix_token", Sources: []string{"env:CACHIX_AUTH_TOKEN"}}
+	if err := Resolve([]types.CredentialSpec{spec}, Options{}); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "cachix-super-secret") {
+		t.Errorf("debug log leaked the credential value: %s", out)
+	}
+	if !strings.Contains(out, types.RedactedPlaceholder) {
+		t.Errorf("debug log shows no redaction placeholder: %s", out)
+	}
+}
+
+// The built-ins resolve through their pre-existing sources, keyring last, and a
+// keyring token flows into the flag field existing consumers read. They are
+// optional: nothing configured is not an error.
+func TestResolveBuiltins(t *testing.T) {
+	t.Run("flag wins", func(t *testing.T) {
+		withFakes(t, &fakeKeyring{entries: map[string]string{"gh_api_token": "from-keyring"}}, false, nil)
+		flags := types.Flags{GHAPIToken: "from-flag"}
+		ResolveBuiltins(&flags)
+		if got, _ := types.CredentialValue("gh_api_token"); got != "from-flag" {
+			t.Errorf("resolved %q, want the flag/config value", got)
+		}
+	})
+
+	t.Run("GITHUB_TOKEN beats keyring", func(t *testing.T) {
+		withFakes(t, &fakeKeyring{entries: map[string]string{"gh_api_token": "from-keyring"}}, false, nil)
+		t.Setenv("GITHUB_TOKEN", "from-env")
+		flags := types.Flags{}
+		ResolveBuiltins(&flags)
+		if got, _ := types.CredentialValue("gh_api_token"); got != "from-env" {
+			t.Errorf("resolved %q, want the env value", got)
+		}
+	})
+
+	t.Run("keyring fills the flag field", func(t *testing.T) {
+		withFakes(t, &fakeKeyring{entries: map[string]string{"gh_api_token": "from-keyring"}}, false, nil)
+		t.Setenv("GITHUB_TOKEN", "")
+		flags := types.Flags{}
+		ResolveBuiltins(&flags)
+		if flags.GHAPIToken != "from-keyring" {
+			t.Errorf("flags.GHAPIToken = %q, want the keyring token", flags.GHAPIToken)
+		}
+	})
+
+	t.Run("nothing configured is not an error", func(t *testing.T) {
+		withFakes(t, &fakeKeyring{}, false, nil)
+		t.Setenv("GITHUB_TOKEN", "")
+		flags := types.Flags{}
+		ResolveBuiltins(&flags)
+		if _, ok := types.CredentialValue("gh_api_token"); ok {
+			t.Error("gh_api_token has a value from nowhere")
+		}
+	})
+}

--- a/internal/helpers/template.go
+++ b/internal/helpers/template.go
@@ -51,8 +51,11 @@ func resolveTemplate(templateData []byte, variables types.Variables, missingKey 
 	data["UserDefined"] = variables.UserDefined
 
 	// data["Flags"] no longer carries credentials (see types.Flags.ToMap), so this
-	// dump is safe; it is the reason they must stay out of that map.
-	log.Debugf("Template variables: %+v", data)
+	// dump is safe; it is the reason they must stay out of that map. Credentials
+	// is added after the dump: it holds the exposeCredentials-gated values, so
+	// only the names may reach the log.
+	log.Debugf("Template variables: %+v (credentials in scope: %v)", data, types.TemplateCredentialNames())
+	data["Credentials"] = types.TemplateCredentials()
 
 	// Execute with the same option the template was parsed with.
 	//

--- a/internal/processors/initialize.go
+++ b/internal/processors/initialize.go
@@ -8,6 +8,7 @@ import (
 
 	"charm.land/log/v2"
 	"github.com/BurntSushi/toml"
+	"github.com/fynxlabs/rwr/internal/credentials"
 	"github.com/fynxlabs/rwr/internal/helpers"
 	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/types"
@@ -18,7 +19,9 @@ import (
 // Initialize loads and parses the init configuration file from a local path or URL.
 // It resolves template variables, sets up system paths, and returns the fully
 // populated InitConfig used to drive all subsequent blueprint processing.
-func Initialize(initFilePath string, flags types.Flags) (*types.InitConfig, error) {
+// selectedProcessors names the blueprint types this run will execute (empty means
+// all); a declared credential scoped to none of them is not resolved.
+func Initialize(initFilePath string, flags types.Flags, selectedProcessors ...string) (*types.InitConfig, error) {
 	var initConfig types.InitConfig
 	var err error
 	var fileExt string
@@ -160,6 +163,26 @@ func Initialize(initFilePath string, flags types.Flags) (*types.InitConfig, erro
 			types.ExposedCredentials())
 	}
 
+	// Resolve the declared credentials before anything renders a template or
+	// spawns a command, so the export gate below sees the full credential set
+	// and a credential that resolves nowhere fails the run up front. Viper's
+	// Unmarshal ignores unknown keys, so the section is re-decoded strictly: a
+	// typo inside a credential declaration must be an error, not a silently
+	// different source order.
+	specs, err := types.DecodeCredentialSpecs(viper.Get("credentials"))
+	if err != nil {
+		return nil, fmt.Errorf("error in %s: %w", initFilePath, err)
+	}
+	initConfig.Credentials = specs
+	types.RegisterCredentials(specs)
+	credentials.ResolveBuiltins(&initConfig.Variables.Flags)
+	if err := credentials.Resolve(specs, credentials.Options{
+		Interactive: initConfig.Variables.Flags.Interactive,
+		Selected:    selectedProcessors,
+	}); err != nil {
+		return nil, err
+	}
+
 	// Set user-defined variables and environment variables
 	if err := setUserDefinedAndEnvVariables(&initConfig); err != nil {
 		return nil, fmt.Errorf("error setting variables: %w", err)
@@ -246,6 +269,15 @@ func setUserDefinedAndEnvVariables(initConfig *types.InitConfig) error {
 
 		value := viper.GetString(key)
 		envKey := fmt.Sprintf("RWR_VAR_%s", strings.ToUpper(strings.ReplaceAll(key, ".", "_")))
+		if err := os.Setenv(envKey, value); err != nil {
+			return fmt.Errorf("error setting environment variable %s: %w", envKey, err)
+		}
+	}
+
+	// Managed credentials export as RWR_CRED_<NAME>, and only the ones the
+	// operator opted into with exposeCredentials whose scope admits scripts —
+	// the same gate that keeps the two built-ins out of RWR_VAR_*.
+	for envKey, value := range types.ExportedCredentialEnv() {
 		if err := os.Setenv(envKey, value); err != nil {
 			return fmt.Errorf("error setting environment variable %s: %w", envKey, err)
 		}

--- a/internal/processors/managed_auth_test.go
+++ b/internal/processors/managed_auth_test.go
@@ -1,0 +1,178 @@
+package processors
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/types"
+	"github.com/spf13/viper"
+)
+
+// writeInitFile writes an init file for Initialize to load.
+func writeInitFile(t *testing.T, content string) string {
+	t.Helper()
+	initFile := filepath.Join(t.TempDir(), "init.yaml")
+	if err := os.WriteFile(initFile, []byte(content), 0644); err != nil {
+		t.Fatalf("writing init file: %v", err)
+	}
+	return initFile
+}
+
+// resetManagedAuthState isolates the global registries Initialize mutates.
+func resetManagedAuthState(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(func() {
+		viper.Reset()
+		types.RegisterCredentials(nil)
+		types.SetExposedCredentials(nil)
+		_ = os.Unsetenv("RWR_CRED_CACHIX_TOKEN")
+	})
+}
+
+const declaredCredentialInit = `
+blueprints:
+  format: yaml
+  location: "."
+
+credentials:
+  - name: cachix_token
+    description: "Cachix auth token"
+    sources: [env:CACHIX_AUTH_TOKEN]
+`
+
+// A declared credential resolves at init time and stays withheld: absent from
+// template scope and the RWR_CRED_* export until exposeCredentials names it —
+// the same treatment the two built-ins get.
+func TestInitializeResolvesAndWithholdsDeclaredCredential(t *testing.T) {
+	resetManagedAuthState(t)
+	t.Setenv("CACHIX_AUTH_TOKEN", "cachix-secret-value")
+
+	initFile := writeInitFile(t, declaredCredentialInit)
+	config, err := Initialize(initFile, types.Flags{})
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if len(config.Credentials) != 1 || config.Credentials[0].Name != "cachix_token" {
+		t.Fatalf("credentials section decoded as %+v", config.Credentials)
+	}
+	if value, _ := types.CredentialValue("cachix_token"); value != "cachix-secret-value" {
+		t.Errorf("cachix_token resolved as %q, want the env value", value)
+	}
+
+	// Withheld from the spawned-command env: no opt-in, no export.
+	if os.Getenv("RWR_CRED_CACHIX_TOKEN") != "" {
+		t.Error("RWR_CRED_CACHIX_TOKEN was exported without exposeCredentials")
+	}
+
+	// Withheld from template scope: rendering may error (missing key) but must
+	// never produce the value.
+	rendered, err := helpers.ResolveTemplate([]byte("v={{ .Credentials.cachix_token }}"), config.Variables)
+	if err == nil && strings.Contains(string(rendered), "cachix-secret-value") {
+		t.Errorf("template rendered an unexposed credential: %s", rendered)
+	}
+	if err != nil && strings.Contains(err.Error(), "cachix-secret-value") {
+		t.Errorf("template error leaked the credential: %v", err)
+	}
+}
+
+// With the exposeCredentials opt-in, the same credential reaches both surfaces.
+func TestInitializeExposedDeclaredCredential(t *testing.T) {
+	resetManagedAuthState(t)
+	t.Setenv("CACHIX_AUTH_TOKEN", "cachix-secret-value")
+
+	initFile := writeInitFile(t, declaredCredentialInit+`
+exposeCredentials:
+  - cachix_token
+`)
+	config, err := Initialize(initFile, types.Flags{})
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	if got := os.Getenv("RWR_CRED_CACHIX_TOKEN"); got != "cachix-secret-value" {
+		t.Errorf("RWR_CRED_CACHIX_TOKEN = %q, want the resolved value", got)
+	}
+	rendered, err := helpers.ResolveTemplate([]byte("v={{ .Credentials.cachix_token }}"), config.Variables)
+	if err != nil {
+		t.Fatalf("ResolveTemplate: %v", err)
+	}
+	if string(rendered) != "v=cachix-secret-value" {
+		t.Errorf("template rendered %q, want the exposed value", rendered)
+	}
+}
+
+// A typo inside a credential declaration is an error naming the key, not a
+// silently different source order: viper ignores unknown keys, so the strict
+// re-decode is the only thing standing between the two.
+func TestInitializeStrictDecodesCredentials(t *testing.T) {
+	resetManagedAuthState(t)
+
+	initFile := writeInitFile(t, `
+blueprints:
+  format: yaml
+  location: "."
+
+credentials:
+  - name: cachix_token
+    soruces: [keyring]
+`)
+	_, err := Initialize(initFile, types.Flags{})
+	if err == nil || !strings.Contains(err.Error(), "soruces") {
+		t.Fatalf("Initialize = %v, want a strict-decode error naming the unknown key", err)
+	}
+}
+
+// A declared credential that resolves nowhere fails before any processor runs,
+// naming the credential and the sources tried; in a non-interactive run the
+// error says prompt was skipped.
+func TestInitializeUnresolvableCredentialFailsUpFront(t *testing.T) {
+	resetManagedAuthState(t)
+	t.Setenv("CACHIX_AUTH_TOKEN", "")
+
+	initFile := writeInitFile(t, `
+blueprints:
+  format: yaml
+  location: "."
+
+credentials:
+  - name: cachix_token
+    sources: [env:CACHIX_AUTH_TOKEN, prompt]
+`)
+	_, err := Initialize(initFile, types.Flags{Interactive: false})
+	if err == nil {
+		t.Fatal("Initialize = nil, want an up-front resolution error")
+	}
+	for _, want := range []string{`"cachix_token"`, "env:CACHIX_AUTH_TOKEN", "prompt skipped"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+}
+
+// A credential scoped to a processor outside the run is not resolved, so its
+// missing sources do not fail an unrelated run.
+func TestInitializeSkipsOutOfScopeCredential(t *testing.T) {
+	resetManagedAuthState(t)
+	t.Setenv("CACHIX_AUTH_TOKEN", "")
+
+	initFile := writeInitFile(t, `
+blueprints:
+  format: yaml
+  location: "."
+
+credentials:
+  - name: cachix_token
+    sources: [env:CACHIX_AUTH_TOKEN]
+    scope: [ssh_keys]
+`)
+	if _, err := Initialize(initFile, types.Flags{}, types.BlueprintTypePackages); err != nil {
+		t.Fatalf("Initialize resolved an out-of-scope credential: %v", err)
+	}
+	if _, err := Initialize(initFile, types.Flags{}, types.BlueprintTypeSSHKeys); err == nil {
+		t.Fatal("Initialize = nil for an in-scope unresolvable credential, want an error")
+	}
+}

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/credentials"
 	"github.com/fynxlabs/rwr/internal/helpers"
 	"github.com/fynxlabs/rwr/internal/prompts"
 	"github.com/fynxlabs/rwr/internal/system"
@@ -317,7 +318,7 @@ func AuthenticateWithGitHub(initConfig *types.InitConfig) (string, error) {
 		log.Warnf("Failed to save token to config: %v", err)
 		log.Infof("Token obtained but could not be saved to config. Re-run with --gh-api-key to supply it directly.")
 	} else {
-		log.Infof("✓ Authentication successful! Token saved to config.")
+		log.Infof("✓ Authentication successful! Token saved.")
 	}
 
 	return token, nil
@@ -452,7 +453,13 @@ func getGitHubToken(initConfig *types.InitConfig) (string, string, error) {
 		return token, "GITHUB_TOKEN", nil
 	}
 
-	// Priority 3: Prompt user for authentication method
+	// Priority 3: OS keyring — where the device flow saves new tokens
+	if token, ok := credentials.FromKeyring("gh_api_token"); ok {
+		log.Debugf("Using GitHub token from the OS keyring")
+		return token, "keyring", nil
+	}
+
+	// Priority 4: Prompt user for authentication method
 	return prompts.PromptForGitHubAuth(initConfig, AuthenticateWithGitHub)
 }
 

--- a/internal/prompts/github.go
+++ b/internal/prompts/github.go
@@ -9,6 +9,7 @@ import (
 
 	"charm.land/huh/v2"
 	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/credentials"
 	"github.com/fynxlabs/rwr/internal/helpers"
 	"github.com/fynxlabs/rwr/internal/types"
 	"github.com/spf13/viper"
@@ -100,18 +101,23 @@ func PromptAndSaveGitHubToken(initConfig *types.InitConfig) (string, error) {
 		log.Warnf("Failed to save token to config: %v", err)
 		log.Infof("Token obtained but could not be saved to config. Re-run with --gh-api-key to supply it directly.")
 	} else {
-		log.Debugf("Token saved to config")
+		log.Debugf("Token saved")
 	}
 
 	return token, nil
 }
 
-// SaveGitHubTokenToConfig writes a GitHub token to the rwr config file.
-// If a different token already exists and interactive mode is on, it prompts
-// the user to confirm the replacement.
+// SaveGitHubTokenToConfig persists a GitHub token: to the OS keyring when a
+// backend is available, falling back to the rwr config file (plaintext at
+// 0600) with a warning naming the file. If a different token already exists
+// and interactive mode is on, it prompts the user to confirm the replacement.
 func SaveGitHubTokenToConfig(token string, initConfig *types.InitConfig) error {
-	// Check if token already exists in config
+	// Check for an existing token: the config file (the grandfathered plaintext
+	// store, still readable) and the keyring (where new tokens land).
 	existingToken := viper.GetString("repository.gh_api_token")
+	if existingToken == "" {
+		existingToken, _ = credentials.FromKeyring("gh_api_token")
+	}
 
 	// If token exists and is different, prompt to confirm replacement (if interactive)
 	if existingToken != "" && existingToken != token && initConfig.Variables.Flags.Interactive {
@@ -123,6 +129,22 @@ func SaveGitHubTokenToConfig(token string, initConfig *types.InitConfig) error {
 			return fmt.Errorf("user declined to replace existing token")
 		}
 	}
+
+	// The registry holds the value for this run either way; persistence below
+	// only decides where the next run reads it from.
+	types.SetCredentialValue("gh_api_token", token)
+
+	// Keyring first: it is the only store that keeps the token off disk in
+	// plaintext. The config file is the fallback, not a second copy — when the
+	// keyring save succeeds, no file gains the token value.
+	saveErr := credentials.SaveToKeyring("gh_api_token", token)
+	if saveErr == nil {
+		log.Debugf("Token saved to the OS keyring")
+		return nil
+	}
+	log.Warnf("OS keyring unavailable (%v); saving the token to %s instead — "+
+		"it is stored in plaintext, readable only by your user (0600)",
+		saveErr, viper.ConfigFileUsed())
 
 	// Set the new token
 	viper.Set("repository.gh_api_token", token)

--- a/internal/prompts/github_save_test.go
+++ b/internal/prompts/github_save_test.go
@@ -1,0 +1,104 @@
+package prompts
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/credentials"
+	"github.com/fynxlabs/rwr/internal/types"
+	"github.com/spf13/viper"
+)
+
+// mapKeyring is the test stand-in for the OS keyring.
+type mapKeyring struct {
+	entries     map[string]string
+	unavailable bool
+}
+
+func (m *mapKeyring) Get(name string) (string, error) {
+	if m.unavailable {
+		return "", errors.New("no keyring backend")
+	}
+	value, ok := m.entries[name]
+	if !ok {
+		return "", credentials.ErrKeyringNotFound
+	}
+	return value, nil
+}
+
+func (m *mapKeyring) Set(name, value string) error {
+	if m.unavailable {
+		return errors.New("no keyring backend")
+	}
+	m.entries[name] = value
+	return nil
+}
+
+func withSaveFixture(t *testing.T, ring credentials.Keyring) string {
+	t.Helper()
+	origRing := credentials.Ring
+	credentials.Ring = ring
+	viper.Reset()
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	viper.SetConfigFile(configFile)
+	t.Cleanup(func() {
+		credentials.Ring = origRing
+		viper.Reset()
+		types.RegisterCredentials(nil)
+	})
+	return configFile
+}
+
+// With a keyring available the device-flow token lands there and no plaintext
+// file gains the token value — the spec's hard rule for managed credentials.
+func TestSaveGitHubTokenPrefersKeyring(t *testing.T) {
+	ring := &mapKeyring{entries: map[string]string{}}
+	configFile := withSaveFixture(t, ring)
+
+	initConfig := &types.InitConfig{}
+	if err := SaveGitHubTokenToConfig("gho_devicetoken", initConfig); err != nil {
+		t.Fatalf("SaveGitHubTokenToConfig: %v", err)
+	}
+
+	if ring.entries["gh_api_token"] != "gho_devicetoken" {
+		t.Error("token did not reach the keyring")
+	}
+	if raw, err := os.ReadFile(configFile); err == nil && strings.Contains(string(raw), "gho_devicetoken") {
+		t.Error("the config file gained the token despite an available keyring")
+	}
+	if value, _ := types.CredentialValue("gh_api_token"); value != "gho_devicetoken" {
+		t.Error("the run's credential registry was not updated")
+	}
+}
+
+// The grandfathered path: no keyring backend falls back to the config file —
+// still restricted to 0600, and the file keeps being read on later runs.
+func TestSaveGitHubTokenFallsBackToConfigFile(t *testing.T) {
+	configFile := withSaveFixture(t, &mapKeyring{unavailable: true})
+
+	initConfig := &types.InitConfig{}
+	if err := SaveGitHubTokenToConfig("gho_devicetoken", initConfig); err != nil {
+		t.Fatalf("SaveGitHubTokenToConfig: %v", err)
+	}
+
+	raw, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("reading config file: %v", err)
+	}
+	if !strings.Contains(string(raw), "gho_devicetoken") {
+		t.Error("fallback did not write the token to the config file")
+	}
+	info, err := os.Stat(configFile)
+	if err != nil {
+		t.Fatalf("stat config file: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("config file mode = %o, want 0600", info.Mode().Perm())
+	}
+	if got := viper.GetString("repository.gh_api_token"); got != "gho_devicetoken" {
+		t.Error("a config-file token must keep resolving (grandfathered read)")
+	}
+}

--- a/internal/types/credentials.go
+++ b/internal/types/credentials.go
@@ -1,0 +1,244 @@
+package types
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
+)
+
+// CredentialSpec is one entry of the init file's `credentials:` section: a named
+// credential the tree's blueprints need, and the ordered places to look for it.
+//
+// Declarations live only in the init file the operator points rwr at — a
+// blueprint can reference a declared credential but never declare one — and
+// exposure to blueprints still requires the operator's exposeCredentials opt-in.
+type CredentialSpec struct {
+	// Name is the credential's identity everywhere: in exposeCredentials, in
+	// template scope ({{ .Credentials.<name> }}), in the exported env name
+	// (RWR_CRED_<NAME>), and in the keyring entry.
+	Name string `mapstructure:"name" yaml:"name" json:"name" toml:"name"`
+	// Description is shown when prompting for the value.
+	Description string `mapstructure:"description,omitempty" yaml:"description,omitempty" json:"description,omitempty" toml:"description,omitempty"`
+	// Sources is the ordered list of places to look: `env:<VAR>`, `keyring`,
+	// `prompt`. First source that yields a value wins. Empty means the default
+	// order [env:RWR_CRED_<NAME>, keyring, prompt].
+	Sources []string `mapstructure:"sources,omitempty" yaml:"sources,omitempty" json:"sources,omitempty" toml:"sources,omitempty"`
+	// Scope limits which surfaces see the credential even after exposure:
+	// "scripts" (spawned-command env), "templates" (template rendering), or a
+	// processor name (the credential is only resolved when that processor is in
+	// the run). Empty reproduces exposeCredentials' full reach.
+	Scope []string `mapstructure:"scope,omitempty" yaml:"scope,omitempty" json:"scope,omitempty" toml:"scope,omitempty"`
+}
+
+// Surfaces a credential's scope can name, beyond processor names.
+const (
+	CredentialSurfaceScripts   = "scripts"
+	CredentialSurfaceTemplates = "templates"
+)
+
+// credentialNamePattern is deliberately narrow: the name becomes an env var
+// segment and a template key, so it has to be a lowercase identifier.
+var credentialNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// DecodeCredentialSpecs strictly decodes the raw `credentials:` section as read
+// by viper. Viper's own Unmarshal ignores unknown keys, so a typo like
+// `soruces:` would silently become the default source order — an error naming
+// the key is the only honest answer.
+func DecodeCredentialSpecs(raw interface{}) ([]CredentialSpec, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	var specs []CredentialSpec
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:      &specs,
+		ErrorUnused: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := decoder.Decode(raw); err != nil {
+		return nil, fmt.Errorf("credentials section: %w", err)
+	}
+	return specs, ValidateCredentialSpecs(specs)
+}
+
+// ValidateCredentialSpecs rejects a declaration rwr cannot honor: a name that
+// cannot become an env var or template key, a source outside the vocabulary, a
+// scope naming no known surface or processor, or a collision with a built-in.
+func ValidateCredentialSpecs(specs []CredentialSpec) error {
+	seen := map[string]bool{}
+	for _, spec := range specs {
+		if !credentialNamePattern.MatchString(spec.Name) {
+			return fmt.Errorf("credential name %q is invalid: names are lowercase identifiers ([a-z][a-z0-9_]*)", spec.Name)
+		}
+		if seen[spec.Name] {
+			return fmt.Errorf("credential %q is declared twice", spec.Name)
+		}
+		seen[spec.Name] = true
+		if isBuiltinCredential(spec.Name) {
+			return fmt.Errorf("credential %q is built in and cannot be redeclared", spec.Name)
+		}
+		for _, source := range spec.Sources {
+			if err := validateCredentialSource(source); err != nil {
+				return fmt.Errorf("credential %q: %w", spec.Name, err)
+			}
+		}
+		for _, scope := range spec.Scope {
+			if err := validateCredentialScope(scope); err != nil {
+				return fmt.Errorf("credential %q: %w", spec.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func validateCredentialSource(source string) error {
+	switch {
+	case source == "keyring" || source == "prompt":
+		return nil
+	case strings.HasPrefix(source, "env:"):
+		if strings.TrimPrefix(source, "env:") == "" {
+			return fmt.Errorf("source %q names no environment variable", source)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown source %q (valid: env:<VAR>, keyring, prompt)", source)
+	}
+}
+
+func validateCredentialScope(scope string) error {
+	switch scope {
+	case CredentialSurfaceScripts, CredentialSurfaceTemplates,
+		BlueprintTypePackages, BlueprintTypeRepositories, BlueprintTypeFiles,
+		BlueprintTypeGit, BlueprintTypeSSHKeys, BlueprintTypeFonts,
+		BlueprintTypeUsers, BlueprintTypeConfiguration, BlueprintTypeServices,
+		BlueprintTypeBootstrap:
+		return nil
+	default:
+		return fmt.Errorf("unknown scope %q (valid: scripts, templates, or a processor name)", scope)
+	}
+}
+
+// builtinCredentialNames are the two credentials rwr always manages, implicit
+// declarations so existing behavior is a special case rather than a parallel
+// system. SecretConfigKeys stays as the bridge from their viper keys.
+var builtinCredentialNames = []string{"gh_api_token", "ssh_private_key"}
+
+func isBuiltinCredential(name string) bool {
+	for _, builtin := range builtinCredentialNames {
+		if name == builtin {
+			return true
+		}
+	}
+	return false
+}
+
+// The credential registry: the declared set (scopes) and the values resolved
+// for this run. Values live only here — never in viper, never in a struct a
+// debug dump can reach — and leave only through the exposure-gated accessors
+// below.
+var (
+	credentialScopes = map[string][]string{}
+	credentialValues = map[string]string{}
+)
+
+// RegisterCredentials records the declared set for this run, replacing any
+// previous registration (and dropping its values, so tests are isolated).
+func RegisterCredentials(specs []CredentialSpec) {
+	credentialScopes = make(map[string][]string, len(specs))
+	credentialValues = map[string]string{}
+	for _, spec := range specs {
+		credentialScopes[spec.Name] = spec.Scope
+	}
+}
+
+// IsManagedCredential reports whether name is a built-in or declared credential.
+func IsManagedCredential(name string) bool {
+	name = normaliseCredentialKey(name)
+	if isBuiltinCredential(name) {
+		return true
+	}
+	_, ok := credentialScopes[name]
+	return ok
+}
+
+// SetCredentialValue records a resolved value. Only resolution may call this;
+// everything downstream reads through the gated accessors.
+func SetCredentialValue(name, value string) {
+	credentialValues[normaliseCredentialKey(name)] = value
+}
+
+// CredentialValue returns a resolved value ungated, for rwr's own use (rwr
+// doing the credentialed work itself is always allowed; handing the value to a
+// blueprint is what the gates below are for).
+func CredentialValue(name string) (string, bool) {
+	value, ok := credentialValues[normaliseCredentialKey(name)]
+	return value, ok
+}
+
+// CredentialScope returns the declared scope for a credential (empty for
+// built-ins and unscoped declarations, meaning everything exposure reaches).
+func CredentialScope(name string) []string {
+	return credentialScopes[normaliseCredentialKey(name)]
+}
+
+// credentialInSurface reports whether the credential's scope admits a surface.
+// An empty scope admits every surface; a scope listing only processor names
+// restricts when the credential is resolved, not where it may appear.
+func credentialInSurface(name, surface string) bool {
+	scope := credentialScopes[normaliseCredentialKey(name)]
+	if len(scope) == 0 {
+		return true
+	}
+	restricted := false
+	for _, entry := range scope {
+		if entry == surface {
+			return true
+		}
+		if entry == CredentialSurfaceScripts || entry == CredentialSurfaceTemplates {
+			restricted = true
+		}
+	}
+	return !restricted
+}
+
+// TemplateCredentials returns the values blueprint templates may render as
+// {{ .Credentials.<name> }}: resolved, opted into via exposeCredentials, and
+// in a scope that admits templates.
+func TemplateCredentials() map[string]interface{} {
+	out := map[string]interface{}{}
+	for name, value := range credentialValues {
+		if IsCredentialExposed(name) && credentialInSurface(name, CredentialSurfaceTemplates) {
+			out[name] = value
+		}
+	}
+	return out
+}
+
+// ExportedCredentialEnv returns the RWR_CRED_<NAME> environment entries for
+// spawned commands: resolved, opted into via exposeCredentials, and in a scope
+// that admits scripts. Env is the only export surface — a value must never be
+// placed in argv, where ps can read it.
+func ExportedCredentialEnv() map[string]string {
+	out := map[string]string{}
+	for name, value := range credentialValues {
+		if IsCredentialExposed(name) && credentialInSurface(name, CredentialSurfaceScripts) {
+			out["RWR_CRED_"+strings.ToUpper(name)] = value
+		}
+	}
+	return out
+}
+
+// TemplateCredentialNames returns the exposed template-scope names, for the
+// debug dump of template variables: the names are loggable, the values are not.
+func TemplateCredentialNames() []string {
+	names := make([]string, 0, len(credentialValues))
+	for name := range TemplateCredentials() {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/types/credentials_test.go
+++ b/internal/types/credentials_test.go
@@ -1,0 +1,207 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+// resetCredentialState restores the package-level registries a test mutates.
+func resetCredentialState(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		RegisterCredentials(nil)
+		SetExposedCredentials(nil)
+	})
+}
+
+func TestDecodeCredentialSpecs(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     interface{}
+		wantErr string
+	}{
+		{name: "absent section", raw: nil},
+		{
+			name: "well-formed entry",
+			raw: []interface{}{map[string]interface{}{
+				"name":        "cachix_token",
+				"description": "Cachix auth token",
+				"sources":     []interface{}{"env:CACHIX_AUTH_TOKEN", "keyring", "prompt"},
+				"scope":       []interface{}{"scripts"},
+			}},
+		},
+		{
+			// Viper's own Unmarshal ignores unknown keys; the strict re-decode is
+			// what turns a typo into an error instead of a silently different
+			// source order.
+			name: "unknown key errors",
+			raw: []interface{}{map[string]interface{}{
+				"name":    "cachix_token",
+				"soruces": []interface{}{"keyring"},
+			}},
+			wantErr: "soruces",
+		},
+		{
+			name:    "invalid name",
+			raw:     []interface{}{map[string]interface{}{"name": "Cachix-Token"}},
+			wantErr: "lowercase identifiers",
+		},
+		{
+			name: "duplicate declaration",
+			raw: []interface{}{
+				map[string]interface{}{"name": "cachix_token"},
+				map[string]interface{}{"name": "cachix_token"},
+			},
+			wantErr: "declared twice",
+		},
+		{
+			name:    "built-ins cannot be redeclared",
+			raw:     []interface{}{map[string]interface{}{"name": "gh_api_token"}},
+			wantErr: "built in",
+		},
+		{
+			name: "unknown source",
+			raw: []interface{}{map[string]interface{}{
+				"name":    "cachix_token",
+				"sources": []interface{}{"vault"},
+			}},
+			wantErr: `unknown source "vault"`,
+		},
+		{
+			name: "env source without a variable",
+			raw: []interface{}{map[string]interface{}{
+				"name":    "cachix_token",
+				"sources": []interface{}{"env:"},
+			}},
+			wantErr: "names no environment variable",
+		},
+		{
+			name: "unknown scope",
+			raw: []interface{}{map[string]interface{}{
+				"name":  "cachix_token",
+				"scope": []interface{}{"everything"},
+			}},
+			wantErr: `unknown scope "everything"`,
+		},
+		{
+			name: "processor-name scope",
+			raw: []interface{}{map[string]interface{}{
+				"name":  "cachix_token",
+				"scope": []interface{}{"ssh_keys"},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeCredentialSpecs(tt.raw)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("DecodeCredentialSpecs = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("DecodeCredentialSpecs = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// A declared credential is managed exactly like the built-ins: the registry is
+// what generalizes the fixed two-key list.
+func TestIsManagedCredential(t *testing.T) {
+	resetCredentialState(t)
+	RegisterCredentials([]CredentialSpec{{Name: "cachix_token"}})
+
+	for _, name := range []string{"gh_api_token", "ssh_private_key", "cachix_token"} {
+		if !IsManagedCredential(name) {
+			t.Errorf("IsManagedCredential(%q) = false, want true", name)
+		}
+	}
+	if IsManagedCredential("editor_theme") {
+		t.Error("IsManagedCredential(\"editor_theme\") = true, want false")
+	}
+}
+
+// A resolved value leaves the registry only through the exposure gates: absent
+// from template scope and the env export without the exposeCredentials opt-in,
+// present with it.
+func TestCredentialExposureGates(t *testing.T) {
+	resetCredentialState(t)
+	RegisterCredentials([]CredentialSpec{{Name: "cachix_token"}})
+	SetCredentialValue("cachix_token", "cachix-secret-value")
+
+	if _, ok := TemplateCredentials()["cachix_token"]; ok {
+		t.Error("unexposed credential reached template scope")
+	}
+	if len(ExportedCredentialEnv()) != 0 {
+		t.Errorf("unexposed credential reached the env export: %v", ExportedCredentialEnv())
+	}
+
+	SetExposedCredentials([]string{"cachix_token"})
+
+	if got := TemplateCredentials()["cachix_token"]; got != "cachix-secret-value" {
+		t.Errorf("exposed credential missing from template scope: %v", got)
+	}
+	if got := ExportedCredentialEnv()["RWR_CRED_CACHIX_TOKEN"]; got != "cachix-secret-value" {
+		t.Errorf("exposed credential missing from the env export: %v", ExportedCredentialEnv())
+	}
+}
+
+// Scope narrows exposure per surface: a scripts-only credential stays out of
+// template scope even when exposed, and vice versa. A scope naming only a
+// processor restricts when the credential resolves, not where it may appear.
+func TestCredentialScopeGates(t *testing.T) {
+	resetCredentialState(t)
+	RegisterCredentials([]CredentialSpec{
+		{Name: "script_token", Scope: []string{CredentialSurfaceScripts}},
+		{Name: "template_token", Scope: []string{CredentialSurfaceTemplates}},
+		{Name: "ssh_token", Scope: []string{BlueprintTypeSSHKeys}},
+	})
+	SetExposedCredentials([]string{"script_token", "template_token", "ssh_token"})
+	SetCredentialValue("script_token", "s")
+	SetCredentialValue("template_token", "t")
+	SetCredentialValue("ssh_token", "k")
+
+	templates := TemplateCredentials()
+	env := ExportedCredentialEnv()
+
+	if _, ok := templates["script_token"]; ok {
+		t.Error("scripts-scoped credential reached template scope")
+	}
+	if _, ok := env["RWR_CRED_SCRIPT_TOKEN"]; !ok {
+		t.Error("scripts-scoped credential missing from the env export")
+	}
+	if _, ok := templates["template_token"]; !ok {
+		t.Error("templates-scoped credential missing from template scope")
+	}
+	if _, ok := env["RWR_CRED_TEMPLATE_TOKEN"]; ok {
+		t.Error("templates-scoped credential reached the env export")
+	}
+	if _, ok := templates["ssh_token"]; !ok {
+		t.Error("processor-scoped credential missing from template scope")
+	}
+	if _, ok := env["RWR_CRED_SSH_TOKEN"]; !ok {
+		t.Error("processor-scoped credential missing from the env export")
+	}
+}
+
+// The debug dump of template variables may log credential names, never values.
+func TestTemplateCredentialNames(t *testing.T) {
+	resetCredentialState(t)
+	RegisterCredentials([]CredentialSpec{{Name: "b_token"}, {Name: "a_token"}})
+	SetExposedCredentials([]string{"a_token", "b_token"})
+	SetCredentialValue("a_token", "va")
+	SetCredentialValue("b_token", "vb")
+
+	names := TemplateCredentialNames()
+	if len(names) != 2 || names[0] != "a_token" || names[1] != "b_token" {
+		t.Errorf("TemplateCredentialNames = %v, want sorted [a_token b_token]", names)
+	}
+	for _, name := range names {
+		if strings.Contains(name, "va") || strings.Contains(name, "vb") {
+			t.Errorf("TemplateCredentialNames leaked a value: %v", names)
+		}
+	}
+}

--- a/internal/types/initialize.go
+++ b/internal/types/initialize.go
@@ -68,6 +68,11 @@ type InitConfig struct {
 	// to read, e.g. ["gh_api_token"]. Empty — the default — means blueprints get
 	// none of them. See docs/credentials.md.
 	ExposeCredentials []string `mapstructure:"exposeCredentials,omitempty" yaml:"exposeCredentials,omitempty" json:"exposeCredentials,omitempty" toml:"exposeCredentials,omitempty"`
+	// Credentials declares the named credentials this tree's blueprints need and
+	// where rwr should look for them. Declaring makes a credential managed
+	// (resolved up front, redacted, withheld); exposing it to blueprints still
+	// requires ExposeCredentials. See docs/credentials.md.
+	Credentials []CredentialSpec `mapstructure:"credentials,omitempty" yaml:"credentials,omitempty" json:"credentials,omitempty" toml:"credentials,omitempty"`
 }
 
 func (u UserInfo) ToMap() map[string]interface{} {

--- a/openspec/changes/add-managed-auth/tasks.md
+++ b/openspec/changes/add-managed-auth/tasks.md
@@ -1,34 +1,46 @@
 # Tasks
 
-- [ ] 1. Types: `credentials:` init-file section (strict decode; unknown keys
+- [x] 1. Types: `credentials:` init-file section (strict decode; unknown keys
       error), credential registry replacing the fixed `SecretConfigKeys` list
       while keeping the two built-ins implicitly declared. Test: a tree
       declaring `cachix_token` gets it withheld/redacted exactly like
       `gh_api_token`; fails without the registry.
-- [ ] 2. Source resolvers: `env:<VAR>`, `keyring`, `prompt` behind one
+- [x] 2. Source resolvers: `env:<VAR>`, `keyring`, `prompt` behind one
       interface; ordered first-hit-wins resolution. Table tests per source and
       per precedence order, keyring faked.
-- [ ] 3. Resolution phase in `ProcessInitialization` (after
+- [x] 3. Resolution phase in `ProcessInitialization` (after
       `SetExposedCredentials`, before `setUserDefinedAndEnvVariables`).
       Tests: unresolvable credential errors up front naming sources tried;
       non-TTY skips `prompt` and the error says so; out-of-scope credentials
       for the selected processors are not resolved.
-- [ ] 4. Keyring store (zalando/go-keyring or equivalent): read source +
+- [x] 4. Keyring store (zalando/go-keyring or equivalent): read source +
       explicit save; unavailable backend degrades silently on read, errors on
       save. Interface-level tests with a fake; no CI dependency on a real
       keyring.
-- [ ] 5. Redaction + export: resolved values registered for redaction; env
+- [x] 5. Redaction + export: resolved values registered for redaction; env
       export as `RWR_CRED_<NAME>` gated by `exposeCredentials` and `scope`;
       template scope under `.Credentials.<name>` behind the same gate. Tests:
       value absent from spawned env and rendered templates without opt-in,
       present with; debug logs show `[redacted]` (fails without redaction
       registration); value never in argv.
-- [ ] 6. Fold the GitHub token in: `--gh-auth` / `--gh-api-key` populate the
+- [x] 6. Fold the GitHub token in: `--gh-auth` / `--gh-api-key` populate the
       `gh_api_token` credential; device-flow save prefers keyring, config-file
       fallback warns with the path. Tests: existing config-file token still
       read; keyring-available path writes no plaintext.
-- [ ] 7. Prompt UX: masked huh input with `description`, post-prompt
+      *Deviation:* the built-ins' implicit sources omit `prompt` at init time —
+      prompting for the GitHub token stays at its point of use (`ssh_keys`),
+      preserving the existing behavior of never prompting a run that does not
+      need the token. Built-ins are optional: unresolved is not an error.
+- [x] 7. Prompt UX: masked huh input with `description`, post-prompt
       save-to-keyring offer, honored `--interactive=false`.
-- [ ] 8. Docs (`configuration.md`, new credentials page) + `examples/` init
+- [x] 8. Docs (`configuration.md`, new credentials page) + `examples/` init
       files covering `credentials:` in all formats; validate covers the
       section.
+      *Deviation:* the credentials page already existed (`docs/credentials.md`)
+      and was extended rather than created; the init-file schema doc is
+      `docs/init-file.md` (there is no init `configuration.md`), and
+      `docs/variables.md` documents the `.Credentials` namespace and
+      `RWR_CRED_*` export. Examples: `examples/macos/{yaml,json,toml,cue}`.
+      Validation of the section happens at load (strict decode in
+      `Initialize`) and in the examples strict-schema/parity tests; `rwr
+      validate` does not parse init files today, so no change there.


### PR DESCRIPTION
Implements `add-managed-auth` (Wave 4, final feature). All change tasks checked; two deviations annotated in tasks.md (built-ins never prompt at init — prompting stays at the ssh_keys point of use; init-section validation is the load-time strict decode + examples schema tests, since `rwr validate` doesn't parse init files).

## What

- **`credentials:` init section** — strict-decoded declarations (`name`, `description`, `sources`, `scope`); unknown keys, duplicate names, and built-in redeclarations error.
- **Sources** — `env:<VAR>` → `keyring` → `prompt` (default order; CI injects via env without prompting, a saved interactive answer isn't re-asked). All resolved up front: failing at second 1 beats failing at minute 20 inside a script. Unresolvable → error naming the credential and every source tried; non-TTY states that prompt was skipped. Credentials scoped to unselected processors aren't resolved at all.
- **Full secret treatment** — values live only in the registry; the two export surfaces (`{{ .Credentials.<name> }}` template scope, `RWR_CRED_<NAME>` env) are both gated by `exposeCredentials` + scope; env is the only spawn-surface (never argv); resolution logs redact, the template debug dump logs names only.
- **Keyring persistence** — zalando/go-keyring behind an interface (tests use a fake, no CI keyring dependency); reads degrade silently, saves error loudly. `SaveGitHubTokenToConfig` prefers the keyring and writes **no plaintext** when it's available; the config-file path stays as a warned 0600 fallback and existing config tokens remain readable (grandfathered — nobody's data deleted).
- **GitHub token folded in** as the first managed credential: flag → config → `GITHUB_TOKEN` → keyring.
- Docs (`docs/credentials.md`, init-file, variables) and the `credentials` section in all four example init formats.

## Verification

Live smoke on top of the unit suite: an exposed credential reaches a script as `RWR_CRED_MY_TOKEN`; withdrawing `exposeCredentials` withholds it; a debug-level run contains zero occurrences of the secret. `go build`/`go test ./...`, `golangci-lint` 0 issues, gosec clean. Every touched file under 500 lines; cmd changes are wiring only.

Commits unsigned — signing key hardware unavailable this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)