### PR TITLE
docs(examples): CUE variants for the alternative layouts

### DIFF
--- a/examples/alternative_layouts/flattened/README.md
+++ b/examples/alternative_layouts/flattened/README.md
@@ -12,6 +12,12 @@ flattened/
 │   ├── git.yaml
 │   ├── files.yaml
 │   └── scripts.yaml
+├── cue/
+│   ├── init.cue
+│   ├── packages.cue
+│   ├── git.cue
+│   ├── files.cue
+│   └── scripts.cue
 ├── json/
 │   ├── init.json
 │   ├── packages.json

--- a/examples/alternative_layouts/flattened/cue/files.cue
+++ b/examples/alternative_layouts/flattened/cue/files.cue
@@ -1,0 +1,22 @@
+{
+  "files": [
+    {
+      "name": ".bashrc",
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "content": "# Custom .bashrc for {{ .UserDefined.project_name }}\nalias ll='ls -alF'\nalias la='ls -A'\nalias l='ls -CF'\nalias grep='grep --color=auto'\nexport PATH=$PATH:$HOME/.local/bin\nexport EDITOR=vim\n"
+    },
+    {
+      "name": ".gitconfig",
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "content": "[user]\n    name = {{ .User.fullName }}\n    email = {{ .User.username }}@example.com\n[core]\n    editor = vim\n[init]\n    defaultBranch = main\n[pull]\n    rebase = false\n"
+    },
+    {
+      "name": ".vimrc",
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "content": "\" Basic vim configuration for {{ .User.username }}\nset number\nset relativenumber\nset tabstop=4\nset shiftwidth=4\nset expandtab\nsyntax on\nset hlsearch\nset incsearch\n"
+    }
+  ]
+}

--- a/examples/alternative_layouts/flattened/cue/git.cue
+++ b/examples/alternative_layouts/flattened/cue/git.cue
@@ -1,0 +1,18 @@
+{
+  "git": [
+    {
+      "name": "dotfiles",
+      "action": "clone",
+      "url": "{{ .UserDefined.repo_url }}",
+      "path": "{{ .User.home }}/dotfiles",
+      "private": false
+    },
+    {
+      "name": "useful-scripts",
+      "action": "clone",
+      "url": "https://github.com/user/useful-scripts.git",
+      "path": "{{ .User.home }}/scripts",
+      "private": false
+    }
+  ]
+}

--- a/examples/alternative_layouts/flattened/cue/init.cue
+++ b/examples/alternative_layouts/flattened/cue/init.cue
@@ -1,0 +1,23 @@
+{
+  "blueprints": {
+    "format": "cue",
+    "schema_version": 1,
+    "location": ".",
+    "order": ["packages", "git", "files", "scripts"]
+  },
+  "variables": {
+    "userDefined": {
+      "project_name": "flattened-setup",
+      "repo_url": "https://github.com/user/dotfiles.git"
+    }
+  },
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"],
+      "scope": ["scripts"]
+    }
+  ],
+  "exposeCredentials": ["example_api_token"]
+}

--- a/examples/alternative_layouts/flattened/cue/packages.cue
+++ b/examples/alternative_layouts/flattened/cue/packages.cue
@@ -1,0 +1,20 @@
+{
+  "packages": [
+    {
+      "name": "git",
+      "action": "install"
+    },
+    {
+      "name": "curl",
+      "action": "install"
+    },
+    {
+      "name": "vim",
+      "action": "install"
+    },
+    {
+      "name": "htop",
+      "action": "install"
+    }
+  ]
+}

--- a/examples/alternative_layouts/flattened/cue/scripts.cue
+++ b/examples/alternative_layouts/flattened/cue/scripts.cue
@@ -1,0 +1,22 @@
+{
+  "scripts": [
+    {
+      "name": "setup-dev-env",
+      "action": "inline",
+      "content": "#!/bin/bash\necho \"Setting up development environment for {{ .User.username }}\"\n\n# Create common directories\nmkdir -p {{ .User.home }}/projects\nmkdir -p {{ .User.home }}/.local/bin\n\n# Set permissions\nchmod 755 {{ .User.home }}/.local/bin\n\necho \"Development environment ready!\"\n",
+      "asUser": "{{ .User.username }}"
+    },
+    {
+      "name": "install-node",
+      "action": "inline",
+      "content": "#!/bin/bash\n# Install Node.js using package manager\nif command -v apt &> /dev/null; then\n    curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -\n    sudo apt-get install -y nodejs\nelif command -v brew &> /dev/null; then\n    brew install node\nelse\n    echo \"No supported package manager found\"\n    exit 1\nfi\n\necho \"Node.js installed successfully\"\nnode --version\nnpm --version\n",
+      "asUser": "root"
+    },
+    {
+      "name": "update-system",
+      "action": "inline",
+      "content": "#!/bin/bash\necho \"Updating system packages...\"\n\nif command -v apt &> /dev/null; then\n    sudo apt update && sudo apt upgrade -y\nelif command -v dnf &> /dev/null; then\n    sudo dnf update -y\nelif command -v pacman &> /dev/null; then\n    sudo pacman -Syu --noconfirm\nelif command -v brew &> /dev/null; then\n    brew update && brew upgrade\nelse\n    echo \"No supported package manager found\"\n    exit 1\nfi\n\necho \"System update complete!\"\n",
+      "asUser": "{{ .User.username }}"
+    }
+  ]
+}

--- a/examples/alternative_layouts/minimal_files/README.md
+++ b/examples/alternative_layouts/minimal_files/README.md
@@ -9,6 +9,9 @@ minimal_files/
 ├── yaml/
 │   ├── init.yaml
 │   └── all_in_one.yaml
+├── cue/
+│   ├── init.cue
+│   └── all_in_one.cue
 ├── json/
 │   ├── init.json
 │   └── all_in_one.json

--- a/examples/alternative_layouts/minimal_files/cue/all_in_one.cue
+++ b/examples/alternative_layouts/minimal_files/cue/all_in_one.cue
@@ -1,0 +1,47 @@
+{
+  "packages": [
+    {
+      "name": "git",
+      "action": "install"
+    },
+    {
+      "name": "curl",
+      "action": "install"
+    },
+    {
+      "name": "vim",
+      "action": "install"
+    }
+  ],
+  "git": [
+    {
+      "name": "dotfiles",
+      "action": "clone",
+      "url": "{{ .UserDefined.repo_url }}",
+      "path": "{{ .User.home }}/dotfiles",
+      "private": false
+    }
+  ],
+  "files": [
+    {
+      "name": ".bashrc",
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "content": "# Custom .bashrc for {{ .UserDefined.project_name }}\nalias ll='ls -alF'\nalias la='ls -A'\nalias l='ls -CF'\nexport PATH=$PATH:$HOME/.local/bin\n"
+    },
+    {
+      "name": ".gitconfig",
+      "action": "create",
+      "target": "{{ .User.home }}/",
+      "content": "[user]\n    name = {{ .User.fullName }}\n    email = {{ .User.username }}@example.com\n[core]\n    editor = vim\n[init]\n    defaultBranch = main\n"
+    }
+  ],
+  "scripts": [
+    {
+      "name": "setup-dev-env",
+      "action": "inline",
+      "content": "#!/bin/bash\necho \"Setting up development environment for {{ .User.username }}\"\nmkdir -p {{ .User.home }}/projects\necho \"Development environment ready!\"\n",
+      "asUser": "{{ .User.username }}"
+    }
+  ]
+}

--- a/examples/alternative_layouts/minimal_files/cue/init.cue
+++ b/examples/alternative_layouts/minimal_files/cue/init.cue
@@ -1,0 +1,23 @@
+{
+  "blueprints": {
+    "format": "cue",
+    "schema_version": 1,
+    "location": ".",
+    "order": ["packages", "git", "files", "scripts"]
+  },
+  "variables": {
+    "userDefined": {
+      "project_name": "minimal-setup",
+      "repo_url": "https://github.com/user/dotfiles.git"
+    }
+  },
+  "credentials": [
+    {
+      "name": "example_api_token",
+      "description": "Example API token used by scripts in this tree",
+      "sources": ["env:EXAMPLE_API_TOKEN", "keyring", "prompt"],
+      "scope": ["scripts"]
+    }
+  ],
+  "exposeCredentials": ["example_api_token"]
+}


### PR DESCRIPTION
The `flattened` and `minimal_files` alternative layouts carried yaml/json/toml columns but never got CUE when the format landed (#214) — only the main platform columns did (those are complete: 14/14 per Linux distro, 13/13 macos/windows).

- Both layouts gain a `cue/` column: JSON-form CUE like every other `.cue` example, template placeholders surviving as quoted strings.
- Inits carry the `credentials` section matching their yaml/json/toml siblings — which is why this is **stacked on #234** (master's strict decode doesn't know the key yet). Retarget to master after #234 merges.
- READMEs list the new column.

Both trees pass `rwr validate` and the strict-schema example walk picks them up automatically.

Commits unsigned — signing key hardware unavailable this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)