### PR TITLE
fix(scan): real list output is not all packages

### DIFF
--- a/internal/scan/packages.go
+++ b/internal/scan/packages.go
@@ -73,11 +73,21 @@ func RunListCommand(provider *types.Provider, command string) []string {
 	var names []string
 	seen := map[string]bool{}
 	for _, line := range strings.Split(string(out), "\n") {
+		// Indented lines are detail under an entry (cargo lists each crate's
+		// binaries indented), not entries themselves.
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+			continue
+		}
 		fields := strings.Fields(line)
 		if len(fields) == 0 {
 			continue
 		}
 		name := fields[0]
+		// snap (and friends) print a header row; "Name" first is a header,
+		// not a package.
+		if name == "Name" {
+			continue
+		}
 		// dpkg emits "name:arch"; cargo emits "name v1.2.3:"; strip both.
 		if i := strings.IndexByte(name, ':'); i > 0 {
 			name = name[:i]

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -62,6 +62,22 @@ func TestPackages_OnlyListVerbsRun(t *testing.T) {
 	}
 }
 
+// Real-world list output: cargo indents each crate's binaries, snap prints
+// a header row. Neither is a package.
+func TestRunListCommand_SkipsDetailAndHeaders(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "fakelist")
+	script := "#!/bin/sh\nprintf 'Name  Version  Rev\\nripgrep v14.1.0:\\n    rg\\nzoxide v0.9.4:\\n    zoxide\\n'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := &types.Provider{Name: "fake", BinPath: bin}
+	names := RunListCommand(p, "list")
+	if strings.Join(names, ",") != "ripgrep,zoxide" {
+		t.Fatalf("names = %v, want [ripgrep zoxide]", names)
+	}
+}
+
 func TestConfigs_KnownNoiseAndSecrets(t *testing.T) {
 	home := t.TempDir()
 	for _, p := range []string{".bashrc", ".config/helix/config.toml", ".config/pulse/cookie", ".config/gh-credentials/token"} {


### PR DESCRIPTION
The parser assumed every stdout line is a package. Two real tools break that: `cargo install --list` indents each crate's binaries (binaries counted as packages) and `snap list` prints a header row (a package named "Name"). Capture pre-selected the garbage; diff reported it as drift.

Fix: skip indented detail lines and the header row. Regression test uses the real cargo/snap output shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)