### PR TITLE
docs: bring the README and docs up to what rwr actually is

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,19 @@
 
 ![RWR Logo](img/rwr_128.gif)
 
-Rinse, Wash, Repeat (RWR) is a powerful and flexible configuration management tool designed for those who like to hop around and reinstall frequently, regardless of whether it's Linux, macOS, or Windows. It aims to simplify the process of setting up and maintaining your system, making it easy to rebuild and reproduce configurations across multiple machines.
+Rinse, Wash, Repeat (RWR) is a powerful and flexible configuration management tool designed for those who like to hop around and reinstall frequently, regardless of whether it's Linux, macOS, or Windows. It aims to simplify the process of setting up and maintaining your system, making it easy to rebuild and reproduce configurations across multiple machines — and, with its run records, to see what a run changed and to reverse it again.
 
 ## Features
 
 - **Blueprint-based Configuration**: Uses configuration files called blueprints to define and manage your system's configuration
 - **Blueprint Imports**: Share and reuse blueprint configurations across multiple files and projects
 - **Profile System**: Additive profile model for managing different environments (dev, staging, production) or use cases (work, personal)
-- **Multi-format Support**: Blueprints can be written in YAML, JSON, or TOML format
+- **Multi-format Support**: Blueprints can be written in YAML, JSON, TOML, or CUE format, and `rwr convert` rewrites a whole tree from one format to another
+- **Multi-configuration Repos**: One blueprint repository can hold several configurations behind a root manifest; RWR matches the machine, or `--config-name` picks one
+- **Task-runner CLI**: `rwr all` runs everything; `rwr run <processor>` (or the shorthand `rwr packages`) runs one processor; `rwr bootstrap` runs just the bootstrap step
+- **Interactive Dashboard**: Interactive runs get a live terminal dashboard with built-in and user-defined themes; non-interactive runs keep plain streaming logs
+- **Run Records**: Every run writes a journal; `rwr status` shows desired-vs-actual drift and `rwr uninstall` reverses what recorded runs applied
+- **Managed Credentials**: Declare credentials in the init file and source them from environment variables, the OS keyring, or a prompt — redacted in logs by default
 - **Cross-platform Package Management**: Integrates with various package managers across Linux, macOS, and Windows
 - **File & Directory Management**: Copy, move, delete, create, and manage permissions with URL source support
 - **Service Management**: Start, stop, enable, and disable system services
@@ -22,7 +27,7 @@ Rinse, Wash, Repeat (RWR) is a powerful and flexible configuration management to
 - **Git Repository Management**: Clone and manage Git repositories
 - **Script Execution**: Execute scripts with multiple interpreter support
 - **SSH Key Management**: Generate and manage SSH keys with GitHub integration
-- **Extensible Architecture**: Add new package managers through TOML-based provider configurations
+- **Extensible Architecture**: Package managers are declarative providers — authored in CUE and embedded in the binary, with filesystem overrides in TOML or JSON
 
 ## Table of Contents<!-- omit in toc -->
 
@@ -133,10 +138,10 @@ Read [Install](docs/install.md) for the full description.
 ## Getting Started
 
 1. **Make the configuration file**: Run
-   [`rwr config --create`](docs/cli/configuration.md). RWR asks for the settings
+   [`rwr config create`](docs/cli/configuration.md). RWR asks for the settings
    and writes the file.
-2. **Give the blueprints**: Give a git repository URL or a local path when RWR
-   asks for it.
+2. **Give the blueprints**: Give a git repository URL, a local path, or a
+   GitHub shorthand like `owner/repo` when RWR asks for it.
 3. **Set up the system**: Run [`rwr all`](docs/cli/command-and-flags.md). RWR
    applies the blueprints.
 
@@ -260,10 +265,12 @@ For detailed documentation on how to use RWR, please refer to the `docs/` direct
 - [Config File](docs/cli/configuration.md)
 - [Profile CLI Commands](docs/cli/profiles.md)
 - [Validate Command](docs/cli/validate.md)
+- [Convert Command](docs/cli/convert.md)
 
 ### Blueprints
 
 - [Blueprint Best Practices](docs/best-practices.md)
+- [Fields Common to Every Blueprint](docs/blueprints/common-fields.md)
 - Blueprint Types
   - [Packages Blueprint](docs/blueprints/packages.md)
   - [Repositories Blueprint](docs/blueprints/repositories.md)
@@ -284,6 +291,7 @@ For detailed documentation on how to use RWR, please refer to the `docs/` direct
 - [Template Variables](docs/variables.md)
 - [Package Manager Providers](docs/providers.md)
 - [Credentials](docs/credentials.md)
+- [Run Records - Status & Uninstall](docs/state.md)
 - [Schema versioning](docs/schema-versioning.md)
 
 For more detailed information on each topic, please refer to the corresponding documentation file.
@@ -382,14 +390,21 @@ GitHub Actions runs the pipeline. There are three workflows.
 
 `Go Build & Test` runs at each push to `master` and at each pull request —
 every pull request, not only those targeting `master`, so a branch stacked on
-another branch is still checked. It has five jobs:
+another branch is still checked. Its jobs:
 
 - `build` runs on `ubuntu-latest`, `macos-latest` and `windows-latest`. Each
   runs `go build ./...` and `go vet ./...`; vet type-checks the test files, so
   this is also the guarantee that the whole tree compiles on that platform.
-  `go test -race -v ./...` gates on Linux. It also runs on macOS and Windows,
-  but with `continue-on-error`, because much of the suite still assumes POSIX
-  behaviour.
+  `go test -race -v ./...` gates on Linux, and a coverage gate keeps total
+  coverage at or above a ratcheting threshold. The tests also run on macOS and
+  Windows, but with `continue-on-error`, because much of the suite still
+  assumes POSIX behaviour.
+- `cross-compile` builds every release target with `goreleaser build
+  --snapshot`, and `release-snapshot` runs the full release pipeline — signing
+  included — as a snapshot, so a release-only breakage is caught before merge.
+- `cue-providers` vets the CUE provider sources under `providers/cue/` and
+  fails when the committed JSON under
+  `internal/system/definitions/providers/` differs from a fresh export.
 - `lint` runs golangci-lint against the repository's own `.golangci.yml`, so it
   is the same set of rules as `mise run lint`.
 - `installers` runs shellcheck over `install.sh` and parses `install.ps1` with
@@ -436,7 +451,8 @@ Please ensure that your code follows the project's coding style and includes app
 RWR keeps living specifications under `openspec/specs/`, one directory per
 capability: `blueprint-processing`, `blueprint-schema-versioning`,
 `blueprint-validation`, `cli`, `command-execution`, `credential-handling`,
-`distribution`, `initialization` and `provider-detection`. Project-wide context
+`distribution`, `initialization`, `provider-detection` and `state-tracking`.
+Project-wide context
 and the rules specs are written against live in `openspec/config.yaml`.
 
 **If a change alters behavior that a spec covers, update that spec in the same

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Map of the Rinse, Wash, Repeat (RWR) docs. Start here if you are new.
 
 ## CLI
 
-- [CLI docs](cli/README.md) — commands, flags, the configuration file, the profiles CLI, and `rwr validate`.
+- [CLI docs](cli/README.md) — commands, flags, the configuration file, the profiles CLI, `rwr validate`, and `rwr convert`.
 
 ## Blueprints
 
@@ -31,11 +31,15 @@ Map of the Rinse, Wash, Repeat (RWR) docs. Start here if you are new.
 
 ## Providers
 
-- [Package Manager Providers](providers.md) — TOML files that define each package manager, no Go code needed.
+- [Package Manager Providers](providers.md) — declarative definitions of each package manager, no Go code needed: authored in CUE, overridable with TOML or JSON files.
 
 ## Credentials and security
 
-- [Credentials in blueprints](credentials.md) — the GitHub token and SSH key RWR holds, and why blueprints cannot read them by default.
+- [Credentials in blueprints](credentials.md) — the credentials RWR holds (GitHub token, SSH key, and any you declare), where they are sourced from, and why blueprints cannot read them by default.
+
+## Run records
+
+- [Run records](state.md) — the journal each run writes, `rwr status` for drift, and `rwr uninstall` to reverse a run.
 
 ## General
 

--- a/docs/blueprints/common-fields.md
+++ b/docs/blueprints/common-fields.md
@@ -6,7 +6,7 @@ type, and the one decoding rule that applies to all of them.
 ## Unknown keys are an error
 
 > [!IMPORTANT]
-> Blueprints decode strictly, in YAML, JSON and TOML alike. A key the blueprint
+> Blueprints decode strictly, in YAML, JSON, TOML and CUE alike. A key the blueprint
 > type does not define — a misspelled `pacakges:`, a `profile:` that should have
 > been `profiles:` — stops the run with an error naming the file and, for YAML,
 > the line.

--- a/docs/blueprints/files.md
+++ b/docs/blueprints/files.md
@@ -136,7 +136,8 @@ mode. `rwr validate` warns when a mode is set on an action that ignores it.
 ### How to write one
 
 **Write it as a quoted octal string.** `mode: "0644"` means the same thing in
-YAML, JSON and TOML, and needs no thought about how each format reads numbers.
+YAML, JSON, TOML and CUE, and needs no thought about how each format reads
+numbers.
 The `0` and `0o` prefixes are both accepted, as is no prefix at all: `"0644"`,
 `"0o644"` and `"644"` are the same mode.
 

--- a/docs/blueprints/scripts.md
+++ b/docs/blueprints/scripts.md
@@ -4,7 +4,7 @@ The Scripts blueprint allows you to execute scripts as part of the configuration
 
 ## Blueprint Structure
 
-The Scripts blueprint follows the same structure as other blueprints in RWR. It can be defined in YAML, JSON, or TOML format.
+The Scripts blueprint follows the same structure as other blueprints in RWR. It can be defined in YAML, JSON, TOML, or CUE format.
 
 See [Fields Common to Every Blueprint](common-fields.md) for `profiles`,
 `import`, `interactive`, and the rule that an unknown key is an error.

--- a/docs/blueprints/services.md
+++ b/docs/blueprints/services.md
@@ -7,7 +7,7 @@ See [Fields Common to Every Blueprint](common-fields.md) for `profiles`,
 
 ## Blueprint Structure
 
-The Services Blueprint is defined in a YAML, JSON, or TOML file and consists of an array of service objects. Each service object represents a system service and its associated properties.
+The Services Blueprint is defined in a YAML, JSON, TOML, or CUE file and consists of an array of service objects. Each service object represents a system service and its associated properties.
 
 ```yaml
 services:

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -4,3 +4,4 @@
 - [Configuration File](configuration.md) — the `config.yaml` settings, file location, environment variables, and precedence.
 - [Profile CLI Commands](profiles.md) — the `--profile` flag and the `rwr profiles` command.
 - [Validate Command](validate.md) — `rwr validate`: check blueprints and provider configurations before a run.
+- [Convert Command](convert.md) — `rwr convert`: rewrite a blueprint tree between formats or migrate deprecated constructs.

--- a/docs/cli/command-and-flags.md
+++ b/docs/cli/command-and-flags.md
@@ -11,7 +11,7 @@ The following flags are available for all commands:
 | `--config` | Path to the config file, or to a directory holding `config.yaml`. The default is `~/.config/rwr`. See [Configuration File](configuration.md) |
 | `--debug`, `-d` | Enable debug mode for verbose output |
 | `--log-level`, `-l` | Set the log level (debug, info, warn, error) |
-| `--init-file`, `-i` | Path to the init file. A directory is accepted: RWR looks in it for `init.yaml`, `init.yml`, `init.json`, then `init.toml` |
+| `--init-file`, `-i` | Path to the init file. A directory is accepted: RWR looks in it for `init.yaml`, `init.yml`, `init.json`, `init.toml`, then `init.cue` |
 | `--gh-api-key` | Specify the GitHub API key for accessing private repositories |
 | `--ssh-key` | Path to an SSH key file, or a Base64-encoded SSH key, for Git authentication |
 | `--skip-version-check` | Do not check GitHub for a newer release at startup |
@@ -141,6 +141,11 @@ rwr validate path/to/blueprints
 | `--providers` | Check the path as provider configurations |
 | `--verbose` | Show more information about each check |
 
+### `rwr convert`
+
+Convert a blueprint tree between formats, or migrate deprecated constructs.
+See [Convert Command](convert.md).
+
 ### `rwr profiles`
 
 Read the blueprint tree and list every profile it declares, with the number of
@@ -198,8 +203,11 @@ Run the fonts processor.
 > There is no `rwr run directories` command. The `directories` key is part of a
 > files blueprint. Use `rwr run files` to process it.
 >
-> There is no `rwr run all`, and `rwr run` takes one processor, not a list. Use
-> `rwr all` to run everything.
+> `rwr run` takes one processor, not a list. `rwr run all` runs every
+> processor — it is the same run as `rwr all`.
+>
+> Every processor name also works straight off the root, task-runner style:
+> `rwr packages` is `rwr run packages`.
 
 ### `rwr completion`
 

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -40,7 +40,7 @@ The `rwr` section contains general settings for the RWR tool.
 
 | Option | Description |
 |--------|-------------|
-| `configdir` | The config directory: where `config.yaml` is looked up, where `rwr config --create` writes it, and where the `bootstrap` marker lives. The default is `$HOME/.config/rwr`. Because it decides where the config file is, it only takes effect from the environment (`RWR_RWR_CONFIGDIR`) — a config file cannot name its own directory. `--config` overrides it |
+| `configdir` | The config directory: where `config.yaml` is looked up, where `rwr config create` writes it, and where the `bootstrap` marker lives. The default is `$HOME/.config/rwr`. Because it decides where the config file is, it only takes effect from the environment (`RWR_RWR_CONFIGDIR`) — a config file cannot name its own directory. `--config` overrides it |
 | `skipVersionCheck` | Set to `true` to turn off the startup check for a newer release. The `--skip-version-check` flag does the same for a single run |
 
 ### `repository` Section
@@ -85,7 +85,7 @@ RWR reads only the keys listed above.
 You can modify the `config.yaml` file directly using a text editor. Alternatively, you can use the `rwr config` command to interactively create or update the configuration file.
 
 ```bash
-rwr config --create
+rwr config create
 ```
 
 This command will prompt you for the necessary settings and generate the `config.yaml` file based on your input.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,8 @@ RWR's profile system allows you to organize and selectively install packages and
 - [Commands and Flags](cli/command-and-flags.md): Learn about the available commands in the RWR CLI and their respective flags.
 - [Configuration File](cli/configuration.md): Understand how to configure RWR through the configuration file.
 - [Profile Commands](cli/profiles.md): Profile-specific CLI commands and flags.
+- [Validate Command](cli/validate.md): Check blueprints and provider configurations before a run.
+- [Convert Command](cli/convert.md): Rewrite a blueprint tree between formats or migrate deprecated constructs.
 
 ## The Init File
 
@@ -59,6 +61,11 @@ RWR supports various blueprint types for managing different aspects of your syst
 
 - [Variables and Templating](variables.md): Learn how to use variables and templating in blueprints to make them more dynamic and reusable.
 
+## Run Records
+
+- [Run records](state.md): The journal each run writes, `rwr status` for
+  desired-vs-actual drift, and `rwr uninstall` to reverse recorded runs.
+
 ## Credentials and Schema Versions
 
 - [Credentials](credentials.md): How RWR holds your GitHub token and SSH key, and
@@ -72,6 +79,8 @@ RWR supports various blueprint types for managing different aspects of your syst
 
 ## Extending RWR
 
+- [Package Manager Providers](providers.md): Declarative provider definitions —
+  add or override a package manager without writing Go code.
 - Coming Soon: Adding a New Processor
 
 ## Troubleshooting

--- a/docs/init-file.md
+++ b/docs/init-file.md
@@ -4,9 +4,9 @@ The Init file is the main entry point for your RWR blueprints. It defines the co
 
 ## File Format
 
-The Init file is typically named `init.yaml`, but `init.yml`, `init.json` and
-`init.toml` work as well. RWR supports YAML, JSON, and TOML formats for the Init
-file.
+The Init file is typically named `init.yaml`, but `init.yml`, `init.json`,
+`init.toml` and `init.cue` work as well. RWR supports YAML, JSON, TOML, and CUE
+formats for the Init file.
 
 ## File Location
 
@@ -47,7 +47,7 @@ The `blueprints` section defines the configuration settings for your blueprints.
 
 | Field | Description | Required |
 |-------|-------------|----------|
-| `format` | The format of the blueprint files (yaml, json, toml) | Yes |
+| `format` | The format of the blueprint files (yaml, json, toml, cue) | Yes |
 | `location` | The directory where the blueprint files are located | No (default: current directory) |
 | `order` | The order of the blueprint types | No. The default is a fixed order. See [Blueprints General](blueprints-general.md) |
 | `git` | Git repository settings for managing blueprints | No |

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -352,7 +352,7 @@ git:
 
 ## Multi-Format Examples
 
-RWR supports YAML, JSON, and TOML formats for all configurations. Here are the same profile examples in different formats:
+RWR supports YAML, JSON, TOML, and CUE formats for all configurations. Here are the same profile examples in different formats:
 
 ### YAML Format
 

--- a/internal/helpers/format_registry.go
+++ b/internal/helpers/format_registry.go
@@ -84,5 +84,5 @@ func CanonicalFormat(format string) (string, error) {
 	if canonical, ok := formatByExtension["."+strings.TrimPrefix(f, ".")]; ok {
 		return canonical, nil
 	}
-	return "", fmt.Errorf("unsupported blueprint format %q; supported formats are yaml, json, toml", format)
+	return "", fmt.Errorf("unsupported blueprint format %q; supported formats are yaml, json, toml, cue", format)
 }


### PR DESCRIPTION
The README's feature list predated most of this year: "YAML, JSON, or TOML" (CUE landed in #214), "TOML-based provider configurations" (providers are CUE-authored since #216–#218), and nothing about multi-config repos, the dashboard, run records, `status`/`uninstall`, managed credentials, `convert`, or the task-runner CLI. Every claim in the rewrite was verified against `cmd/` and `internal/` first — nothing is aspirational.

- **README**: features list rewritten (verified bullet by bullet), Getting Started uses `rwr config create` (not the deprecated flag) and the `owner/repo` init shorthand, docs index includes `state.md`/`credentials.md`/`convert.md`/`common-fields.md`, CI section matches the actual workflow jobs, specs list includes `state-tracking`.
- **docs sweep**: the two systemic staleness patterns fixed everywhere they appear — three-format claims and pre-CUE provider-authoring claims — plus the false "there is no `rwr run all`" note removed, `init.cue` added to discovery docs, `docs/index.md` gains the pages that were linked nowhere.
- **One code truth-fix found in passing**: the unsupported-format error message now names cue.

Left alone deliberately: lines describing three-format *examples* (they accurately describe what's shown), and the examples CI wording (the cross-check genuinely covers three formats).

Commits unsigned — signing key hardware unavailable this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)