### PR TITLE
docs(openspec): propose system-scan, diff, and capture

### DIFF
--- a/openspec/changes/add-capture-command/proposal.md
+++ b/openspec/changes/add-capture-command/proposal.md
@@ -1,0 +1,48 @@
+# Change: rwr capture — turn a handcrafted machine into a blueprint tree
+
+Depends on: add-system-scan (the harvest layer).
+
+## Why
+
+The first blueprint tree is the expensive one. An operator with a machine
+they have shaped over years — packages across pacman *and* cargo *and* npm,
+a decade of dotfiles, hand-enabled services — has no path into rwr except
+transcribing it all by hand. That is exactly the work a tool that already
+knows every provider's package list, the blueprint schema, and four output
+formats should do.
+
+The trap is dumping `pacman -Q`: a capture that includes everything the OS
+ever installed is as useless as no capture. The scan layer's explicit-only
+filtering handles packages; for configs and services no heuristic beats a
+human with a checklist, so the human gets a checklist.
+
+## What Changes
+
+- `rwr capture [dir]`: scans the machine (add-system-scan) and walks the
+  operator through a multi-page huh form — one page per category:
+  - packages (per provider, explicit-only, pre-selected);
+  - configs (dotfiles + `~/.config` survivors of the noise list,
+    pre-selected only for the known-dotfile set);
+  - services (enabled units, unselected by default — most are distro
+    plumbing);
+  - git checkouts (discovered clones, pre-selected).
+- Generates into `dir` (default `./rwr-blueprints`):
+  - a tree in the chosen format (`--format cue|yaml|json|toml`, default
+    cue): init file, per-category blueprint files, selected config files
+    copied under `files/src/` with matching file entries;
+  - `--manifest` also writes a root manifest with the current machine's
+    OS/distro matchers, ready to grow more machines.
+- The generated tree SHALL pass `rwr validate` before capture reports
+  success — a capture that emits an invalid tree has failed, loudly.
+- Non-interactive mode (`--all`, CI/scripting) takes every pre-selected
+  default without the form.
+
+## Breakage
+
+None. New command; nothing existing changes.
+
+## Impact
+
+- Affected specs: `cli` (new command), reads `system-scan`.
+- Affected code: `cmd/capture.go` (wiring), `internal/capture` (form +
+  generation), scan emission layer for the file contents.

--- a/openspec/changes/add-capture-command/specs/cli/spec.md
+++ b/openspec/changes/add-capture-command/specs/cli/spec.md
@@ -1,0 +1,45 @@
+# CLI — Deltas
+
+## ADDED Requirements
+
+### Requirement: rwr capture generates a blueprint tree from the machine
+
+`rwr capture` SHALL scan the machine, present the findings as a per-category
+selection form (packages per provider explicit-only and pre-selected;
+configs pre-selected only for known dotfiles; services unselected by
+default; git checkouts pre-selected), and generate a blueprint tree in the
+chosen registry format from the selection — init file, per-category
+blueprints, and selected config files copied under `files/src/` with
+matching entries. `--all` SHALL take the defaults without the form;
+`--manifest` SHALL add a root manifest carrying the machine's detected
+matchers.
+
+#### Scenario: Handcrafted machine to tree
+
+- **GIVEN** a machine with explicit pacman and cargo packages and known
+  dotfiles
+- **WHEN** `rwr capture --all --format cue out/` runs
+- **THEN** out/ contains an init and packages blueprints per provider and
+  the dotfiles under `files/src/` with file entries
+
+#### Scenario: Dependency noise never captured
+
+- **WHEN** the packages page is built for a provider with `list_explicit`
+- **THEN** only explicitly-installed packages appear on it
+
+#### Scenario: Secret-shaped paths need explicit intent
+
+- **GIVEN** the config scan finding `~/.ssh/config` and key material
+- **WHEN** the selection defaults are computed
+- **THEN** key material is never pre-selected, and selecting it warns
+
+### Requirement: A capture that emits an invalid tree fails
+
+`rwr capture` SHALL run validation over the generated tree and SHALL exit
+non-zero when it does not pass, naming the failures. A generator whose
+output needs hand-repair before first use has not captured anything.
+
+#### Scenario: Broken emission is loud
+
+- **WHEN** the generated tree fails strict decode
+- **THEN** capture exits non-zero naming the failing file

--- a/openspec/changes/add-capture-command/tasks.md
+++ b/openspec/changes/add-capture-command/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+- [ ] 1. `internal/capture`: selection model over scan results with
+      per-category defaults (explicit packages on, known dotfiles on,
+      services off, git checkouts on). Test: defaults per category.
+- [ ] 2. huh multi-page form: one page per category, counts in titles,
+      select-all/none per page; `--all` skips the form taking defaults.
+      Test: `--all` selection equals defaults; form model unit-tested
+      without a TTY.
+- [ ] 3. Tree generation: init + per-category blueprint files in the chosen
+      format; selected configs copied under `files/src/` with file entries
+      targeting their origin via `{{ .User.home }}`. Test: golden tree from
+      a fixture scan; secrets-shaped paths (`~/.ssh`, key material) are
+      never auto-selected and warn when selected explicitly.
+- [ ] 4. `--manifest`: root manifest with the machine's detected OS/distro
+      matchers. Test: generated manifest strict-decodes and matches the
+      fixture OS.
+- [ ] 5. Self-check: capture runs `rwr validate` on the generated tree and
+      fails loudly if it fails (test: corrupt an emission → capture exits
+      non-zero).
+- [ ] 6. Docs: `docs/cli/capture.md` + a "start from an existing machine"
+      section in quick-start.

--- a/openspec/changes/add-diff-command/proposal.md
+++ b/openspec/changes/add-diff-command/proposal.md
@@ -1,0 +1,47 @@
+# Change: rwr diff — machine drift as blueprint updates
+
+Depends on: add-system-scan (the harvest layer).
+
+## Why
+
+A provisioned machine drifts: packages installed by hand, configs adjusted,
+services enabled. `rwr status` (state-tracking spec) answers "does the
+machine match the tree" — but its unit of report is drift, and its consumer
+is an exit code. The operator's actual next step is "fold the drift I want
+to keep back into the blueprints", and today that is a manual diff of
+`pacman -Qe` against yaml by eyeball.
+
+The journal (`internal/state`) makes this tractable: rwr knows what *it*
+applied, so hand-installed work is separable from blueprint-installed work
+instead of guessed at.
+
+## What Changes
+
+- `rwr diff`: compares the scan (add-system-scan) against the resolved
+  blueprint tree and reports what is on the machine but not in the tree,
+  and what the tree declares that is gone from the machine.
+- Output modes:
+  - default: a readable list grouped by category and provider;
+  - `--format cue|yaml|json|toml`: paste-ready blueprint blocks of the
+    additions/removals, rendered by the scan emission layer;
+  - `--packages` (and siblings) to scope to one category.
+- `--into <tree>`: interactive routing. For each change group a huh form
+  offers the destination candidates discovered from the tree itself — the
+  matching machine tree's blueprint file, any Common file the tree imports
+  for that category, or skip — then writes the edit in the target file's
+  own format. rwr cannot know whether a new package is an Archcraft thing
+  or a Common thing; that is the operator's call, made once per group
+  instead of once per hand-edit.
+- Never applies anything: diff writes blueprint files when told to, and the
+  system only when the operator later runs `rwr all`.
+
+## Breakage
+
+None. New command; no existing surface changes.
+
+## Impact
+
+- Affected specs: `cli` (new command), reads `system-scan` and
+  `state-tracking`.
+- Affected code: `cmd/diff.go` (wiring), `internal/diff` (comparison +
+  routing), huh form (dependency already present).

--- a/openspec/changes/add-diff-command/specs/cli/spec.md
+++ b/openspec/changes/add-diff-command/specs/cli/spec.md
@@ -1,0 +1,52 @@
+# CLI — Deltas
+
+## ADDED Requirements
+
+### Requirement: rwr diff reports machine drift as blueprint material
+
+`rwr diff` SHALL compare the system scan against the resolved blueprint
+tree and report additions (on the machine, absent from the tree) and
+removals (declared, gone), grouped by category and provider. Packages the
+journal shows a run applied SHALL NOT report as hand-added. With
+`--format`, the delta SHALL render as paste-ready blueprint blocks in the
+named registry format. Diff never mutates the system.
+
+#### Scenario: Hand-installed package surfaces
+
+- **GIVEN** a package present in the explicit list, absent from the tree
+  and from the journal
+- **WHEN** `rwr diff --packages` runs
+- **THEN** it is reported as an addition with its provider
+
+#### Scenario: Blueprint-installed package is not drift
+
+- **GIVEN** a package the journal records a run applied
+- **WHEN** `rwr diff` runs
+- **THEN** it is not reported as an addition
+
+#### Scenario: Paste-ready output
+
+- **WHEN** `rwr diff --packages --format cue` runs
+- **THEN** the output is a packages block that strict-decodes
+
+### Requirement: rwr diff --into routes changes into the tree interactively
+
+`rwr diff --into <tree>` SHALL offer each change group a destination chosen
+by the operator — the matching machine tree's file for that category, a
+Common file the tree imports, or skip — and SHALL write accepted edits in
+the destination file's own format, leaving a tree that passes validation.
+Whether a change is machine-specific or Common is the operator's decision;
+rwr's job is to make it once per group instead of once per hand-edit.
+
+#### Scenario: Routed into Common
+
+- **GIVEN** a new package and a tree whose packages file imports a Common
+  base
+- **WHEN** the operator picks the Common destination
+- **THEN** the entry lands in the Common file, in that file's format, and
+  the tree validates
+
+#### Scenario: Non-interactive refuses with the alternative
+
+- **WHEN** `rwr diff --into tree` runs without a TTY
+- **THEN** it fails naming `--format` as the non-interactive path

--- a/openspec/changes/add-diff-command/tasks.md
+++ b/openspec/changes/add-diff-command/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+- [ ] 1. `internal/diff`: scan-vs-tree comparison per category — additions
+      (on machine, not in tree) and removals (in tree, gone from machine),
+      package identity matched provider-aware. Test: synthetic tree +
+      fixture scan → expected delta; blueprint-installed packages (journal
+      entries) never report as hand-added.
+- [ ] 2. `rwr diff` list output grouped by category/provider; exit 0 always
+      (reporting, not gating — `rwr status` owns the exit code). Test:
+      golden output.
+- [ ] 3. `--format cue|yaml|json|toml` paste-ready blocks via the scan
+      emission layer; `--packages`/`--configs`/`--services`/`--git` scoping.
+      Test: emitted block strict-decodes; scoped runs touch only their
+      scanners.
+- [ ] 4. `--into <tree>`: destination discovery (machine tree file for the
+      category, Common files reachable via its imports, skip), huh form per
+      change group, edit written in the target file's own format. Tests:
+      destination discovery on a fixture tree with Common imports;
+      non-interactive `--into` without a TTY errors naming `--format` as
+      the alternative; written file strict-decodes and `rwr validate`
+      passes.
+- [ ] 5. Docs: `docs/cli/diff.md`, cross-link from state.md's status
+      section.

--- a/openspec/changes/add-system-scan/proposal.md
+++ b/openspec/changes/add-system-scan/proposal.md
@@ -1,0 +1,58 @@
+# Change: System scan — the shared harvest layer for diff and capture
+
+Scope: the scanning foundation only. The two consumers — `rwr diff`
+(add-diff-command) and `rwr capture` (add-capture-command) — are separate
+changes that depend on this one.
+
+## Why
+
+Two upcoming commands need the same answer to the same question: "what is
+actually on this machine, filtered to what a human chose to put there?"
+
+- `rwr diff` compares that answer against the blueprint tree and offers the
+  delta as blueprint updates.
+- `rwr capture` takes that answer on a machine with no tree at all and
+  generates one.
+
+Today rwr can only see what a blueprint declared (`internal/processors/plan.go`)
+or what a run recorded (`internal/state`). The status querier
+(`internal/status/query.go`) reads provider `list` output, but that is the
+full installed set — on Arch that is every dependency ever pulled in, ~1200
+packages of noise around the ~200 the operator actually asked for. There is
+no notion of "explicitly installed", no config scanner, and no service
+scanner beyond the single-unit `is-enabled` probe.
+
+## What Changes
+
+- A `list_explicit` command joins the provider CUE schema and definitions:
+  the manager's explicitly-installed query (`pacman -Qe`, `apt-mark
+  showmanual`, `brew leaves`, `dnf repoquery --userinstalled`,
+  `cargo install --list`, `npm ls -g --depth=0`, …). Providers without one
+  fall back to `list` and are marked unfiltered in scan results.
+- `internal/scan`: read-only scanners returning typed results —
+  - packages: per detected provider, explicit set preferred;
+  - configs: the known-dotfile set (`.bashrc`, `.gitconfig`, …) plus
+    top-level `~/.config` entries, minus a shipped known-noise exclusion
+    list (caches, state dirs, session junk);
+  - services: enabled units the operator enabled (linux: `systemctl
+    list-unit-files --state=enabled`, minus vendor presets where
+    determinable), per-platform, honest `unknown` elsewhere;
+  - git checkouts: clones under configured roots (default `~/git`).
+- Scanners never mutate and never elevate — same contract as the status
+  querier, enforced the same way.
+- Blueprint emission helpers: a scan result renders as a blueprint block in
+  any registry format (cue/yaml/json/toml), reusing the format-registry
+  encoders the convert command established.
+
+## Breakage
+
+None. Additive schema field (providers without `list_explicit` keep working),
+new internal package, no CLI surface of its own.
+
+## Impact
+
+- Affected specs: `system-scan` (new capability), `provider-detection`
+  (schema field).
+- Affected code: `providers/cue/schema.cue` + definitions, new
+  `internal/scan`, format emission shared with `internal/convert`.
+- Consumers: add-diff-command, add-capture-command.

--- a/openspec/changes/add-system-scan/specs/provider-detection/spec.md
+++ b/openspec/changes/add-system-scan/specs/provider-detection/spec.md
@@ -1,0 +1,22 @@
+# Provider Detection — Deltas
+
+## ADDED Requirements
+
+### Requirement: Providers may declare an explicit-install list command
+
+The provider schema SHALL accept an optional `list_explicit` command — the
+package manager's query for explicitly-installed packages (`pacman -Qe`,
+`apt-mark showmanual`, `brew leaves`) — and scan consumers SHALL prefer it
+over `list`. Absence is not an error: consumers fall back to
+`list` and say so.
+
+#### Scenario: Schema accepts the verb
+
+- **GIVEN** a CUE provider declaring `list_explicit`
+- **WHEN** the export pipeline runs
+- **THEN** it exports and the loaded provider carries the command
+
+#### Scenario: Absence falls back
+
+- **WHEN** a provider defines only `list`
+- **THEN** loading succeeds and scans mark its results unfiltered

--- a/openspec/changes/add-system-scan/specs/system-scan/spec.md
+++ b/openspec/changes/add-system-scan/specs/system-scan/spec.md
@@ -1,0 +1,61 @@
+# System Scan — Deltas
+
+## ADDED Requirements
+
+### Requirement: Scans report what the operator put on the machine
+
+A scan SHALL report the machine's operator-chosen state per category —
+packages, configs, services, git checkouts — preferring each package
+manager's explicitly-installed query (`list_explicit`) over its full list,
+and marking results unfiltered when only the full list exists. Dependency
+noise is the difference between a usable answer and 1200 rows.
+
+#### Scenario: Explicit packages preferred
+
+- **GIVEN** a provider defining both `list` and `list_explicit`
+- **WHEN** the package scanner runs
+- **THEN** the result contains the explicit set and is not marked unfiltered
+
+#### Scenario: Fallback is honest
+
+- **WHEN** a provider defines only `list`
+- **THEN** the scan result carries the full set marked unfiltered
+
+### Requirement: Scans are read-only and unelevated
+
+A scan SHALL NOT mutate the system and SHALL NOT elevate: it executes only
+the provider's list verbs and reads files and unit states. A state
+inspection that changes state, or asks for root, is one nobody trusts.
+
+#### Scenario: Only list verbs execute
+
+- **GIVEN** a provider whose non-list commands are trap binaries
+- **WHEN** a scan runs
+- **THEN** no trap fires
+
+### Requirement: Config scanning ships a noise exclusion list
+
+The config scanner SHALL report the known dotfiles and top-level `~/.config`
+entries, minus a shipped exclusion list of cache, state, and session
+directories; excluded entries SHALL be recoverable with an
+include-everything flag. The human selects from what is shown, so what is
+shown must be worth reading.
+
+#### Scenario: Cache noise excluded by default
+
+- **GIVEN** `~/.config` containing an application config and `~/.config/pulse`
+- **WHEN** the config scanner runs
+- **THEN** the application config is reported and the pulse state is not
+
+### Requirement: Scan results render as blueprints in any format
+
+A scan result SHALL render as a blueprint block in any registry format
+(cue, yaml, json, toml), and the rendered block SHALL strict-decode against
+the blueprint schema. Emission that produces invalid blueprints is worse
+than a plain list.
+
+#### Scenario: Rendered block round-trips
+
+- **WHEN** a package scan renders as a cue packages block
+- **THEN** the block decodes strictly as a packages blueprint with the same
+  entries

--- a/openspec/changes/add-system-scan/tasks.md
+++ b/openspec/changes/add-system-scan/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+- [ ] 1. `list_explicit` in the provider CUE schema + the definitions that
+      have one (pacman family, apt, dnf, brew, cargo, npm-family, zypper,
+      apk, chocolatey/scoop/winget where supported); export pipeline and
+      round-trip tests updated. Test: a provider without the verb still
+      exports and loads.
+- [ ] 2. `internal/scan` package scanner: per detected provider, parse
+      explicit output (fixtures per provider, like the status querier);
+      fall back to `list` marked unfiltered. Test: fixtures per provider;
+      a scan never executes a non-list verb (trap-binary test, same
+      pattern as status).
+- [ ] 3. Config scanner: known-dotfile set + `~/.config` top level, shipped
+      noise exclusion list, results carry path + kind. Test: fixture home
+      dir; excluded entries absent; unknown entries present.
+- [ ] 4. Service scanner: enabled units minus vendor presets on linux;
+      `unknown` off-platform. Test: parse fixtures.
+- [ ] 5. Git scanner: clones under configured roots with remote URL +
+      path. Test: fixture tree.
+- [ ] 6. Emission: scan results → blueprint block in any registry format,
+      reusing the convert encoders. Test: golden output per format,
+      round-trips through strict decode.


### PR DESCRIPTION
Proposals for the two ideas (drift-to-blueprints and machine-to-blueprints), structured as three changes because they share their guts — either feature can land first.

- **`add-system-scan`** — the shared harvest layer: a `list_explicit` provider verb (`pacman -Qe`, `apt-mark showmanual`, `brew leaves`, `cargo install --list`, …) so results are the ~200 packages the operator chose, not 1200 rows of dependencies; read-only never-elevating scanners for packages/configs/services/git checkouts; a shipped config noise-exclusion list; blueprint emission in any registry format that must strict-decode.
- **`add-diff-command`** — scan vs the resolved tree. Hand-installed work is separable from blueprint-installed work via the run journal, so a blueprint-installed package never reports as drift. Output: readable list, `--format cue|yaml|json|toml` paste-ready blocks, or `--into <tree>` interactive routing — per change group, a huh pick between the machine tree's file, a Common file the tree imports, or skip. Machine-vs-Common is the operator's decision; rwr just makes it once per group.
- **`add-capture-command`** — the same scan with no tree: multi-page huh selection (per-provider explicit packages pre-selected, known dotfiles pre-selected, services off by default, key material never auto-selected and warns), generating an init + per-category blueprints + `files/src/` copies + optional manifest in the chosen format. Capture validates its own output and fails loudly if it doesn't pass.

All three validate; `openspec validate --all` 14/14.

Commits unsigned — signing key hardware unavailable this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)