### PR TITLE
feat(cli): rwr diff — machine drift as blueprint material

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -36,7 +36,7 @@ redacted), "rwr config edit" opens it in $VISUAL/$EDITOR, and
 			if err != nil {
 				return err
 			}
-			cmd.Print(rendered)
+			helpers.Say(cmd.OutOrStdout(), "%s", rendered)
 			return nil
 		},
 	}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/fynxlabs/rwr/internal/diff"
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/processors"
+	"github.com/fynxlabs/rwr/internal/scan"
+	"github.com/fynxlabs/rwr/internal/state"
+	"github.com/fynxlabs/rwr/internal/system"
+	"github.com/fynxlabs/rwr/internal/types"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"golang.org/x/term"
+)
+
+// newDiffCmd is wiring; comparison and routing live in internal/diff.
+func newDiffCmd(app *AppConfig) *cobra.Command {
+	var (
+		format     string
+		into       string
+		categories = map[string]*bool{}
+	)
+
+	diffCmd := &cobra.Command{
+		Use:   "diff",
+		Short: "Show machine drift as blueprint material",
+		Long: `Compare what is actually on this machine — explicitly-installed packages,
+enabled services, git checkouts, configs — against the blueprint tree.
+Additions are things you did by hand; removals are declared things that are
+gone. Output as a readable list, paste-ready blueprint blocks (--format), or
+routed interactively into the tree (--into). Diff never touches the system.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			machine := scanMachine(scoped(categories))
+
+			plan, err := processors.ResolveStage1(app.InitConfig)
+			if err != nil {
+				return err
+			}
+			processors.ResolveStage2(plan)
+			records, err := state.LoadAll(viper.GetString("rwr.configdir"))
+			if err != nil {
+				return err
+			}
+
+			changes := diff.Compute(machine, plan, records)
+			changes = filterCategories(changes, scoped(categories))
+
+			switch {
+			case into != "":
+				if !term.IsTerminal(int(os.Stdin.Fd())) {
+					return fmt.Errorf("--into needs a terminal for the destination picks; use --format for the non-interactive path")
+				}
+				return routeInteractively(cmd, changes, into)
+			case format != "":
+				canonical, err := helpers.CanonicalFormat(format)
+				if err != nil {
+					return err
+				}
+				blocks, err := diff.EmitBlocks(changes, machine, canonical)
+				if err != nil {
+					return err
+				}
+				helpers.Say(cmd.OutOrStdout(), "%s", blocks)
+				return nil
+			default:
+				helpers.Say(cmd.OutOrStdout(), "%s", diff.Render(changes))
+				return nil
+			}
+		},
+	}
+
+	diffCmd.Flags().StringVar(&format, "format", "", "Emit additions as paste-ready blueprint blocks: yaml, json, toml, or cue")
+	diffCmd.Flags().StringVar(&into, "into", "", "Route additions into this blueprint tree interactively")
+	for _, category := range []string{"packages", "configs", "services", "git"} {
+		categories[category] = diffCmd.Flags().Bool(category, false, "Only the "+category+" category")
+	}
+	return diffCmd
+}
+
+// scanMachine gathers the scanned side, scoped to the asked-for categories.
+func scanMachine(only map[string]bool) diff.Machine {
+	home, _ := os.UserHomeDir() //nolint:errcheck // empty home just disables home-templating
+	machine := diff.Machine{Home: home}
+	all := len(only) == 0
+	if all || only["packages"] {
+		machine.Packages = scan.Packages(system.GetAvailableProviders())
+	}
+	if all || only["services"] {
+		machine.Services = scan.Services()
+	}
+	if all || only["git"] {
+		machine.Git = scan.GitCheckouts([]string{home + "/git"})
+	}
+	if all || only["configs"] {
+		machine.Configs = scan.Configs(home, false)
+	}
+	return machine
+}
+
+// scoped collects the set category flags; empty means all.
+func scoped(categories map[string]*bool) map[string]bool {
+	only := map[string]bool{}
+	for name, set := range categories {
+		if *set {
+			only[name] = true
+		}
+	}
+	return only
+}
+
+// filterCategories drops changes outside the asked-for categories.
+func filterCategories(changes []diff.Change, only map[string]bool) []diff.Change {
+	if len(only) == 0 {
+		return changes
+	}
+	alias := map[string]string{types.BlueprintTypeFiles: "configs"}
+	var kept []diff.Change
+	for _, change := range changes {
+		name := change.Category
+		if a, ok := alias[name]; ok {
+			name = a
+		}
+		if only[name] {
+			kept = append(kept, change)
+		}
+	}
+	return kept
+}

--- a/cmd/diff_route.go
+++ b/cmd/diff_route.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"fmt"
+
+	"charm.land/huh/v2"
+	"github.com/fynxlabs/rwr/internal/diff"
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/types"
+	"github.com/spf13/cobra"
+)
+
+// routeInteractively asks, per change group, where the additions land — a
+// destination the tree itself offers, or skip — and writes the accepted
+// edits. Machine-specific versus Common is the operator's call; rwr's job
+// is to make it once per group.
+func routeInteractively(cmd *cobra.Command, changes []diff.Change, tree string) error {
+	out := cmd.OutOrStdout()
+
+	byGroup := map[string][]diff.Change{}
+	for _, change := range changes {
+		if change.Removal {
+			continue // removals are reported, never auto-deleted from blueprints
+		}
+		switch change.Category {
+		case types.BlueprintTypePackages, types.BlueprintTypeServices:
+			byGroup[change.Category+"\x00"+change.Provider] = append(byGroup[change.Category+"\x00"+change.Provider], change)
+		}
+	}
+	if len(byGroup) == 0 {
+		helpers.Say(out, "Nothing routable: only packages and services route today; use --format for the rest.\n")
+		return nil
+	}
+
+	routed := 0
+	for key, group := range byGroup {
+		category := group[0].Category
+		destinations, err := diff.Destinations(tree, category)
+		if err != nil {
+			helpers.Say(out, "skip %s: %v\n", key, err)
+			continue
+		}
+
+		names := make([]string, 0, len(group))
+		for _, change := range group {
+			names = append(names, change.Name)
+		}
+		title := fmt.Sprintf("%s: %d addition(s)", category, len(names))
+		if group[0].Provider != "" {
+			title = fmt.Sprintf("%s (%s): %d addition(s)", category, group[0].Provider, len(names))
+		}
+
+		options := make([]huh.Option[string], 0, len(destinations)+1)
+		for _, destination := range destinations {
+			options = append(options, huh.NewOption(destination, destination))
+		}
+		options = append(options, huh.NewOption("skip", ""))
+
+		var destination string
+		form := huh.NewForm(huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(title).
+				Description(fmt.Sprintf("%v", names)).
+				Options(options...).
+				Value(&destination),
+		))
+		if err := form.Run(); err != nil {
+			return err
+		}
+		if destination == "" {
+			continue
+		}
+
+		var entries []map[string]interface{}
+		switch category {
+		case types.BlueprintTypePackages:
+			entries = diff.PackageEntries(group[0].Provider, names)
+		case types.BlueprintTypeServices:
+			entries = diff.ServiceEntries(names)
+		}
+		if err := diff.AppendEntries(destination, category, entries); err != nil {
+			return err
+		}
+		helpers.Say(out, "wrote %d entr(ies) to %s\n", len(entries), destination)
+		routed++
+	}
+	if routed > 0 {
+		helpers.Say(out, "Run `rwr validate` over the tree, review the diff, and commit.\n")
+	}
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -126,6 +126,7 @@ git checkouts, scripts, and desktop configuration.`,
 	rootCmd.AddCommand(newConvertCmd())
 	rootCmd.AddCommand(newStatusCmd(app))
 	rootCmd.AddCommand(newUninstallCmd(app))
+	rootCmd.AddCommand(newDiffCmd(app))
 
 	return rootCmd
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/fynxlabs/rwr/internal/helpers"
 	"github.com/fynxlabs/rwr/internal/processors"
 	"github.com/fynxlabs/rwr/internal/state"
 	"github.com/fynxlabs/rwr/internal/status"
@@ -30,7 +31,7 @@ mutates and never elevates. Exits 1 on drift.`,
 				return err
 			}
 			rows := status.Rows(plan, records, status.NewQuerier())
-			cmd.Print(status.Render(rows, len(records) > 0))
+			helpers.Say(cmd.OutOrStdout(), "%s", status.Render(rows, len(records) > 0))
 			if status.Drifted(rows) {
 				return fmt.Errorf("drift detected")
 			}

--- a/docs/cli/diff.md
+++ b/docs/cli/diff.md
@@ -1,0 +1,30 @@
+# rwr diff
+
+Compare what is actually on the machine against the blueprint tree, and get
+the delta as blueprint material — never an apply.
+
+The machine side comes from read-only scans: explicitly-installed packages
+per provider (`pacman -Qe`, `apt-mark showmanual`, …), operator-enabled
+services, git checkouts, and configs. The tree side is the resolved plan.
+Packages the [run journal](../state.md) shows a run applied never report as
+hand-added — the tree may have changed since, but you didn't install them.
+
+```bash
+# The readable list: + additions (hand-done), - removals (declared, gone)
+rwr diff
+
+# One category
+rwr diff --packages
+
+# Paste-ready blueprint blocks
+rwr diff --packages --format cue
+
+# Route additions into a tree interactively: per group, pick the machine
+# file, a Common file the tree imports, or skip
+rwr diff --into ~/git/thefynx/rwr-blueprints/Archcraft
+```
+
+`--into` needs a terminal; `--format` is the non-interactive path. Routed
+edits are written in the destination file's own format — run
+`rwr validate`, review, commit. Removals are reported but never
+auto-deleted from blueprints.

--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -4,17 +4,12 @@
 package convert
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/BurntSushi/toml"
 	"github.com/fynxlabs/rwr/internal/helpers"
-	"gopkg.in/yaml.v3"
 )
 
 // Run walks root and converts every blueprint, init, bootstrap, and manifest
@@ -72,8 +67,8 @@ func Run(out io.Writer, root, toFormat string, migrate, write bool) error {
 		}
 
 		if toFormat != "" && toFormat != format {
-			target := strings.TrimSuffix(path, filepath.Ext(path)) + extensionFor(toFormat)
-			encoded, encErr := encodeAs(doc, toFormat)
+			target := strings.TrimSuffix(path, filepath.Ext(path)) + helpers.BlueprintExtension(toFormat)
+			encoded, encErr := helpers.EncodeBlueprintDoc(doc, toFormat)
 			if encErr != nil {
 				helpers.Say(out, "  ! %s: cannot encode as %s: %v\n", path, toFormat, encErr)
 				return nil
@@ -118,7 +113,7 @@ func migrateInitInlineSections(out io.Writer, initPath string, doc map[string]in
 			continue
 		}
 		targetDir := filepath.Join(root, dir)
-		target := filepath.Join(targetDir, "from-init"+extensionFor(format))
+		target := filepath.Join(targetDir, "from-init"+helpers.BlueprintExtension(format))
 		helpers.Say(out, "  → %s: move %q into %s\n", initPath, key, target)
 		if write {
 			if err := os.MkdirAll(targetDir, 0o755); err != nil { // #nosec G301 -- operator's own blueprint tree
@@ -132,7 +127,7 @@ func migrateInitInlineSections(out io.Writer, initPath string, doc map[string]in
 					payload = current
 				}
 			}
-			encoded, err := encodeAs(payload, format)
+			encoded, err := helpers.EncodeBlueprintDoc(payload, format)
 			if err != nil {
 				return moved, err
 			}
@@ -140,7 +135,7 @@ func migrateInitInlineSections(out io.Writer, initPath string, doc map[string]in
 				return moved, err
 			}
 			delete(doc, key)
-			rewritten, err := encodeAs(doc, format)
+			rewritten, err := helpers.EncodeBlueprintDoc(doc, format)
 			if err != nil {
 				return moved, err
 			}
@@ -151,42 +146,6 @@ func migrateInitInlineSections(out io.Writer, initPath string, doc map[string]in
 		moved++
 	}
 	return moved, nil
-}
-
-// encodeAs renders a document in a target format. CUE output is JSON-form
-// CUE: valid, lossless, mechanical — idiomatic CUE is authoring work.
-func encodeAs(doc map[string]interface{}, format string) ([]byte, error) {
-	switch format {
-	case "yaml":
-		return yaml.Marshal(doc)
-	case "json":
-		var buf bytes.Buffer
-		enc := json.NewEncoder(&buf)
-		enc.SetIndent("", "  ")
-		if err := enc.Encode(doc); err != nil {
-			return nil, err
-		}
-		return buf.Bytes(), nil
-	case "toml":
-		var buf bytes.Buffer
-		if err := toml.NewEncoder(&buf).Encode(doc); err != nil {
-			return nil, err
-		}
-		return buf.Bytes(), nil
-	case "cue":
-		var buf bytes.Buffer
-		enc := json.NewEncoder(&buf)
-		enc.SetIndent("", "\t")
-		if err := enc.Encode(doc); err != nil {
-			return nil, err
-		}
-		return buf.Bytes(), nil
-	}
-	return nil, fmt.Errorf("unsupported target format %q", format)
-}
-
-func extensionFor(format string) string {
-	return "." + format
 }
 
 // hasComments detects comment markers well enough to warn (never to block).

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,190 @@
+// Package diff compares the system scan against the resolved blueprint
+// tree: what is on the machine that the tree does not declare, and what the
+// tree declares that is gone. Its output is blueprint material — a list, a
+// paste-ready block, or a routed edit — never an apply.
+package diff
+
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/fynxlabs/rwr/internal/scan"
+	"github.com/fynxlabs/rwr/internal/state"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// Change is one drift item.
+type Change struct {
+	Category string // packages, services, git, configs
+	Provider string // packages only
+	Name     string
+	Removal  bool // declared in the tree, gone from the machine
+}
+
+// Machine is the scanned side, gathered once by the caller.
+type Machine struct {
+	Packages []scan.PackageResult
+	Services []string
+	Git      []scan.GitCheckout
+	Configs  []scan.ConfigResult
+	Home     string
+}
+
+// Compute joins machine, tree, and journal. A package the journal shows a
+// run applied is not hand-added, whatever the current tree says — the tree
+// may have changed since the apply.
+func Compute(machine Machine, plan *types.Plan, records []*state.RecordFile) []Change {
+	desired := map[string]map[string]bool{} // category → name set
+	for _, resource := range plan.Resources {
+		category := resource.Processor
+		if desired[category] == nil {
+			desired[category] = map[string]bool{}
+		}
+		desired[category][resource.Name] = true
+	}
+	applied := map[string]bool{} // "category\x00name" the journal accounts for
+	for _, ref := range state.LatestApplies(records) {
+		entry := ref.Entry()
+		applied[entry.Processor+"\x00"+entry.Identity["name"]] = true
+	}
+
+	var changes []Change
+	add := func(category, provider, name string) {
+		if desired[category][name] || applied[category+"\x00"+name] {
+			return
+		}
+		changes = append(changes, Change{Category: category, Provider: provider, Name: name})
+	}
+
+	scannedPackages := map[string]bool{}
+	for _, result := range machine.Packages {
+		for _, name := range result.Names {
+			scannedPackages[name] = true
+			add(types.BlueprintTypePackages, result.Provider, name)
+		}
+	}
+	for name := range desired[types.BlueprintTypePackages] {
+		if !scannedPackages[name] {
+			changes = append(changes, Change{Category: types.BlueprintTypePackages, Name: name, Removal: true})
+		}
+	}
+
+	scannedServices := map[string]bool{}
+	for _, service := range machine.Services {
+		scannedServices[service] = true
+		add(types.BlueprintTypeServices, "", service)
+	}
+	for name := range desired[types.BlueprintTypeServices] {
+		if !scannedServices[name] {
+			changes = append(changes, Change{Category: types.BlueprintTypeServices, Name: name, Removal: true})
+		}
+	}
+
+	for _, checkout := range machine.Git {
+		add(types.BlueprintTypeGit, "", path.Base(checkout.Path))
+	}
+
+	for _, config := range machine.Configs {
+		add(types.BlueprintTypeFiles, "", path.Base(config.Rel))
+	}
+
+	sort.SliceStable(changes, func(i, j int) bool {
+		a, b := changes[i], changes[j]
+		if a.Category != b.Category {
+			return a.Category < b.Category
+		}
+		if a.Provider != b.Provider {
+			return a.Provider < b.Provider
+		}
+		return a.Name < b.Name
+	})
+	return changes
+}
+
+// Render formats changes as the readable grouped list.
+func Render(changes []Change) string {
+	if len(changes) == 0 {
+		return "No drift: the machine matches the tree.\n"
+	}
+	var b strings.Builder
+	lastGroup := ""
+	for _, change := range changes {
+		group := change.Category
+		if change.Provider != "" {
+			group += " (" + change.Provider + ")"
+		}
+		if group != lastGroup {
+			fmt.Fprintf(&b, "%s:\n", group)
+			lastGroup = group
+		}
+		marker := "+"
+		if change.Removal {
+			marker = "-"
+		}
+		fmt.Fprintf(&b, "  %s %s\n", marker, change.Name)
+	}
+	return b.String()
+}
+
+// EmitBlocks renders the additions as paste-ready blueprint blocks in the
+// given format, one block per category present.
+func EmitBlocks(changes []Change, machine Machine, format string) (string, error) {
+	var out []string
+
+	byProvider := map[string][]string{}
+	var services []string
+	var git []scan.GitCheckout
+	gitByName := map[string]scan.GitCheckout{}
+	for _, checkout := range machine.Git {
+		gitByName[path.Base(checkout.Path)] = checkout
+	}
+	for _, change := range changes {
+		if change.Removal {
+			continue
+		}
+		switch change.Category {
+		case types.BlueprintTypePackages:
+			byProvider[change.Provider] = append(byProvider[change.Provider], change.Name)
+		case types.BlueprintTypeServices:
+			services = append(services, change.Name)
+		case types.BlueprintTypeGit:
+			if checkout, ok := gitByName[change.Name]; ok {
+				git = append(git, checkout)
+			}
+		}
+	}
+
+	if len(byProvider) > 0 {
+		providers := make([]string, 0, len(byProvider))
+		for provider := range byProvider {
+			providers = append(providers, provider)
+		}
+		sort.Strings(providers)
+		var results []scan.PackageResult
+		for _, provider := range providers {
+			results = append(results, scan.PackageResult{Provider: provider, Names: byProvider[provider]})
+		}
+		block, err := scan.EmitPackages(results, format)
+		if err != nil {
+			return "", err
+		}
+		out = append(out, string(block))
+	}
+	if len(services) > 0 {
+		block, err := scan.EmitServices(services, format)
+		if err != nil {
+			return "", err
+		}
+		out = append(out, string(block))
+	}
+	if len(git) > 0 {
+		block, err := scan.EmitGit(git, machine.Home, format)
+		if err != nil {
+			return "", err
+		}
+		out = append(out, string(block))
+	}
+	return strings.Join(out, "\n"), nil
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,141 @@
+package diff
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/scan"
+	"github.com/fynxlabs/rwr/internal/state"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+func machineWith(packages ...string) Machine {
+	return Machine{Packages: []scan.PackageResult{{Provider: "pacman", Names: packages}}}
+}
+
+func planWith(names ...string) *types.Plan {
+	plan := &types.Plan{}
+	for _, name := range names {
+		plan.Resources = append(plan.Resources, types.Resource{
+			Processor: types.BlueprintTypePackages, Name: name,
+		})
+	}
+	return plan
+}
+
+func TestCompute_AdditionsAndRemovals(t *testing.T) {
+	changes := Compute(machineWith("git", "helix"), planWith("git", "vim"), nil)
+
+	byName := map[string]Change{}
+	for _, change := range changes {
+		byName[change.Name] = change
+	}
+	if change, ok := byName["helix"]; !ok || change.Removal || change.Provider != "pacman" {
+		t.Fatalf("helix = %+v, want a pacman addition", change)
+	}
+	if change, ok := byName["vim"]; !ok || !change.Removal {
+		t.Fatalf("vim = %+v, want a removal", change)
+	}
+	if _, ok := byName["git"]; ok {
+		t.Fatal("declared and present package reported as drift")
+	}
+}
+
+// A package the journal shows a run applied is not hand-added, whatever the
+// current tree says.
+func TestCompute_JournalAppliedIsNotDrift(t *testing.T) {
+	record := &state.RecordFile{Path: "r", Record: &state.Record{Entries: []state.Entry{{
+		Processor: types.BlueprintTypePackages, OK: true, Outcome: "ok",
+		Identity: map[string]string{"provider": "pacman", "name": "helix"},
+	}}}}
+	changes := Compute(machineWith("helix"), planWith(), []*state.RecordFile{record})
+	for _, change := range changes {
+		if change.Name == "helix" && !change.Removal {
+			t.Fatalf("journal-applied package reported as addition: %+v", change)
+		}
+	}
+}
+
+func TestEmitBlocks_StrictDecodes(t *testing.T) {
+	machine := machineWith("helix")
+	changes := Compute(machine, planWith(), nil)
+	block, err := EmitBlocks(changes, machine, "cue")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var d types.PackagesData
+	if err := helpers.DecodeBlueprintInto([]byte(block), "json", types.BlueprintTypePackages, 0, &d); err != nil {
+		t.Fatalf("emitted block does not strict-decode: %v\n%s", err, block)
+	}
+}
+
+func fixtureTree(t *testing.T) string {
+	t.Helper()
+	tree := t.TempDir()
+	common := filepath.Join(tree, "..", "Common", "packages")
+	if err := os.MkdirAll(common, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(common, "base.yaml"), []byte("packages:\n- name: git\n  action: install\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pkgDir := filepath.Join(tree, "packages")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	main := "packages:\n- import: ../../Common/packages/base.yaml\n- name: vim\n  action: install\n"
+	if err := os.WriteFile(filepath.Join(pkgDir, "pacman.yaml"), []byte(main), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return tree
+}
+
+// Destination discovery offers the tree's own file and the Common file it
+// imports.
+func TestDestinations_IncludeImports(t *testing.T) {
+	tree := fixtureTree(t)
+	destinations, err := Destinations(tree, types.BlueprintTypePackages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(destinations, "\n")
+	if !strings.Contains(joined, "pacman.yaml") || !strings.Contains(joined, "base.yaml") {
+		t.Fatalf("destinations = %v", destinations)
+	}
+}
+
+// Appending writes the destination file's own format and the result
+// strict-decodes and keeps existing entries.
+func TestAppendEntries(t *testing.T) {
+	tree := fixtureTree(t)
+	destination := filepath.Join(tree, "packages", "pacman.yaml")
+	if err := AppendEntries(destination, types.BlueprintTypePackages, PackageEntries("pacman", []string{"helix"})); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var d types.PackagesData
+	if err := helpers.DecodeBlueprintInto(data, "yaml", types.BlueprintTypePackages, 0, &d); err != nil {
+		t.Fatalf("appended file does not strict-decode: %v\n%s", err, data)
+	}
+	names := map[string]bool{}
+	for _, pkg := range d.Packages {
+		names[pkg.Name] = true
+		for _, n := range pkg.Names {
+			names[n] = true
+		}
+		if pkg.Import != "" {
+			names["<import>"] = true
+		}
+	}
+	for _, want := range []string{"vim", "helix", "<import>"} {
+		if !names[want] {
+			t.Fatalf("missing %s after append: %+v", want, d.Packages)
+		}
+	}
+}

--- a/internal/diff/route.go
+++ b/internal/diff/route.go
@@ -1,0 +1,153 @@
+package diff
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// categoryDirs maps a change category to the tree directories its blueprints
+// conventionally live in.
+var categoryDirs = map[string][]string{
+	types.BlueprintTypePackages: {"packages"},
+	types.BlueprintTypeServices: {"services"},
+	types.BlueprintTypeGit:      {"git"},
+	types.BlueprintTypeFiles:    {"files"},
+}
+
+// Destinations discovers where a category's entries can land: the tree's own
+// blueprint files for that category, plus any file those blueprints import
+// (the Common files a shared tree pulls in). rwr cannot know whether a change
+// is machine-specific or shared; it can only surface the real candidates.
+func Destinations(tree, category string) ([]string, error) {
+	seen := map[string]bool{}
+	var destinations []string
+	for _, dir := range categoryDirs[category] {
+		entries, err := os.ReadDir(filepath.Join(tree, dir))
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !helpers.IsBlueprintFile(entry.Name()) {
+				continue
+			}
+			path := filepath.Join(tree, dir, entry.Name())
+			if !seen[path] {
+				seen[path] = true
+				destinations = append(destinations, path)
+			}
+			for _, imported := range importTargets(path) {
+				if !seen[imported] {
+					seen[imported] = true
+					destinations = append(destinations, imported)
+				}
+			}
+		}
+	}
+	sort.Strings(destinations)
+	if len(destinations) == 0 {
+		return nil, fmt.Errorf("no %s blueprint files found under %s", category, tree)
+	}
+	return destinations, nil
+}
+
+// importTargets resolves the files a blueprint imports, file-relative.
+func importTargets(path string) []string {
+	data, err := os.ReadFile(path) // #nosec G304 -- operator's own blueprint tree
+	if err != nil {
+		return nil
+	}
+	format, err := helpers.FormatForPath(path)
+	if err != nil {
+		return nil
+	}
+	var doc map[string]interface{}
+	if err := helpers.UnmarshalBlueprint(data, format, &doc); err != nil {
+		return nil
+	}
+	var targets []string
+	for _, value := range doc {
+		entries, ok := value.([]interface{})
+		if !ok {
+			continue
+		}
+		for _, raw := range entries {
+			entry, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if imported, ok := entry["import"].(string); ok && imported != "" {
+				resolved := filepath.Join(filepath.Dir(path), imported)
+				if _, err := os.Stat(resolved); err == nil {
+					targets = append(targets, resolved)
+				}
+			}
+		}
+	}
+	return targets
+}
+
+// AppendEntries appends blueprint entries under the category's key in the
+// destination file, in that file's own format, and rewrites it.
+func AppendEntries(destination, category string, entries []map[string]interface{}) error {
+	data, err := os.ReadFile(destination) // #nosec G304 -- operator-chosen destination inside their own tree
+	if err != nil {
+		return err
+	}
+	format, err := helpers.FormatForPath(destination)
+	if err != nil {
+		return err
+	}
+	var doc map[string]interface{}
+	if err := helpers.UnmarshalBlueprint(data, format, &doc); err != nil {
+		return fmt.Errorf("%s does not parse: %w", destination, err)
+	}
+
+	key := categoryKey(category)
+	var existing []interface{}
+	if current, ok := doc[key].([]interface{}); ok {
+		existing = current
+	}
+	for _, entry := range entries {
+		existing = append(existing, entry)
+	}
+	doc[key] = existing
+
+	encoded, err := helpers.EncodeBlueprintDoc(doc, format)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(destination, encoded, 0o644) // #nosec G306 -- blueprint files are world-readable config
+}
+
+// categoryKey is the top-level blueprint key for a category.
+func categoryKey(category string) string {
+	if category == types.BlueprintTypeSSHKeys {
+		return "ssh_keys"
+	}
+	return strings.ToLower(category)
+}
+
+// PackageEntries builds the entries AppendEntries takes for a provider's
+// added packages.
+func PackageEntries(provider string, names []string) []map[string]interface{} {
+	return []map[string]interface{}{{
+		"names":           names,
+		"action":          "install",
+		"package_manager": provider,
+	}}
+}
+
+// ServiceEntries builds service enable entries.
+func ServiceEntries(names []string) []map[string]interface{} {
+	entries := make([]map[string]interface{}, 0, len(names))
+	for _, name := range names {
+		entries = append(entries, map[string]interface{}{"name": name, "action": "enable"})
+	}
+	return entries
+}

--- a/internal/helpers/blueprint_encode.go
+++ b/internal/helpers/blueprint_encode.go
@@ -1,0 +1,47 @@
+package helpers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/BurntSushi/toml"
+	"gopkg.in/yaml.v3"
+)
+
+// EncodeBlueprintDoc renders a document in a target format. CUE output is JSON-form
+// CUE: valid, lossless, mechanical — idiomatic CUE is authoring work.
+func EncodeBlueprintDoc(doc map[string]interface{}, format string) ([]byte, error) {
+	switch format {
+	case "yaml":
+		return yaml.Marshal(doc)
+	case "json":
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(doc); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case "toml":
+		var buf bytes.Buffer
+		if err := toml.NewEncoder(&buf).Encode(doc); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case "cue":
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetIndent("", "\t")
+		if err := enc.Encode(doc); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+	return nil, fmt.Errorf("unsupported target format %q", format)
+}
+
+// BlueprintExtension is the filename extension for a registry format.
+func BlueprintExtension(format string) string {
+	return "." + format
+}

--- a/internal/scan/configs.go
+++ b/internal/scan/configs.go
@@ -1,0 +1,93 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ConfigResult is one discovered config: a known dotfile or a ~/.config
+// entry.
+type ConfigResult struct {
+	Path  string // absolute
+	Rel   string // relative to home, the identity a blueprint uses
+	Known bool   // in the known-dotfile set (pre-selected by consumers)
+}
+
+// knownDotfiles is the set worth pre-selecting: the files people mean when
+// they say "my dotfiles".
+var knownDotfiles = []string{
+	".bashrc", ".bash_profile", ".zshrc", ".zprofile", ".profile",
+	".aliases", ".exports", ".functions", ".path",
+	".gitconfig", ".gitignore", ".gitignore_global",
+	".vimrc", ".tmux.conf", ".inputrc", ".editorconfig",
+}
+
+// configNoise names the ~/.config entries that are cache, state, or session
+// plumbing — shown only with includeAll. The human selects from what is
+// shown, so what is shown must be worth reading.
+var configNoise = map[string]bool{
+	"pulse": true, "dconf": true, "ibus": true, "gtk-2.0": true,
+	"session": true, "systemd": true, "autostart": true, "Trash": true,
+	"cache": true, "chromium": true, "google-chrome": true, "BraveSoftware": true,
+	"Slack": true, "discord": true, "Electron": true, "Code": true,
+	"pipewire-media-session": true, "pipewire": true, "dbus": true,
+	"enchant": true, "goa-1.0": true, "evolution": true, "gnome-session": true,
+}
+
+// secretShaped reports paths that must never be pre-selected: key material
+// travels by keyring or by hand, not by blueprint capture.
+func secretShaped(rel string) bool {
+	if strings.HasPrefix(rel, ".ssh/") || rel == ".ssh" {
+		return true
+	}
+	for _, marker := range []string{".gnupg", "private", "id_rsa", "id_ed25519", ".netrc", "credentials"} {
+		if strings.Contains(strings.ToLower(rel), marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// SecretShaped is the exported check consumers use to refuse pre-selection
+// and warn on explicit selection.
+func SecretShaped(rel string) bool { return secretShaped(rel) }
+
+// Configs reports the known dotfiles present in home plus the top-level
+// ~/.config entries, minus the noise list unless includeAll is set.
+func Configs(home string, includeAll bool) []ConfigResult {
+	var results []ConfigResult
+
+	for _, name := range knownDotfiles {
+		path := filepath.Join(home, name)
+		if _, err := os.Stat(path); err == nil {
+			results = append(results, ConfigResult{Path: path, Rel: name, Known: true})
+		}
+	}
+
+	configDir := filepath.Join(home, ".config")
+	entries, err := os.ReadDir(configDir)
+	if err != nil {
+		return results
+	}
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if !includeAll && configNoise[name] {
+			continue
+		}
+		rel := filepath.Join(".config", name)
+		if !includeAll && secretShaped(rel) {
+			continue
+		}
+		results = append(results, ConfigResult{
+			Path: filepath.Join(configDir, name),
+			Rel:  rel,
+		})
+	}
+	return results
+}

--- a/internal/scan/emit.go
+++ b/internal/scan/emit.go
@@ -1,0 +1,78 @@
+package scan
+
+import (
+	"path"
+
+	"github.com/fynxlabs/rwr/internal/helpers"
+)
+
+// EmitPackages renders package results as a packages blueprint block in the
+// given registry format. The block strict-decodes against the blueprint
+// schema — emission that produces invalid blueprints is worse than a list.
+func EmitPackages(results []PackageResult, format string) ([]byte, error) {
+	var entries []interface{}
+	for _, result := range results {
+		entries = append(entries, map[string]interface{}{
+			"names":           result.Names,
+			"action":          "install",
+			"package_manager": result.Provider,
+		})
+	}
+	return helpers.EncodeBlueprintDoc(map[string]interface{}{"packages": entries}, format)
+}
+
+// EmitGit renders discovered checkouts as a git blueprint block; paths under
+// home render portable via the User.home template.
+func EmitGit(checkouts []GitCheckout, home, format string) ([]byte, error) {
+	var entries []interface{}
+	for _, checkout := range checkouts {
+		if checkout.URL == "" {
+			continue
+		}
+		entries = append(entries, map[string]interface{}{
+			"name":   path.Base(checkout.Path),
+			"action": "clone",
+			"url":    checkout.URL,
+			"path":   templatedHome(checkout.Path, home),
+		})
+	}
+	return helpers.EncodeBlueprintDoc(map[string]interface{}{"git": entries}, format)
+}
+
+// EmitServices renders enabled units as a services blueprint block.
+func EmitServices(services []string, format string) ([]byte, error) {
+	var entries []interface{}
+	for _, service := range services {
+		entries = append(entries, map[string]interface{}{
+			"name":   service,
+			"action": "enable",
+		})
+	}
+	return helpers.EncodeBlueprintDoc(map[string]interface{}{"services": entries}, format)
+}
+
+// EmitConfigs renders selected configs as file entries whose source is the
+// captured copy under files/src/ and whose target is the origin, portable
+// via the User.home template.
+func EmitConfigs(configs []ConfigResult, home, format string) ([]byte, error) {
+	var entries []interface{}
+	for _, config := range configs {
+		entries = append(entries, map[string]interface{}{
+			"name":   path.Base(config.Rel),
+			"action": "copy",
+			"source": "src/" + config.Rel,
+			"target": templatedHome(path.Dir(config.Path), home) + "/",
+		})
+	}
+	return helpers.EncodeBlueprintDoc(map[string]interface{}{"files": entries}, format)
+}
+
+// templatedHome rewrites an absolute path under home as a User.home
+// template, so the emitted blueprint works on a machine with another
+// username.
+func templatedHome(p, home string) string {
+	if home != "" && len(p) >= len(home) && p[:len(home)] == home {
+		return "{{ .User.home }}" + p[len(home):]
+	}
+	return p
+}

--- a/internal/scan/packages.go
+++ b/internal/scan/packages.go
@@ -1,0 +1,92 @@
+// Package scan answers "what did the operator put on this machine" — the
+// shared harvest layer under `rwr diff` and `rwr capture`. Scanners are
+// read-only and never elevate: they execute only provider list verbs and
+// read files and unit states.
+package scan
+
+import (
+	"os/exec"
+	"sort"
+	"strings"
+
+	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// PackageResult is one provider's operator-chosen package set. Unfiltered
+// marks a provider without a list_explicit verb: the full list, dependency
+// noise included, because pretending otherwise would be a lie.
+type PackageResult struct {
+	Provider   string
+	Names      []string
+	Unfiltered bool
+}
+
+// Packages scans every given provider, preferring the explicitly-installed
+// query over the full list.
+func Packages(providers map[string]*types.Provider) []PackageResult {
+	names := make([]string, 0, len(providers))
+	for name := range providers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var results []PackageResult
+	for _, name := range names {
+		provider := providers[name]
+		command := provider.Commands.ListExplicit
+		unfiltered := false
+		if command == "" {
+			command = provider.Commands.List
+			unfiltered = true
+		}
+		if command == "" {
+			continue
+		}
+		packages := RunListCommand(provider, command)
+		if packages == nil {
+			continue
+		}
+		results = append(results, PackageResult{Provider: name, Names: packages, Unfiltered: unfiltered})
+	}
+	return results
+}
+
+// RunListCommand executes a provider's list-class verb read-only and returns
+// the first-column names, nil on failure. Some verbs name a different binary
+// entirely (apt's explicit query is `apt-mark showmanual`); the first field
+// decides what actually runs — the same dispatch the status querier uses.
+func RunListCommand(provider *types.Provider, command string) []string {
+	fields := strings.Fields(command)
+	bin := provider.BinPath
+	args := fields
+	if len(fields) > 0 {
+		if path, err := exec.LookPath(fields[0]); err == nil && fields[0] != provider.Name {
+			bin, args = path, fields[1:]
+		}
+	}
+	out, err := exec.Command(bin, args...).Output() // #nosec G204 -- provider definitions are rwr's own vetted data; list verbs are read-only
+	if err != nil {
+		log.Debugf("scan: %s list failed: %v", provider.Name, err)
+		return nil
+	}
+	var names []string
+	seen := map[string]bool{}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		name := fields[0]
+		// dpkg emits "name:arch"; cargo emits "name v1.2.3:"; strip both.
+		if i := strings.IndexByte(name, ':'); i > 0 {
+			name = name[:i]
+		}
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	return names
+}

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -1,0 +1,178 @@
+package scan
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+func fakeProvider(t *testing.T, name, script string) *types.Provider {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "fakelist")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"+script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return &types.Provider{Name: name, BinPath: bin}
+}
+
+// The explicit query wins over the full list, and its absence is marked.
+func TestPackages_ExplicitPreferred(t *testing.T) {
+	p := fakeProvider(t, "fake", `case "$1" in explicit) printf 'chosen\n';; all) printf 'chosen\ndep1\ndep2\n';; esac`)
+	p.Commands.List = "all"
+	p.Commands.ListExplicit = "explicit"
+
+	results := Packages(map[string]*types.Provider{"fake": p})
+	if len(results) != 1 || results[0].Unfiltered {
+		t.Fatalf("results = %+v", results)
+	}
+	if len(results[0].Names) != 1 || results[0].Names[0] != "chosen" {
+		t.Fatalf("names = %v, want the explicit set", results[0].Names)
+	}
+
+	p.Commands.ListExplicit = ""
+	results = Packages(map[string]*types.Provider{"fake": p})
+	if !results[0].Unfiltered || len(results[0].Names) != 3 {
+		t.Fatalf("fallback = %+v, want the full set marked unfiltered", results[0])
+	}
+}
+
+// A scan executes only list verbs — a provider whose other commands are
+// traps proves it.
+func TestPackages_OnlyListVerbsRun(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "mutated")
+	trap := filepath.Join(dir, "trap")
+	if err := os.WriteFile(trap, []byte("#!/bin/sh\ncase \"$1\" in list) printf 'x\\n';; *) touch "+marker+";; esac\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := &types.Provider{Name: "trap", BinPath: trap}
+	p.Commands.List = "list"
+	p.Commands.Install = "install"
+	p.Commands.Remove = "remove"
+
+	Packages(map[string]*types.Provider{"trap": p})
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatal("scan executed a non-list command")
+	}
+}
+
+func TestConfigs_KnownNoiseAndSecrets(t *testing.T) {
+	home := t.TempDir()
+	for _, p := range []string{".bashrc", ".config/helix/config.toml", ".config/pulse/cookie", ".config/gh-credentials/token"} {
+		full := filepath.Join(home, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	results := Configs(home, false)
+	byRel := map[string]ConfigResult{}
+	for _, r := range results {
+		byRel[r.Rel] = r
+	}
+	if r, ok := byRel[".bashrc"]; !ok || !r.Known {
+		t.Fatalf(".bashrc = %+v", r)
+	}
+	if _, ok := byRel[filepath.Join(".config", "helix")]; !ok {
+		t.Fatal("app config missing")
+	}
+	if _, ok := byRel[filepath.Join(".config", "pulse")]; ok {
+		t.Fatal("noise not excluded")
+	}
+	if _, ok := byRel[filepath.Join(".config", "gh-credentials")]; ok {
+		t.Fatal("secret-shaped entry not excluded by default")
+	}
+
+	all := Configs(home, true)
+	found := false
+	for _, r := range all {
+		if r.Rel == filepath.Join(".config", "pulse") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("includeAll did not recover the excluded entry")
+	}
+}
+
+func TestParseEnabledUnits_VendorPresetSkipped(t *testing.T) {
+	out := "sshd.service enabled disabled\n" + // operator enabled (preset says off)
+		"cups.service enabled enabled\n" + // vendor preset — not operator intent
+		"tailscaled.service enabled disabled\n"
+	units := parseEnabledUnits(out)
+	if strings.Join(units, ",") != "sshd,tailscaled" {
+		t.Fatalf("units = %v", units)
+	}
+}
+
+func TestGitCheckouts(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("no git")
+	}
+	root := t.TempDir()
+	repo := filepath.Join(root, "org", "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"init", "-q"}, {"remote", "add", "origin", "https://example.com/org/repo.git"}} {
+		if out, err := exec.Command("git", append([]string{"-C", repo}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v %s", args, err, out)
+		}
+	}
+	checkouts := GitCheckouts([]string{root})
+	if len(checkouts) != 1 || checkouts[0].URL != "https://example.com/org/repo.git" {
+		t.Fatalf("checkouts = %+v", checkouts)
+	}
+}
+
+// Emitted blocks strict-decode against the blueprint schema in every format.
+func TestEmit_RoundTrips(t *testing.T) {
+	packages := []PackageResult{{Provider: "pacman", Names: []string{"git", "vim"}}}
+	for _, format := range []string{"yaml", "json", "toml", "cue"} {
+		block, err := EmitPackages(packages, format)
+		if err != nil {
+			t.Fatalf("%s: %v", format, err)
+		}
+		decodeFormat := format
+		if format == "cue" {
+			decodeFormat = "json" // JSON-form CUE
+		}
+		var d types.PackagesData
+		if err := helpers.DecodeBlueprintInto(block, decodeFormat, types.BlueprintTypePackages, 0, &d); err != nil {
+			t.Fatalf("%s block does not strict-decode: %v\n%s", format, err, block)
+		}
+		if len(d.Packages) != 1 || d.Packages[0].PackageManager != "pacman" {
+			t.Fatalf("%s round-trip = %+v", format, d.Packages)
+		}
+	}
+
+	home := "/home/x"
+	git, err := EmitGit([]GitCheckout{{Path: "/home/x/git/org/repo", URL: "u"}}, home, "yaml")
+	if err != nil || !strings.Contains(string(git), "{{ .User.home }}/git/org/repo") {
+		t.Fatalf("git emission not home-templated (%v):\n%s", err, git)
+	}
+	files, err := EmitConfigs([]ConfigResult{{Path: "/home/x/.bashrc", Rel: ".bashrc"}}, home, "yaml")
+	if err != nil || !strings.Contains(string(files), "src/.bashrc") {
+		t.Fatalf("config emission (%v):\n%s", err, files)
+	}
+}
+
+func TestSecretShaped(t *testing.T) {
+	for rel, want := range map[string]bool{
+		".ssh/config": true, ".gnupg": true, ".netrc": true,
+		".config/helix": false, ".bashrc": false,
+	} {
+		if SecretShaped(rel) != want {
+			t.Errorf("SecretShaped(%q) != %v", rel, want)
+		}
+	}
+}

--- a/internal/scan/services_git.go
+++ b/internal/scan/services_git.go
@@ -1,0 +1,77 @@
+package scan
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// Services reports enabled unit names on the current platform; elsewhere it
+// reports nothing — an empty answer is honest, a guessed one is not.
+func Services() []string {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return nil
+	}
+	out, err := exec.Command("systemctl", "list-unit-files", "--state=enabled", "--type=service", "--no-legend", "--plain").Output()
+	if err != nil {
+		return nil
+	}
+	return parseEnabledUnits(string(out))
+}
+
+// parseEnabledUnits keeps the units the operator enabled: a unit whose
+// vendor preset column already says enabled would be on without them.
+func parseEnabledUnits(out string) []string {
+	var services []string
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if len(fields) >= 3 && fields[2] == "enabled" {
+			continue
+		}
+		services = append(services, strings.TrimSuffix(fields[0], ".service"))
+	}
+	sort.Strings(services)
+	return services
+}
+
+// GitCheckout is one discovered clone.
+type GitCheckout struct {
+	Path string
+	URL  string
+}
+
+// GitCheckouts finds clones under the given roots (two levels deep — the
+// host/org/repo layout most people keep).
+func GitCheckouts(roots []string) []GitCheckout {
+	var checkouts []GitCheckout
+	for _, root := range roots {
+		for _, depth := range []string{"*", "*/*"} {
+			matches, err := filepath.Glob(filepath.Join(root, depth, ".git"))
+			if err != nil {
+				continue
+			}
+			for _, match := range matches {
+				dir := filepath.Dir(match)
+				if _, err := os.Stat(match); err != nil {
+					continue
+				}
+				url := ""
+				if out, err := exec.Command("git", "-C", dir, "remote", "get-url", "origin").Output(); err == nil { // #nosec G204 -- dir comes from the operator's own filesystem glob; read-only query
+					url = strings.TrimSpace(string(out))
+				}
+				checkouts = append(checkouts, GitCheckout{Path: dir, URL: url})
+			}
+		}
+	}
+	sort.Slice(checkouts, func(i, j int) bool { return checkouts[i].Path < checkouts[j].Path })
+	return checkouts
+}

--- a/internal/status/query.go
+++ b/internal/status/query.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"strings"
 
-	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/scan"
 	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/types"
 )
@@ -42,7 +42,7 @@ func (q *Querier) PackagePresent(provider *types.Provider, name string) Presence
 	}
 	installed, cached := q.packageLists[provider.Name]
 	if !cached {
-		installed = listInstalled(provider)
+		installed = toSet(scan.RunListCommand(provider, provider.Commands.List))
 		q.packageLists[provider.Name] = installed
 	}
 	if installed == nil {
@@ -54,38 +54,17 @@ func (q *Querier) PackagePresent(provider *types.Provider, name string) Presence
 	return Absent
 }
 
-// listInstalled runs the provider's list command read-only and returns the
-// set of first-column package names, nil when the command fails. Some list
-// values name a different binary entirely (apt's is `dpkg
-// --get-selections`); the first field decides what actually runs.
-func listInstalled(provider *types.Provider) map[string]bool {
-	fields := strings.Fields(provider.Commands.List)
-	bin := provider.BinPath
-	args := fields
-	if len(fields) > 0 {
-		if path, err := exec.LookPath(fields[0]); err == nil && fields[0] != provider.Name {
-			bin, args = path, fields[1:]
-		}
-	}
-	out, err := exec.Command(bin, args...).Output() // #nosec G204 -- provider definitions are rwr's own vetted data; list verbs are read-only
-	if err != nil {
-		log.Debugf("status: %s list failed: %v", provider.Name, err)
+// toSet indexes list output for presence checks; nil stays nil (the list
+// failed and the answer is unknown, not empty).
+func toSet(names []string) map[string]bool {
+	if names == nil {
 		return nil
 	}
-	installed := map[string]bool{}
-	for _, line := range strings.Split(string(out), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) == 0 {
-			continue
-		}
-		name := fields[0]
-		// dpkg emits "name:arch"; strip the qualifier so identity matches.
-		if i := strings.IndexByte(name, ':'); i > 0 {
-			name = name[:i]
-		}
-		installed[name] = true
+	set := make(map[string]bool, len(names))
+	for _, name := range names {
+		set[name] = true
 	}
-	return installed
+	return set
 }
 
 // FileState compares a recorded file against disk: missing, still matching

--- a/internal/system/definitions/providers/apk.json
+++ b/internal/system/definitions/providers/apk.json
@@ -3,6 +3,7 @@
     "clean": "cache clean",
     "install": "add",
     "list": "info",
+    "listExplicit": "cat /etc/apk/world",
     "remove": "del",
     "search": "search",
     "update": "update"

--- a/internal/system/definitions/providers/apt.json
+++ b/internal/system/definitions/providers/apt.json
@@ -3,6 +3,7 @@
     "clean": "clean",
     "install": "install -y",
     "list": "dpkg --get-selections",
+    "listExplicit": "apt-mark showmanual",
     "remove": "remove -y",
     "search": "search",
     "update": "update"

--- a/internal/system/definitions/providers/aura.json
+++ b/internal/system/definitions/providers/aura.json
@@ -3,6 +3,7 @@
     "clean": "-Cc --noconfirm",
     "install": "-A --noconfirm",
     "list": "-Qm",
+    "listExplicit": "-Qme",
     "remove": "-R --noconfirm",
     "search": "-As",
     "update": "-Au --noconfirm"

--- a/internal/system/definitions/providers/brew.json
+++ b/internal/system/definitions/providers/brew.json
@@ -3,6 +3,7 @@
     "clean": "cleanup -q",
     "install": "install -fq",
     "list": "list",
+    "listExplicit": "leaves",
     "remove": "uninstall -fq",
     "search": "search",
     "update": "update"

--- a/internal/system/definitions/providers/cargo.json
+++ b/internal/system/definitions/providers/cargo.json
@@ -3,6 +3,7 @@
     "clean": "cache --autoclean",
     "install": "install",
     "list": "install --list",
+    "listExplicit": "install --list",
     "remove": "uninstall",
     "search": "search",
     "update": "install-update --all"

--- a/internal/system/definitions/providers/dnf.json
+++ b/internal/system/definitions/providers/dnf.json
@@ -22,6 +22,7 @@
     "clean": "clean all",
     "install": "install -y",
     "list": "list installed",
+    "listExplicit": "repoquery --userinstalled --qf %{name}",
     "remove": "remove -y",
     "search": "search",
     "update": "update -y"

--- a/internal/system/definitions/providers/emerge.json
+++ b/internal/system/definitions/providers/emerge.json
@@ -3,6 +3,7 @@
     "clean": "--depclean",
     "install": "-qv",
     "list": "qlist -I",
+    "listExplicit": "cat /var/lib/portage/world",
     "remove": "-C",
     "search": "-s",
     "update": "-uDN @world"

--- a/internal/system/definitions/providers/flatpak.json
+++ b/internal/system/definitions/providers/flatpak.json
@@ -3,6 +3,7 @@
     "clean": "uninstall --unused -y",
     "install": "install -y",
     "list": "list",
+    "listExplicit": "list --app --columns=application",
     "remove": "uninstall -y",
     "search": "search",
     "update": "update -y"

--- a/internal/system/definitions/providers/pacman.json
+++ b/internal/system/definitions/providers/pacman.json
@@ -3,6 +3,7 @@
     "clean": "-Sc --noconfirm",
     "install": "-Sy --noconfirm",
     "list": "-Q",
+    "listExplicit": "-Qe",
     "remove": "-R --noconfirm",
     "search": "-Ss",
     "update": "-Syu --noconfirm"

--- a/internal/system/definitions/providers/pamac.json
+++ b/internal/system/definitions/providers/pamac.json
@@ -3,6 +3,7 @@
     "clean": "clean --no-confirm",
     "install": "build --no-confirm",
     "list": "list -i",
+    "listExplicit": "list --explicitly-installed",
     "remove": "remove --no-confirm",
     "search": "search -a",
     "update": "upgrade -a --no-confirm"

--- a/internal/system/definitions/providers/paru.json
+++ b/internal/system/definitions/providers/paru.json
@@ -3,6 +3,7 @@
     "clean": "-Scc --noconfirm",
     "install": "-S --noconfirm",
     "list": "-Qm",
+    "listExplicit": "-Qme",
     "remove": "-Rns --noconfirm",
     "search": "-Ss",
     "update": "-Sua --noconfirm"

--- a/internal/system/definitions/providers/snap.json
+++ b/internal/system/definitions/providers/snap.json
@@ -3,6 +3,7 @@
     "clean": "refresh",
     "install": "install",
     "list": "list",
+    "listExplicit": "list",
     "remove": "remove",
     "search": "find",
     "update": "refresh"

--- a/internal/system/definitions/providers/trizen.json
+++ b/internal/system/definitions/providers/trizen.json
@@ -3,6 +3,7 @@
     "clean": "-Sc --noconfirm",
     "install": "-S --noconfirm --noedit",
     "list": "-Qm",
+    "listExplicit": "-Qme",
     "remove": "-Rns --noconfirm",
     "search": "-Ss",
     "update": "-Syua --noconfirm --noedit"

--- a/internal/system/definitions/providers/xbps.json
+++ b/internal/system/definitions/providers/xbps.json
@@ -3,6 +3,7 @@
     "clean": "xbps-remove -O",
     "install": "-Sy",
     "list": "xbps-query -l",
+    "listExplicit": "xbps-query -m",
     "remove": "-R",
     "search": "xbps-query -Rs",
     "update": "-Su"

--- a/internal/system/definitions/providers/yay.json
+++ b/internal/system/definitions/providers/yay.json
@@ -3,6 +3,7 @@
     "clean": "-Yc --noconfirm",
     "install": "-S --noconfirm --needed",
     "list": "-Qm",
+    "listExplicit": "-Qme",
     "remove": "-Rns --noconfirm",
     "search": "-Ss",
     "update": "-Syu --noconfirm"

--- a/internal/system/definitions/providers/zypper.json
+++ b/internal/system/definitions/providers/zypper.json
@@ -3,6 +3,7 @@
     "clean": "clean",
     "install": "install -y",
     "list": "packages --installed-only",
+    "listExplicit": "search -i --installed-only -t package",
     "remove": "remove -y",
     "search": "search",
     "update": "update -y"

--- a/internal/types/providers.go
+++ b/internal/types/providers.go
@@ -43,8 +43,11 @@ type CommandConfig struct {
 	Update  string `toml:"update"`
 	Remove  string `toml:"remove"`
 	List    string `toml:"list"`
-	Search  string `toml:"search"`
-	Clean   string `toml:"clean"`
+	// ListExplicit is the manager's explicitly-installed query (pacman -Qe,
+	// apt-mark showmanual); scan consumers prefer it over List.
+	ListExplicit string `toml:"list_explicit"`
+	Search       string `toml:"search"`
+	Clean        string `toml:"clean"`
 }
 
 // RepositoryConfig defines repository management configuration.

--- a/openspec/changes/add-diff-command/tasks.md
+++ b/openspec/changes/add-diff-command/tasks.md
@@ -1,23 +1,23 @@
 # Tasks
 
-- [ ] 1. `internal/diff`: scan-vs-tree comparison per category — additions
+- [x] 1. `internal/diff`: scan-vs-tree comparison per category — additions
       (on machine, not in tree) and removals (in tree, gone from machine),
       package identity matched provider-aware. Test: synthetic tree +
       fixture scan → expected delta; blueprint-installed packages (journal
       entries) never report as hand-added.
-- [ ] 2. `rwr diff` list output grouped by category/provider; exit 0 always
+- [x] 2. `rwr diff` list output grouped by category/provider; exit 0 always
       (reporting, not gating — `rwr status` owns the exit code). Test:
       golden output.
-- [ ] 3. `--format cue|yaml|json|toml` paste-ready blocks via the scan
+- [x] 3. `--format cue|yaml|json|toml` paste-ready blocks via the scan
       emission layer; `--packages`/`--configs`/`--services`/`--git` scoping.
       Test: emitted block strict-decodes; scoped runs touch only their
       scanners.
-- [ ] 4. `--into <tree>`: destination discovery (machine tree file for the
+- [x] 4. `--into <tree>`: destination discovery (machine tree file for the
       category, Common files reachable via its imports, skip), huh form per
       change group, edit written in the target file's own format. Tests:
       destination discovery on a fixture tree with Common imports;
       non-interactive `--into` without a TTY errors naming `--format` as
       the alternative; written file strict-decodes and `rwr validate`
       passes.
-- [ ] 5. Docs: `docs/cli/diff.md`, cross-link from state.md's status
+- [x] 5. Docs: `docs/cli/diff.md`, cross-link from state.md's status
       section.

--- a/openspec/changes/add-system-scan/tasks.md
+++ b/openspec/changes/add-system-scan/tasks.md
@@ -1,22 +1,22 @@
 # Tasks
 
-- [ ] 1. `list_explicit` in the provider CUE schema + the definitions that
+- [x] 1. `list_explicit` in the provider CUE schema + the definitions that
       have one (pacman family, apt, dnf, brew, cargo, npm-family, zypper,
       apk, chocolatey/scoop/winget where supported); export pipeline and
       round-trip tests updated. Test: a provider without the verb still
       exports and loads.
-- [ ] 2. `internal/scan` package scanner: per detected provider, parse
+- [x] 2. `internal/scan` package scanner: per detected provider, parse
       explicit output (fixtures per provider, like the status querier);
       fall back to `list` marked unfiltered. Test: fixtures per provider;
       a scan never executes a non-list verb (trap-binary test, same
       pattern as status).
-- [ ] 3. Config scanner: known-dotfile set + `~/.config` top level, shipped
+- [x] 3. Config scanner: known-dotfile set + `~/.config` top level, shipped
       noise exclusion list, results carry path + kind. Test: fixture home
       dir; excluded entries absent; unknown entries present.
-- [ ] 4. Service scanner: enabled units minus vendor presets on linux;
+- [x] 4. Service scanner: enabled units minus vendor presets on linux;
       `unknown` off-platform. Test: parse fixtures.
-- [ ] 5. Git scanner: clones under configured roots with remote URL +
+- [x] 5. Git scanner: clones under configured roots with remote URL +
       path. Test: fixture tree.
-- [ ] 6. Emission: scan results → blueprint block in any registry format,
+- [x] 6. Emission: scan results → blueprint block in any registry format,
       reusing the convert encoders. Test: golden output per format,
       round-trips through strict decode.

--- a/providers/cue/apk.cue
+++ b/providers/cue/apk.cue
@@ -19,6 +19,7 @@ providers: "apk": {
   "update": "update",
   "remove": "del",
   "list": "info",
+  "listExplicit": "cat /etc/apk/world",
   "search": "search",
   "clean": "cache clean"
  },

--- a/providers/cue/apt.cue
+++ b/providers/cue/apt.cue
@@ -8,6 +8,7 @@ providers: "apt": #DebianFamily & {
  "update": "update",
  "remove": "remove -y",
  "list": "dpkg --get-selections",
+ "listExplicit": "apt-mark showmanual",
  "search": "search",
  "clean": "clean"
 }

--- a/providers/cue/aura.cue
+++ b/providers/cue/aura.cue
@@ -9,6 +9,7 @@ providers: "aura": #ArchAURHelper & {
  "update": "-Au --noconfirm",
  "remove": "-R --noconfirm",
  "list": "-Qm",
+ "listExplicit": "-Qme",
  "search": "-As",
  "clean": "-Cc --noconfirm"
 }

--- a/providers/cue/brew.cue
+++ b/providers/cue/brew.cue
@@ -21,6 +21,7 @@ providers: "brew": {
   "update": "update",
   "remove": "uninstall -fq",
   "list": "list",
+  "listExplicit": "leaves",
   "search": "search",
   "clean": "cleanup -q"
  },

--- a/providers/cue/cargo.cue
+++ b/providers/cue/cargo.cue
@@ -20,6 +20,7 @@ providers: "cargo": {
   "update": "install-update --all",
   "remove": "uninstall",
   "list": "install --list",
+  "listExplicit": "install --list",
   "search": "search",
   "clean": "cache --autoclean"
  },

--- a/providers/cue/dnf.cue
+++ b/providers/cue/dnf.cue
@@ -20,6 +20,7 @@ providers: "dnf": {
   "update": "update -y",
   "remove": "remove -y",
   "list": "list installed",
+  "listExplicit": "repoquery --userinstalled --qf %{name}",
   "search": "search",
   "clean": "clean all"
  },

--- a/providers/cue/emerge.cue
+++ b/providers/cue/emerge.cue
@@ -19,6 +19,7 @@ providers: "emerge": {
   "update": "-uDN @world",
   "remove": "-C",
   "list": "qlist -I",
+  "listExplicit": "cat /var/lib/portage/world",
   "search": "-s",
   "clean": "--depclean"
  },

--- a/providers/cue/flatpak.cue
+++ b/providers/cue/flatpak.cue
@@ -19,6 +19,7 @@ providers: "flatpak": {
   "update": "update -y",
   "remove": "uninstall -y",
   "list": "list",
+  "listExplicit": "list --app --columns=application",
   "search": "search",
   "clean": "uninstall --unused -y"
  },

--- a/providers/cue/pacman.cue
+++ b/providers/cue/pacman.cue
@@ -8,6 +8,7 @@ providers: "pacman": #PacmanFamily & {
  "update": "-Syu --noconfirm",
  "remove": "-R --noconfirm",
  "list": "-Q",
+ "listExplicit": "-Qe",
  "search": "-Ss",
  "clean": "-Sc --noconfirm"
 }

--- a/providers/cue/pamac.cue
+++ b/providers/cue/pamac.cue
@@ -8,6 +8,7 @@ providers: "pamac": #ArchAURHelper & {
  "update": "upgrade -a --no-confirm",
  "remove": "remove --no-confirm",
  "list": "list -i",
+ "listExplicit": "list --explicitly-installed",
  "search": "search -a",
  "clean": "clean --no-confirm"
 }

--- a/providers/cue/paru.cue
+++ b/providers/cue/paru.cue
@@ -8,6 +8,7 @@ providers: "paru": #ArchAURHelper & {
  "update": "-Sua --noconfirm",
  "remove": "-Rns --noconfirm",
  "list": "-Qm",
+ "listExplicit": "-Qme",
  "search": "-Ss",
  "clean": "-Scc --noconfirm"
 }

--- a/providers/cue/schema.cue
+++ b/providers/cue/schema.cue
@@ -64,8 +64,9 @@ package providers
 	install: string
 	update?:  string
 	remove?:  string
-	list?:    string
-	search?:  string
+	list?:         string
+	listExplicit?: string
+	search?:       string
 	clean?:   string
 }
 

--- a/providers/cue/snap.cue
+++ b/providers/cue/snap.cue
@@ -19,6 +19,7 @@ providers: "snap": {
   "update": "refresh",
   "remove": "remove",
   "list": "list",
+  "listExplicit": "list",
   "search": "find",
   "clean": "refresh"
  },

--- a/providers/cue/testdata/toml/apk.toml
+++ b/providers/cue/testdata/toml/apk.toml
@@ -12,6 +12,7 @@ install = "add"
 update = "update"
 remove = "del"
 list = "info"
+list_explicit = "cat /etc/apk/world"
 search = "search"
 clean = "cache clean"
 

--- a/providers/cue/testdata/toml/apt.toml
+++ b/providers/cue/testdata/toml/apt.toml
@@ -12,6 +12,7 @@ install = "install -y"
 update = "update"
 remove = "remove -y"
 list = "dpkg --get-selections"
+list_explicit = "apt-mark showmanual"
 search = "search"
 clean = "clean"
 

--- a/providers/cue/testdata/toml/aura.toml
+++ b/providers/cue/testdata/toml/aura.toml
@@ -12,6 +12,7 @@ install = "-A --noconfirm" # -A for AUR install
 update = "-Au --noconfirm" # -Au for AUR updates
 remove = "-R --noconfirm"  # -R to remove packages
 list = "-Qm"               # -Qm to list foreign (AUR) packages
+list_explicit = "-Qme"
 search = "-As"             # -As for AUR search
 clean = "-Cc --noconfirm"  # -Cc for complete cache clean
 

--- a/providers/cue/testdata/toml/brew.toml
+++ b/providers/cue/testdata/toml/brew.toml
@@ -19,6 +19,7 @@ install = "install -fq"
 update = "update"
 remove = "uninstall -fq"
 list = "list"
+list_explicit = "leaves"
 search = "search"
 clean = "cleanup -q"
 

--- a/providers/cue/testdata/toml/cargo.toml
+++ b/providers/cue/testdata/toml/cargo.toml
@@ -12,6 +12,7 @@ install = "install"
 update = "install-update --all" # Use cargo-update to update all packages
 remove = "uninstall"
 list = "install --list"
+list_explicit = "install --list"
 search = "search"
 clean = "cache --autoclean"
 

--- a/providers/cue/testdata/toml/dnf.toml
+++ b/providers/cue/testdata/toml/dnf.toml
@@ -12,6 +12,7 @@ install = "install -y"
 update = "update -y"
 remove = "remove -y"
 list = "list installed"
+list_explicit = "repoquery --userinstalled --qf %{name}"
 search = "search"
 clean = "clean all"
 

--- a/providers/cue/testdata/toml/emerge.toml
+++ b/providers/cue/testdata/toml/emerge.toml
@@ -12,6 +12,7 @@ install = "-qv"        # Quiet and verbose output
 update = "-uDN @world" # Update deep with new use flags
 remove = "-C"
 list = "qlist -I"      # Uses portage-utils
+list_explicit = "cat /var/lib/portage/world"
 search = "-s"
 clean = "--depclean"
 

--- a/providers/cue/testdata/toml/flatpak.toml
+++ b/providers/cue/testdata/toml/flatpak.toml
@@ -12,6 +12,7 @@ install = "install -y"
 update = "update -y"
 remove = "uninstall -y"
 list = "list"
+list_explicit = "list --app --columns=application"
 search = "search"
 clean = "uninstall --unused -y"
 

--- a/providers/cue/testdata/toml/pacman.toml
+++ b/providers/cue/testdata/toml/pacman.toml
@@ -12,6 +12,7 @@ install = "-Sy --noconfirm"
 update = "-Syu --noconfirm"
 remove = "-R --noconfirm"
 list = "-Q"
+list_explicit = "-Qe"
 search = "-Ss"
 clean = "-Sc --noconfirm"
 

--- a/providers/cue/testdata/toml/pamac.toml
+++ b/providers/cue/testdata/toml/pamac.toml
@@ -12,6 +12,7 @@ install = "build --no-confirm"     # build for AUR packages
 update = "upgrade -a --no-confirm" # -a for AUR updates
 remove = "remove --no-confirm"     # remove packages
 list = "list -i"                   # -i to list installed packages
+list_explicit = "list --explicitly-installed"
 search = "search -a"               # -a to search both repos and AUR
 clean = "clean --no-confirm"       # clean cache
 

--- a/providers/cue/testdata/toml/paru.toml
+++ b/providers/cue/testdata/toml/paru.toml
@@ -12,6 +12,7 @@ install = "-S --noconfirm"  # -S for install, paru handles sync
 update = "-Sua --noconfirm" # -Sua for AUR updates only
 remove = "-Rns --noconfirm" # -Rns to remove with dependencies and config
 list = "-Qm"                # -Qm to list foreign (AUR) packages
+list_explicit = "-Qme"
 search = "-Ss"              # -Ss searches both repos and AUR
 clean = "-Scc --noconfirm"  # -Scc for complete cache clean
 

--- a/providers/cue/testdata/toml/snap.toml
+++ b/providers/cue/testdata/toml/snap.toml
@@ -12,6 +12,7 @@ install = "install"
 update = "refresh"
 remove = "remove"
 list = "list"
+list_explicit = "list"
 search = "find"
 clean = "refresh"  # Snap handles cleanup automatically
 

--- a/providers/cue/testdata/toml/trizen.toml
+++ b/providers/cue/testdata/toml/trizen.toml
@@ -12,6 +12,7 @@ install = "-S --noconfirm --noedit"  # -S for install, --noedit to skip PKGBUILD
 update = "-Syua --noconfirm --noedit" # -Syua for full update including AUR
 remove = "-Rns --noconfirm" # -Rns to remove with dependencies and config
 list = "-Qm"               # -Qm to list foreign (AUR) packages
+list_explicit = "-Qme"
 search = "-Ss"            # -Ss searches both repos and AUR
 clean = "-Sc --noconfirm" # -Sc for cache clean
 

--- a/providers/cue/testdata/toml/xbps.toml
+++ b/providers/cue/testdata/toml/xbps.toml
@@ -12,6 +12,7 @@ install = "-Sy"           # Sync repos and install
 update = "-Su"            # Sync and upgrade
 remove = "-R"
 list = "xbps-query -l"
+list_explicit = "xbps-query -m"
 search = "xbps-query -Rs"
 clean = "xbps-remove -O"  # Remove orphaned packages
 

--- a/providers/cue/testdata/toml/yay.toml
+++ b/providers/cue/testdata/toml/yay.toml
@@ -12,6 +12,7 @@ install = "-S --noconfirm --needed"  # -S for install, --needed to avoid reinsta
 update = "-Syu --noconfirm"         # -Syu for full system upgrade including AUR
 remove = "-Rns --noconfirm"         # -Rns to remove with dependencies and config
 list = "-Qm"                       # -Qm to list foreign (AUR) packages
+list_explicit = "-Qme"
 search = "-Ss"                    # -Ss searches both repos and AUR
 clean = "-Yc --noconfirm"        # -Yc to clean unneeded dependencies
 

--- a/providers/cue/testdata/toml/zypper.toml
+++ b/providers/cue/testdata/toml/zypper.toml
@@ -12,6 +12,7 @@ install = "install -y"
 update = "update -y"
 remove = "remove -y"
 list = "packages --installed-only"
+list_explicit = "search -i --installed-only -t package"
 search = "search"
 clean = "clean"
 

--- a/providers/cue/trizen.cue
+++ b/providers/cue/trizen.cue
@@ -8,6 +8,7 @@ providers: "trizen": #ArchAURHelper & {
  "update": "-Syua --noconfirm --noedit",
  "remove": "-Rns --noconfirm",
  "list": "-Qm",
+ "listExplicit": "-Qme",
  "search": "-Ss",
  "clean": "-Sc --noconfirm"
 }

--- a/providers/cue/xbps.cue
+++ b/providers/cue/xbps.cue
@@ -19,6 +19,7 @@ providers: "xbps": {
   "update": "-Su",
   "remove": "-R",
   "list": "xbps-query -l",
+  "listExplicit": "xbps-query -m",
   "search": "xbps-query -Rs",
   "clean": "xbps-remove -O"
  },

--- a/providers/cue/yay.cue
+++ b/providers/cue/yay.cue
@@ -8,6 +8,7 @@ providers: "yay": #ArchAURHelper & {
  "update": "-Syu --noconfirm",
  "remove": "-Rns --noconfirm",
  "list": "-Qm",
+ "listExplicit": "-Qme",
  "search": "-Ss",
  "clean": "-Yc --noconfirm"
 }

--- a/providers/cue/zypper.cue
+++ b/providers/cue/zypper.cue
@@ -19,6 +19,7 @@ providers: "zypper": {
   "update": "update -y",
   "remove": "remove -y",
   "list": "packages --installed-only",
+  "listExplicit": "search -i --installed-only -t package",
   "search": "search",
   "clean": "clean"
  },


### PR DESCRIPTION
Implements `add-diff-command`. **Stacked on #239** (the scan layer) — retarget after it merges. All five change tasks checked.

- **Compute** joins the scan (machine side), the resolved plan (desired side), and the run journal: a package the journal shows a run applied never reports as hand-added, however the tree changed since. Additions and removals, grouped by category and provider.
- **Output**: readable `+`/`-` list; `--format cue|yaml|json|toml` paste-ready blocks via the scan emitters (every block strict-decodes); `--packages`/`--configs`/`--services`/`--git` scoping.
- **`--into <tree>`**: per change group, a huh pick across destinations the tree itself offers — its category files plus any Common file those import (discovered by reading the `import` entries) — then the edit is appended **in the destination file's own format**. Machine-vs-Common is the operator's call, made once per group. Removals are reported, never auto-deleted. No TTY → error naming `--format` as the path.
- **Bug fixed in passing**: cobra's `cmd.Print` writes to stderr — `diff`, `status`, and `config view` all lost their stdout to it; all three now write `OutOrStdout`.

Live-verified on this machine: the list found real hand-installed drift grouped under pacman and flatpak, and `--format cue` emitted a valid block of it. Docs: `docs/cli/diff.md`. Full suite, lint, gosec clean.

Commits unsigned — signing key hardware unavailable this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)