### PR TITLE
chore: no em dashes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
         run: go build -v ./...
 
       # vet type-checks the test files too, so this is also the guarantee that the
-      # whole tree — tests included — compiles for this platform.
+      # whole tree - tests included - compiles for this platform.
       - name: Vet
         run: go vet ./...
 
@@ -56,7 +56,7 @@ jobs:
       # The same run on macOS and Windows, reporting only.
       #
       # The suite has never executed on either platform, and a good deal of it
-      # assumes POSIX behaviour — unix file modes, /bin/bash, path separators.
+      # assumes POSIX behaviour - unix file modes, /bin/bash, path separators.
       # Gating on it immediately would paint master red for reasons unrelated to
       # whatever change is being reviewed. This surfaces the failures so they can
       # be triaged and skipped or fixed at their source; delete continue-on-error
@@ -67,8 +67,8 @@ jobs:
         run: go test -race -v ./...
 
   # The build matrix above compiles natively: linux/amd64, darwin/arm64,
-  # windows/amd64. The release ships more targets than that — linux/arm 32-bit,
-  # linux/riscv64, linux/arm64, windows/arm64, darwin/amd64 — and none of them
+  # windows/amd64. The release ships more targets than that - linux/arm 32-bit,
+  # linux/riscv64, linux/arm64, windows/arm64, darwin/amd64 - and none of them
   # was compiled before merge, so a target-specific break (a constant that
   # overflows 32-bit int, a missing syscall) surfaced only when the release ran.
   # That is exactly how the linux_arm_7 math.MaxInt64 break reached master.
@@ -100,7 +100,7 @@ jobs:
   # blocks only ever ran inside a real tag push or the master prerelease, which
   # is how the cosign 3.x sign-blob CLI change could break every release and
   # nightly before anything caught it. This runs the full release pipeline as a
-  # snapshot — including the cosign signing step — before merge. Keyless signing
+  # snapshot - including the cosign signing step - before merge. Keyless signing
   # needs an OIDC token, which fork PRs do not get, so those are skipped (they
   # still run cross-compile).
   release-snapshot:
@@ -157,7 +157,7 @@ jobs:
 
 
   # golangci-lint gates every commit locally, through mise (`mise run lint`) and
-  # the hk pre-commit hook — but only for contributors who ran `mise install`.
+  # the hk pre-commit hook - but only for contributors who ran `mise install`.
   # Anyone else got no lint at all, and neither did any pull request.
   lint:
     runs-on: ubuntu-latest
@@ -170,7 +170,7 @@ jobs:
           go-version: ">=1.26.5"
 
       # Reads .golangci.yml from the repo root, so this runs the same rules as
-      # `golangci-lint run` locally — there is no second copy of the config to drift.
+      # `golangci-lint run` locally - there is no second copy of the config to drift.
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           # Pinned like the other gate tooling: a lint release must not change
@@ -209,7 +209,7 @@ jobs:
           Write-Host "install.ps1 parses cleanly"
 
       # Gating. PSAvoidUsingWriteHost is excluded deliberately: install.ps1 is
-      # a console script whose entire output is for the human running it —
+      # a console script whose entire output is for the human running it -
       # Write-Host is the right tool there, and it was the only finding class.
       - name: PSScriptAnalyzer install.ps1
         shell: pwsh
@@ -222,7 +222,7 @@ jobs:
   # The examples are the closest thing to a compatibility contract with users:
   # every blueprint field they use is a field somebody's real blueprint uses too.
   # Breaking one silently is easy, because the decoders RWR uses ignore unknown
-  # keys — a renamed field turns every blueprint using it into a no-op rather
+  # keys - a renamed field turns every blueprint using it into a no-op rather
   # than an error. These checks make that a failed build instead.
   examples:
     runs-on: ubuntu-latest
@@ -256,7 +256,7 @@ jobs:
             echo "::endgroup::"
           done < <(find examples \( -name 'init.*' -o -name 'manifest.*' \) | sort)
           if [ "$found" -eq 0 ]; then
-            echo "No init files found under examples/ — this loop validated nothing." >&2
+            echo "No init files found under examples/ - this loop validated nothing." >&2
             exit 1
           fi
           echo "Validated $found example trees."

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: RWR - Master Prerelease
 
 # Publishes a build of master on every merge, so there is always something
 # installable that reflects current master. These are explicitly not vetted
-# releases — see the release notes the job writes.
+# releases - see the release notes the job writes.
 #
 # goreleaser's own nightly support is a Pro feature, so this assembles a snapshot
 # build and publishes it through gh. The `nightly` tag is moved to each new commit
@@ -42,7 +42,7 @@ jobs:
         with:
           go-version: ">=1.26.5"
 
-      # cosign signs checksums.txt, syft writes the SBOMs — both invoked by
+      # cosign signs checksums.txt, syft writes the SBOMs - both invoked by
       # goreleaser (signs: / sboms: in .goreleaser.yaml). The nightly gets the
       # same treatment as a release: people install it.
       - name: Install cosign

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: RWR - Release
 
-# Only version tags cut a release. "*" meant any tag — a typo, an experiment,
-# a manually pushed `nightly` — published to GitHub, the Homebrew tap and the
+# Only version tags cut a release. "*" meant any tag - a typo, an experiment,
+# a manually pushed `nightly` - published to GitHub, the Homebrew tap and the
 # naur dispatch. Release tags here have always been v-prefixed (v0.5.1).
 on:
   push:
@@ -29,7 +29,7 @@ jobs:
         with:
           go-version: ">=1.26.5"
 
-      # cosign signs checksums.txt, syft writes the SBOMs — both invoked by
+      # cosign signs checksums.txt, syft writes the SBOMs - both invoked by
       # goreleaser (signs: / sboms: in .goreleaser.yaml).
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ linters:
 
   exclusions:
     rules:
-      # Tests are now linted (run.tests: true), which is the point — govet, staticcheck,
+      # Tests are now linted (run.tests: true), which is the point - govet, staticcheck,
       # ineffassign, unused and misspell all apply to test code as of this change.
       # errcheck is held back only because ~96 existing fixtures call os.WriteFile bare.
       # That matters: a fixture whose write silently failed makes its test meaningless.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ![RWR Logo](img/rwr_128.gif)
 
-Rinse, Wash, Repeat (RWR) is a powerful and flexible configuration management tool designed for those who like to hop around and reinstall frequently, regardless of whether it's Linux, macOS, or Windows. It aims to simplify the process of setting up and maintaining your system, making it easy to rebuild and reproduce configurations across multiple machines — and, with its run records, to see what a run changed and to reverse it again.
+Rinse, Wash, Repeat (RWR) is a powerful and flexible configuration management tool designed for those who like to hop around and reinstall frequently, regardless of whether it's Linux, macOS, or Windows. It aims to simplify the process of setting up and maintaining your system, making it easy to rebuild and reproduce configurations across multiple machines - and, with its run records, to see what a run changed and to reverse it again.
 
 ## Features
 
@@ -17,7 +17,7 @@ Rinse, Wash, Repeat (RWR) is a powerful and flexible configuration management to
 - **Task-runner CLI**: `rwr all` runs everything; `rwr run <processor>` (or the shorthand `rwr packages`) runs one processor; `rwr bootstrap` runs just the bootstrap step
 - **Interactive Dashboard**: Interactive runs get a live terminal dashboard with built-in and user-defined themes; non-interactive runs keep plain streaming logs
 - **Run Records**: Every run writes a journal; `rwr status` shows desired-vs-actual drift and `rwr uninstall` reverses what recorded runs applied
-- **Managed Credentials**: Declare credentials in the init file and source them from environment variables, the OS keyring, or a prompt — redacted in logs by default
+- **Managed Credentials**: Declare credentials in the init file and source them from environment variables, the OS keyring, or a prompt - redacted in logs by default
 - **Cross-platform Package Management**: Integrates with various package managers across Linux, macOS, and Windows
 - **File & Directory Management**: Copy, move, delete, create, and manage permissions with URL source support
 - **Service Management**: Start, stop, enable, and disable system services
@@ -27,7 +27,7 @@ Rinse, Wash, Repeat (RWR) is a powerful and flexible configuration management to
 - **Git Repository Management**: Clone and manage Git repositories
 - **Script Execution**: Execute scripts with multiple interpreter support
 - **SSH Key Management**: Generate and manage SSH keys with GitHub integration
-- **Extensible Architecture**: Package managers are declarative providers — authored in CUE and embedded in the binary, with filesystem overrides in TOML or JSON
+- **Extensible Architecture**: Package managers are declarative providers - authored in CUE and embedded in the binary, with filesystem overrides in TOML or JSON
 
 ## Table of Contents<!-- omit in toc -->
 
@@ -163,7 +163,7 @@ log:
 ```
 
 `init-file` may be a local path, a directory to look in, or an `https://` URL.
-Where the blueprints themselves come from — a git remote or a local directory —
+Where the blueprints themselves come from - a git remote or a local directory -
 is decided by the init file, under `blueprints.location` and `blueprints.git`.
 
 Point RWR at a different configuration with `--config`, which takes either a file
@@ -231,18 +231,18 @@ See the [examples/imports/](examples/imports/) directory for detailed examples.
 
 RWR supports these blueprint types:
 
-- **packages** — Install and remove packages with a package manager
-- **repositories** — Manage the package repositories
-- **files** — Copy, move, delete, and link files. The `directories` and
+- **packages** - Install and remove packages with a package manager
+- **repositories** - Manage the package repositories
+- **files** - Copy, move, delete, and link files. The `directories` and
   `templates` keys are part of this type
-- **services** — Manage the system services
-- **configuration** — Set the desktop and system settings
-- **git** — Clone and update git repositories
-- **scripts** — Run scripts with a program that you select
-- **users** — Manage the user accounts and the groups
-- **ssh_keys** — Make SSH keys and send them to GitHub
-- **fonts** — Install fonts
-- **bootstrap** — Prepare the system before the other types run
+- **services** - Manage the system services
+- **configuration** - Set the desktop and system settings
+- **git** - Clone and update git repositories
+- **scripts** - Run scripts with a program that you select
+- **users** - Manage the user accounts and the groups
+- **ssh_keys** - Make SSH keys and send them to GitHub
+- **fonts** - Install fonts
+- **bootstrap** - Prepare the system before the other types run
 
 For detailed blueprint documentation, see the [Blueprint Types](docs/index.md#blueprints) section.
 
@@ -388,7 +388,7 @@ mise run update     # go get -u ./... and go mod tidy
 
 GitHub Actions runs the pipeline. There are three workflows.
 
-`Go Build & Test` runs at each push to `master` and at each pull request —
+`Go Build & Test` runs at each push to `master` and at each pull request -
 every pull request, not only those targeting `master`, so a branch stacked on
 another branch is still checked. Its jobs:
 
@@ -400,8 +400,8 @@ another branch is still checked. Its jobs:
   Windows, but with `continue-on-error`, because much of the suite still
   assumes POSIX behaviour.
 - `cross-compile` builds every release target with `goreleaser build
-  --snapshot`, and `release-snapshot` runs the full release pipeline — signing
-  included — as a snapshot, so a release-only breakage is caught before merge.
+  --snapshot`, and `release-snapshot` runs the full release pipeline - signing
+  included - as a snapshot, so a release-only breakage is caught before merge.
 - `cue-providers` vets the CUE provider sources under `providers/cue/` and
   fails when the committed JSON under
   `internal/system/definitions/providers/` differs from a fresh export.
@@ -429,10 +429,10 @@ creates the GitHub release, and updates the Homebrew tap.
 
 The release workflow needs these secrets:
 
-- `GITHUB_TOKEN` — creates the release and sends the files to it.
-- `HOMEBREW_TAP_DEPLOY_KEY` — an SSH key that can write to the Homebrew tap
+- `GITHUB_TOKEN` - creates the release and sends the files to it.
+- `HOMEBREW_TAP_DEPLOY_KEY` - an SSH key that can write to the Homebrew tap
   repository.
-- `NAUR_DISPATCH_TOKEN` — starts the update of the naur repository.
+- `NAUR_DISPATCH_TOKEN` - starts the update of the naur repository.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 rwr provisions machines: it installs packages, writes system configuration,
 manages users and services, and runs elevated commands from blueprint files.
-Security reports are taken seriously — a bug here runs as root on people's
+Security reports are taken seriously - a bug here runs as root on people's
 computers.
 
 ## Reporting a vulnerability
@@ -22,14 +22,14 @@ provider definition that demonstrates the problem, and what an attacker gains.
 Reports we especially care about:
 
 - Anything that lets a blueprint, provider definition, or downloaded content
-  do more than the operator asked for — command injection, path traversal
+  do more than the operator asked for - command injection, path traversal
   escaping declared boundaries, template injection.
 - Local privilege escalation through rwr's elevated operations or staging.
 - Credential exposure: tokens or keys reaching logs, process listings,
   subprocess environments, or world-readable files.
 - Integrity of the release pipeline and installers (checksums, signatures).
 
-Out of scope: blueprints doing destructive things they explicitly declare —
+Out of scope: blueprints doing destructive things they explicitly declare -
 blueprints are trusted operator input by design. The trust boundary is that a
 blueprint may do what the operator could do; it must not be possible for
 *data* a blueprint references (URLs, archives, names) to widen that.
@@ -38,5 +38,5 @@ blueprint may do what the operator could do; it must not be possible for
 
 Only the [latest release](https://github.com/FynxLabs/rwr/releases/latest)
 receives fixes. The `nightly` prerelease is a rolling build of master and is
-not a supported target, though reports against it are welcome — that's where
+not a supported target, though reports against it are welcome - that's where
 fixes land first.

--- a/cmd/appconfig_test.go
+++ b/cmd/appconfig_test.go
@@ -3,7 +3,7 @@ package cmd
 import "testing"
 
 // Two trees, two AppConfigs, zero cross-talk: parsing flags on one must not
-// leak into the other. Impossible before the refactor — seventeen package
+// leak into the other. Impossible before the refactor - seventeen package
 // globals meant every test shared (and had to reset) the same state.
 func TestAppConfig_InstancesAreIsolated(t *testing.T) {
 	appA, appB := NewAppConfig(), NewAppConfig()

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -26,9 +26,9 @@ func newCaptureCmd(app *AppConfig) *cobra.Command {
 	captureCmd := &cobra.Command{
 		Use:   "capture [dir]",
 		Short: "Turn this handcrafted machine into a blueprint tree",
-		Long: `Scan the machine — explicitly-installed packages across every detected
+		Long: `Scan the machine - explicitly-installed packages across every detected
 package manager, dotfiles and ~/.config entries, enabled services, git
-checkouts — pick what to keep on a per-category form, and generate a
+checkouts - pick what to keep on a per-category form, and generate a
 validated blueprint tree from the selection. --all skips the form and takes
 the defaults; --manifest adds a root manifest matched to this machine.`,
 		Args: cobra.MaximumNArgs(1),
@@ -98,7 +98,7 @@ func selectionForm(findings capture.Findings, selection *capture.Selection) erro
 		for _, name := range result.Names {
 			options = append(options, huh.NewOption(name, name).Selected(preselect))
 		}
-		title := fmt.Sprintf("Packages — %s (%d found)", provider, len(result.Names))
+		title := fmt.Sprintf("Packages - %s (%d found)", provider, len(result.Names))
 		if result.Unfiltered {
 			title += " [full list: no explicit query, nothing pre-selected]"
 		}
@@ -135,7 +135,7 @@ func selectionForm(findings capture.Findings, selection *capture.Selection) erro
 		}
 		groups = append(groups, huh.NewGroup(
 			huh.NewMultiSelect[string]().
-				Title(fmt.Sprintf("Services (%d enabled — most are distro plumbing)", len(findings.Services))).
+				Title(fmt.Sprintf("Services (%d enabled - most are distro plumbing)", len(findings.Services))).
 				Options(options...).Value(&servicePicks).Filterable(true),
 		))
 	}
@@ -170,7 +170,7 @@ func selectionForm(findings capture.Findings, selection *capture.Selection) erro
 	for _, key := range configPicks {
 		config := findings.Configs[int(key)]
 		if scan.SecretShaped(config.Rel) {
-			fmt.Fprintf(os.Stderr, "warning: %s is secret-shaped — captured because you selected it; review before committing\n", config.Rel)
+			fmt.Fprintf(os.Stderr, "warning: %s is secret-shaped - captured because you selected it; review before committing\n", config.Rel)
 		}
 		selection.Configs = append(selection.Configs, config)
 	}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -48,7 +48,7 @@ func TestRootShorthands(t *testing.T) {
 }
 
 // No two flags may claim the same shorthand across the root set and any
-// subcommand's local set — a future flag grabbing a taken letter fails here.
+// subcommand's local set - a future flag grabbing a taken letter fails here.
 func TestNoShorthandCollisions(t *testing.T) {
 	app := &AppConfig{}
 	root := NewRootCmd(app)

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -25,7 +25,7 @@ another format (--to yaml|json|toml|cue), or rewrite deprecated constructs to
 their current equivalents (--migrate).
 
 Dry-run by default: nothing is written without --write. Comments are NOT
-preserved across formats — the command warns per file that carries them.
+preserved across formats - the command warns per file that carries them.
 Template placeholders survive as quoted strings; a file whose templates make
 it unparseable is reported and skipped, never mangled.`,
 		Args: cobra.MaximumNArgs(1),

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -27,8 +27,8 @@ func newDiffCmd(app *AppConfig) *cobra.Command {
 	diffCmd := &cobra.Command{
 		Use:   "diff",
 		Short: "Show machine drift as blueprint material",
-		Long: `Compare what is actually on this machine — explicitly-installed packages,
-enabled services, git checkouts, configs — against the blueprint tree.
+		Long: `Compare what is actually on this machine - explicitly-installed packages,
+enabled services, git checkouts, configs - against the blueprint tree.
 Additions are things you did by hand; removals are declared things that are
 gone. Output as a readable list, paste-ready blueprint blocks (--format), or
 routed interactively into the tree (--into). Diff never touches the system.`,

--- a/cmd/diff_route.go
+++ b/cmd/diff_route.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// routeInteractively asks, per change group, where the additions land — a
-// destination the tree itself offers, or skip — and writes the accepted
+// routeInteractively asks, per change group, where the additions land - a
+// destination the tree itself offers, or skip - and writes the accepted
 // edits. Machine-specific versus Common is the operator's call; rwr's job
 // is to make it once per group.
 func routeInteractively(cmd *cobra.Command, changes []diff.Change, tree string) error {

--- a/cmd/manifest_select.go
+++ b/cmd/manifest_select.go
@@ -79,7 +79,7 @@ func selectFromManifest(app *AppConfig, manifestPath string) (string, error) {
 	}
 
 	// The selection frame, rendered before resolve stage 1 ever runs:
-	// matched entries first, the rest after — selectable, because matchers
+	// matched entries first, the rest after - selectable, because matchers
 	// are hints and the operator may know better.
 	isMatched := map[string]bool{}
 	for _, entry := range matched {
@@ -91,7 +91,7 @@ func selectFromManifest(app *AppConfig, manifestPath string) (string, error) {
 	}
 	for _, entry := range manifest.Configurations {
 		if !isMatched[entry.Name] {
-			options = append(options, huh.NewOption(entry.Name+"  ("+entry.Init+") — not matched", entry.Name))
+			options = append(options, huh.NewOption(entry.Name+"  ("+entry.Init+") - not matched", entry.Name))
 		}
 	}
 	var chosen string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,7 +44,7 @@ git checkouts, scripts, and desktop configuration.`,
 		// (`rwr packages`) needs the args to reach RunE.
 		Args: cobra.ArbitraryArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// Logging, config directory, and the config file — previously a
+			// Logging, config directory, and the config file - previously a
 			// cobra.OnInitialize hook, which is process-global and appends per
 			// tree; a per-tree PreRun keeps instances isolated.
 			if err := loadConfig(app); err != nil {
@@ -67,7 +67,7 @@ git checkouts, scripts, and desktop configuration.`,
 				"validate": true,
 				"convert":  true,
 				// uninstall's input is the run record, never the blueprint
-				// tree — it must work after the tree is edited or deleted.
+				// tree - it must work after the tree is edited or deleted.
 				"uninstall": true,
 				// capture creates a tree from the machine; requiring one
 				// first would be backwards.
@@ -150,7 +150,7 @@ func registerRootFlags(rootCmd *cobra.Command, app *AppConfig) {
 
 	flags.BoolVarP(&app.Interactive, "interactive", "I", true, "Enable interactive mode (use --interactive=false to disable; per-item prompts, not -i)")
 
-	// Flag for the init file path. Bound to repository.init-file — the key the
+	// Flag for the init file path. Bound to repository.init-file - the key the
 	// config file and docs have always used. It was bound to rwr.init-file,
 	// which nothing read: a two-key split where the flag wrote one key and the
 	// config lookup read the other. rwr.init-file still works via a deprecation
@@ -222,7 +222,7 @@ func initializeSystemInfo(app *AppConfig, selectedProcessors ...string) error {
 	// If no init file is specified via flag, check config
 	app.InitFilePath = configuredInitFile(app.InitFilePath)
 
-	// One resolver for every accepted form — local path, directory, https URL,
+	// One resolver for every accepted form - local path, directory, https URL,
 	// GitHub blob URL, owner/repo[/path][@ref] shorthand. See its doc comment
 	// for the precedence.
 	resolved, err := helpers.ResolveInitSource(app.InitFilePath)
@@ -282,7 +282,7 @@ func initializeSystemInfo(app *AppConfig, selectedProcessors ...string) error {
 
 // configuredInitFile resolves where the init file comes from: the --init-file
 // flag, then the repository.init-file config key (which the flag is also bound
-// to), then the deprecated rwr.init-file key — honored with a warning so
+// to), then the deprecated rwr.init-file key - honored with a warning so
 // configs written against the old two-key split keep working.
 func configuredInitFile(flagValue string) string {
 	if flagValue != "" {
@@ -300,7 +300,7 @@ func configuredInitFile(flagValue string) string {
 
 // resolveConfigLocation decides the config directory and, when --config named
 // a file, the config file path. Precedence: the --config flag, then the
-// rwr.configdir key (env: RWR_RWR_CONFIGDIR — it has to come from the
+// rwr.configdir key (env: RWR_RWR_CONFIGDIR - it has to come from the
 // environment, since the config file cannot name its own directory), then
 // ~/.config/rwr. rwr.configdir used to be read and then unconditionally
 // overwritten, so documenting it was a lie.
@@ -361,7 +361,7 @@ func loadConfig(app *AppConfig) error {
 	// helpers.Bootstrap and the config creator resolve their paths from this key.
 	// Without it they fell back to ~/.config/rwr regardless of --config, so
 	// --config moved run_once but left the bootstrap marker behind in the default
-	// location — the two disagreed about where the config directory was.
+	// location - the two disagreed about where the config directory was.
 	viper.Set("rwr.configdir", app.ConfigLocation)
 
 	if err = helpers.EnsureConfigDir(app.ConfigLocation); err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,7 +15,7 @@ func newRunCmd(app *AppConfig) *cobra.Command {
 		Long: `Run a single processor.
 
 "rwr run" on its own lists the processors, like a task runner. Name one to
-run it — "rwr run packages" — or use the shorthand straight off the root:
+run it - "rwr run packages" - or use the shorthand straight off the root:
 "rwr packages". To run everything: "rwr run all", or "rwr all" from the root.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Bare `rwr run` lists the processors, like a bare `mise run`.
@@ -29,7 +29,7 @@ run it — "rwr run packages" — or use the shorthand straight off the root:
 		},
 	}
 
-	// `rwr run all` runs everything — the same task `rwr all` names at the root.
+	// `rwr run all` runs everything - the same task `rwr all` names at the root.
 	runCmd.AddCommand(&cobra.Command{
 		Use:   "all",
 		Short: "Run all processors",
@@ -112,7 +112,7 @@ func selectedProcessorsFor(cmd *cobra.Command, args []string) []string {
 }
 
 // processorShorthand resolves a root-level argument to a processor, so
-// `rwr packages` works like `rwr run packages` — the processor names are not
+// `rwr packages` works like `rwr run packages` - the processor names are not
 // part of the prime command namespace, exactly like a task runner's tasks.
 func processorShorthand(name string) (runProcessorSpec, bool) {
 	for _, p := range runProcessors {

--- a/cmd/tui_run.go
+++ b/cmd/tui_run.go
@@ -16,7 +16,7 @@ import (
 )
 
 // runWithTUI executes the whole-tree run under the dashboard. The run itself
-// is unchanged — All() emits events; the TUI is one consumer of them.
+// is unchanged - All() emits events; the TUI is one consumer of them.
 func runWithTUI(app *AppConfig, order []string) error {
 	plan, err := processors.ResolveStage1(app.InitConfig)
 	if err != nil {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -20,7 +20,7 @@ func newUninstallCmd(app *AppConfig) *cobra.Command {
 
 	uninstallCmd := &cobra.Command{
 		Use:   "uninstall",
-		Short: "Reverse what recorded runs applied — and only that",
+		Short: "Reverse what recorded runs applied - and only that",
 		Long: `Remove what the run journal shows was applied: packages via the provider's
 remove verb, files and git checkouts hash-guarded (modified content is
 skipped and listed), services disabled, fonts deleted from their recorded
@@ -63,7 +63,7 @@ users, uploaded SSH keys, repositories) is listed up front.`,
 			}
 
 			if failed := uninstall.Execute(out, items, status.NewQuerier()); failed > 0 {
-				return fmt.Errorf("%d removal(s) failed; failed entries stay unreversed — re-run to retry them", failed)
+				return fmt.Errorf("%d removal(s) failed; failed entries stay unreversed - re-run to retry them", failed)
 			}
 			return nil
 		},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -41,7 +41,7 @@ var latestReleaseURL = "https://api.github.com/repos/fynxlabs/rwr/releases/lates
 // SetVersionInfo records the build metadata injected at link time. Empty
 // fields fall back to Go's embedded build info, which is what `go install`
 // builds have instead of ldflags. NewRootCmd wires it into cobra so that
-// `rwr --version` works alongside `rwr version` — buildInfo is link-time
+// `rwr --version` works alongside `rwr version` - buildInfo is link-time
 // constant data, set once from main before any tree is built.
 func SetVersionInfo(info BuildInfo) {
 	buildInfo = fillFromBuildInfo(info)
@@ -143,7 +143,7 @@ func checkForNewVersion(app *AppConfig) {
 	// Read through viper, not the flag variable: the flag is bound to
 	// rwr.skipVersionCheck, but that binding is one-way. Checking the variable
 	// alone meant the config key `rwr config --create` writes, and its env form,
-	// were both inert — only the command-line flag did anything.
+	// were both inert - only the command-line flag did anything.
 	if app.SkipVersionCheck || viper.GetBool("rwr.skipVersionCheck") {
 		log.Debugf("Version check skipped (rwr.skipVersionCheck)")
 		return

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,43 +4,43 @@ Map of the Rinse, Wash, Repeat (RWR) docs. Start here if you are new.
 
 ## Start here
 
-- [Documentation Home](index.md) — what RWR is and an overview of every topic.
-- [Install RWR](install.md) — install with a script, a package manager, or a binary.
-- [Quick Start Guide](quick-start.md) — install, make a basic configuration, run your first blueprint.
+- [Documentation Home](index.md) - what RWR is and an overview of every topic.
+- [Install RWR](install.md) - install with a script, a package manager, or a binary.
+- [Quick Start Guide](quick-start.md) - install, make a basic configuration, run your first blueprint.
 
 ## CLI
 
-- [CLI docs](cli/README.md) — commands, flags, the configuration file, the profiles CLI, `rwr validate`, and `rwr convert`.
+- [CLI docs](cli/README.md) - commands, flags, the configuration file, the profiles CLI, `rwr validate`, and `rwr convert`.
 
 ## Blueprints
 
-- [What are Blueprints?](blueprints-general.md) — the blueprint model: types, formats, and structure.
-- [Blueprint type docs](blueprints/README.md) — one page per blueprint type (packages, files, services, ...).
-- [Init File](init-file.md) — the entry point that names your blueprint tree and its settings.
-- [Bootstrap Process](bootstrap.md) — the setup RWR runs before the main blueprints.
-- [Blueprint schema versioning](schema-versioning.md) — how blueprints declare a schema version per type.
+- [What are Blueprints?](blueprints-general.md) - the blueprint model: types, formats, and structure.
+- [Blueprint type docs](blueprints/README.md) - one page per blueprint type (packages, files, services, ...).
+- [Init File](init-file.md) - the entry point that names your blueprint tree and its settings.
+- [Bootstrap Process](bootstrap.md) - the setup RWR runs before the main blueprints.
+- [Blueprint schema versioning](schema-versioning.md) - how blueprints declare a schema version per type.
 
 ## Profiles
 
-- [Profile System](profiles.md) — group packages and configurations by context and select what applies.
-- [Profile Best Practices](profile-best-practices.md) — practical tips and examples for organizing profiles.
+- [Profile System](profiles.md) - group packages and configurations by context and select what applies.
+- [Profile Best Practices](profile-best-practices.md) - practical tips and examples for organizing profiles.
 
 ## Variables
 
-- [Variables and Templating](variables.md) — variables and templates so one blueprint serves many machines.
+- [Variables and Templating](variables.md) - variables and templates so one blueprint serves many machines.
 
 ## Providers
 
-- [Package Manager Providers](providers.md) — declarative definitions of each package manager, no Go code needed: authored in CUE, overridable with TOML or JSON files.
+- [Package Manager Providers](providers.md) - declarative definitions of each package manager, no Go code needed: authored in CUE, overridable with TOML or JSON files.
 
 ## Credentials and security
 
-- [Credentials in blueprints](credentials.md) — the credentials RWR holds (GitHub token, SSH key, and any you declare), where they are sourced from, and why blueprints cannot read them by default.
+- [Credentials in blueprints](credentials.md) - the credentials RWR holds (GitHub token, SSH key, and any you declare), where they are sourced from, and why blueprints cannot read them by default.
 
 ## Run records
 
-- [Run records](state.md) — the journal each run writes, `rwr status` for drift, and `rwr uninstall` to reverse a run.
+- [Run records](state.md) - the journal each run writes, `rwr status` for drift, and `rwr uninstall` to reverse a run.
 
 ## General
 
-- [Best Practices](best-practices.md) — blueprint organization, configuration management, and maintenance.
+- [Best Practices](best-practices.md) - blueprint organization, configuration management, and maintenance.

--- a/docs/blueprints-general.md
+++ b/docs/blueprints-general.md
@@ -141,15 +141,15 @@ blueprints:
 
 Blueprints can be written in [CUE](https://cuelang.org), which adds types,
 constraints, and composition on top of what YAML/JSON/TOML offer. A `.cue`
-blueprint is evaluated in-process — no `cue` binary is needed on the target
-machine — exported to concrete values, and decoded exactly like its YAML
+blueprint is evaluated in-process - no `cue` binary is needed on the target
+machine - exported to concrete values, and decoded exactly like its YAML
 equivalent.
 
 JSON is valid CUE, so any JSON blueprint is already a CUE blueprint. What CUE
 adds is checking at authoring time:
 
 ```cue
-// packages/base.cue — constraints hold before anything touches the machine
+// packages/base.cue - constraints hold before anything touches the machine
 #Package: {
 	name:    string
 	action:  "install" | "remove"
@@ -165,7 +165,7 @@ packages: [
 
 A violated constraint (say `action: "instal"`) or an unresolved field
 (`version: string` with no concrete value) fails evaluation with the file,
-line, and failing field — at `rwr validate` time, not halfway through a run.
+line, and failing field - at `rwr validate` time, not halfway through a run.
 
 Evaluation is sandboxed: a `.cue` blueprint can import only CUE's built-in
 standard library (`strings`, `list`, …). Imports that would resolve through

--- a/docs/blueprints/README.md
+++ b/docs/blueprints/README.md
@@ -2,16 +2,16 @@
 
 One page per blueprint type.
 
-Read [Fields Common to Every Blueprint](common-fields.md) first — it covers `profiles`, `import`, `interactive`, and the rule that an unknown key is an error.
+Read [Fields Common to Every Blueprint](common-fields.md) first - it covers `profiles`, `import`, `interactive`, and the rule that an unknown key is an error.
 
-- [Packages](packages.md) — installs and removes packages across many package managers.
-- [Repositories](repositories.md) — adds and removes package manager repositories.
-- [Files](files.md) — copies, moves, deletes, creates, and modifies files; renders templates.
-- [Directories](directories.md) — creates, deletes, copies, and moves directories; sets permissions and owner.
-- [Configuration](configuration.md) — manages system configuration: dconf/gsettings (Linux), defaults (macOS), the registry (Windows).
-- [Services](services.md) — starts, stops, enables, and disables services.
-- [Git](git.md) — clones and manages Git repositories.
-- [Scripts](scripts.md) — runs custom scripts for tasks other blueprint types do not cover.
-- [SSH Keys](ssh-keys.md) — generates and manages SSH keys; can upload public keys to GitHub.
-- [Users and Groups](users-and-groups.md) — creates, modifies, and removes user accounts and groups.
-- [Fonts](fonts.md) — installs and removes Nerd Fonts.
+- [Packages](packages.md) - installs and removes packages across many package managers.
+- [Repositories](repositories.md) - adds and removes package manager repositories.
+- [Files](files.md) - copies, moves, deletes, creates, and modifies files; renders templates.
+- [Directories](directories.md) - creates, deletes, copies, and moves directories; sets permissions and owner.
+- [Configuration](configuration.md) - manages system configuration: dconf/gsettings (Linux), defaults (macOS), the registry (Windows).
+- [Services](services.md) - starts, stops, enables, and disables services.
+- [Git](git.md) - clones and manages Git repositories.
+- [Scripts](scripts.md) - runs custom scripts for tasks other blueprint types do not cover.
+- [SSH Keys](ssh-keys.md) - generates and manages SSH keys; can upload public keys to GitHub.
+- [Users and Groups](users-and-groups.md) - creates, modifies, and removes user accounts and groups.
+- [Fonts](fonts.md) - installs and removes Nerd Fonts.

--- a/docs/blueprints/common-fields.md
+++ b/docs/blueprints/common-fields.md
@@ -7,8 +7,8 @@ type, and the one decoding rule that applies to all of them.
 
 > [!IMPORTANT]
 > Blueprints decode strictly, in YAML, JSON, TOML and CUE alike. A key the blueprint
-> type does not define — a misspelled `pacakges:`, a `profile:` that should have
-> been `profiles:` — stops the run with an error naming the file and, for YAML,
+> type does not define - a misspelled `pacakges:`, a `profile:` that should have
+> been `profiles:` - stops the run with an error naming the file and, for YAML,
 > the line.
 
 An unknown key used to be dropped in silence. A misspelled section then produced
@@ -50,7 +50,7 @@ nothing else.
 Supported by: `packages`, `repositories`, `files`, `templates`, `directories`,
 `git`, `scripts`, `services`, `ssh_keys`, `users` and `groups`.
 
-**Not** supported by `fonts` or `configurations` — those two types have no
+**Not** supported by `fonts` or `configurations` - those two types have no
 `import` field, so an `import` key in them is now a decode error rather than a
 silently ignored one.
 
@@ -61,7 +61,7 @@ flag for a single entry. Omit it to follow the flag.
 
 Read per entry by `directories`, `packages`, `repositories`, `scripts`,
 `services`, `ssh_keys` and `users`. `files`, `templates` and `git` accept the
-key but do **not** read it — those processors follow only the global flag. Not
+key but do **not** read it - those processors follow only the global flag. Not
 supported at all by `fonts`, `groups` or `configurations`.
 
 ## `schema_version`
@@ -86,5 +86,5 @@ version a type does not support is an error.
 Every type has `name`. A `names` list, which repeats the rest of the entry once
 per name, is read by `files`, `templates`, `packages` and `fonts`.
 
-`directories` and `configurations` accept a `names` key and do **not** read it —
+`directories` and `configurations` accept a `names` key and do **not** read it -
 write one entry per item there. Every other type rejects `names` outright.

--- a/docs/blueprints/configuration.md
+++ b/docs/blueprints/configuration.md
@@ -37,7 +37,7 @@ The tool-specific settings are `file`, `schema`, `key`, `settings`, `value`,
 `path`, `domain`, `kind` and `type`, described per tool below.
 
 > [!NOTE]
-> Profiles work for configuration entries as of this release — the type had no
+> Profiles work for configuration entries as of this release - the type had no
 > `profiles` field before, so every entry was applied on every machine. The
 > configuration blueprint has **no `import` field** and no `interactive` field;
 > writing either one is now a decode error.
@@ -74,7 +74,7 @@ The gsettings tool sets individual keys in one schema.
 | Option | Required | Description |
 |--------|----------|-------------|
 | `schema` | Yes | The gsettings schema |
-| `settings` | Yes | A map of key to value. This is where the keys go — `key` and `value` are **not** read by this tool |
+| `settings` | Yes | A map of key to value. This is where the keys go - `key` and `value` are **not** read by this tool |
 
 Each key is checked with `gsettings writable` first. A key that is not writable,
 or that fails to apply, is recorded as a failure and reported at the end of the
@@ -160,7 +160,7 @@ configurations:
 ## Notes
 
 * `run_once` is honoured by the dconf tool only. The other three tools apply their setting on every run; each of them is idempotent.
-* The `elevated` option runs the command through sudo on Unix-like systems. On Windows it does not raise privileges — see the note above.
+* The `elevated` option runs the command through sudo on Unix-like systems. On Windows it does not raise privileges - see the note above.
 * A gsettings entry that cannot apply a key does not stop the run; the failures are collected and reported at the end. The other tools return their error immediately.
 
 For more information on using the Configuration Processor in your RWR setup, please refer to the [Blueprints Overview](../blueprints-general.md) and the [Best Practices](../best-practices.md) sections of the documentation.

--- a/docs/blueprints/directories.md
+++ b/docs/blueprints/directories.md
@@ -46,7 +46,7 @@ The following settings are available for the Directories Blueprint:
 | `target` | string | The parent directory. The entry's `name` is joined onto it, so `target: ~/` with `name: .config` manages `~/.config`. The one exception is `symlink`, where `target` is the link's own path |
 | `owner` | string | The owner of the directory (applied by `chown`, and after `create` and `copy`) |
 | `group` | string | The group of the directory (applied by `chown`/`chgrp`, and after `create` and `copy`) |
-| `mode` | string | The permissions of the directory. Write a quoted octal string: `mode: "0755"`. A bare `mode: 755` is an **error** — see [File modes](files.md#file-modes). Defaults to `0755` when omitted; required for `chmod` |
+| `mode` | string | The permissions of the directory. Write a quoted octal string: `mode: "0755"`. A bare `mode: 755` is an **error** - see [File modes](files.md#file-modes). Defaults to `0755` when omitted; required for `chmod` |
 | `elevated` | bool | Read by `copy` only; other directory actions are performed by rwr's own process (default: false) |
 | `interactive` | bool | Override global interactive mode for this directory (`true`/`false`). If omitted, uses the global `--interactive` flag. Controls whether diffs are shown before overwriting existing files during copy operations |
 

--- a/docs/blueprints/files.md
+++ b/docs/blueprints/files.md
@@ -129,7 +129,7 @@ behaves as a directory.
 ## File modes
 
 `mode` is a permission mode, at most four octal digits (`0o7777`). It is applied
-by the `create` and `chmod` actions only — a copy takes the source's
+by the `create` and `chmod` actions only - a copy takes the source's
 permissions, a symlink has none, and delete, chown and chgrp do not touch the
 mode. `rwr validate` warns when a mode is set on an action that ignores it.
 
@@ -157,8 +157,8 @@ mode 0644 typed without quotes; write mode: "0644" for 0o644, or mode: "1204"
 for 0o1204
 ```
 
-This is the change to watch for. `mode: 644` used to decode to 0o1204 — a setuid
-mode nobody asked for — and apply it without complaint. It is now an error, and
+This is the change to watch for. `mode: 644` used to decode to 0o1204 - a setuid
+mode nobody asked for - and apply it without complaint. It is now an error, and
 the message tells you what to write instead. Anything above `0o7777`, or a
 negative number, is refused the same way.
 
@@ -187,8 +187,8 @@ When no `mode` is declared:
 | A plain file (`create`) | `0644` |
 | A directory | `0755` |
 
-Rendered templates are private because templates can render credentials — a
-`.netrc`, a `gh` config — and those must not exist world-readable even for an
+Rendered templates are private because templates can render credentials - a
+`.netrc`, a `gh` config - and those must not exist world-readable even for an
 instant. For the same reason, when a created file's mode gives nothing to group
 or other, any parent directory RWR has to create is made `0700` instead of
 `0755`.
@@ -204,7 +204,7 @@ set, and written to `target`.
 
 A template entry needs `name`, `source` and `target`; one missing any of them is
 skipped with a warning. Because the rendered result is written as content, a
-template is always **created** at its target whatever `action` says — an entry
+template is always **created** at its target whatever `action` says - an entry
 declaring `action: copy` renders and creates, and logs a warning saying so.
 
 Template files use the Go template syntax and can include variables, conditionals, and loops. The `variables` setting allows you to define a map of variables and their corresponding values, which can be used within the template files.

--- a/docs/blueprints/fonts.md
+++ b/docs/blueprints/fonts.md
@@ -30,7 +30,7 @@ The following settings are available for the Fonts Blueprint:
 
 | Setting | Required | Description |
 |---------|----------|-------------|
-| `name` | Yes* | The name of the font to manage, exactly as the nerd-fonts release names its archive — `Hack`, `FiraCode`, `JetBrainsMono`. It must not contain a path separator or `..` |
+| `name` | Yes* | The name of the font to manage, exactly as the nerd-fonts release names its archive - `Hack`, `FiraCode`, `JetBrainsMono`. It must not contain a path separator or `..` |
 | `names` | Yes* | A list of font names to manage. The rest of the entry is repeated for each |
 | `action` | Yes | `install` or `remove` |
 | `provider` | No | Defaults to `nerd`. Nerd Fonts is the only implementation; another value is accepted by the schema but changes nothing |
@@ -41,7 +41,7 @@ The following settings are available for the Fonts Blueprint:
 skipped.
 
 > [!NOTE]
-> Profiles work for fonts as of this release — the type had no `profiles` field
+> Profiles work for fonts as of this release - the type had no `profiles` field
 > before, so a font entry ran on every machine regardless of what it declared.
 > The fonts blueprint has **no `import` field** and no `interactive` field;
 > writing either one is now a decode error.

--- a/docs/blueprints/packages.md
+++ b/docs/blueprints/packages.md
@@ -57,7 +57,7 @@ Note that you must provide either `name`, `names`, or `import` for each package 
 ### Package names may not begin with `-`
 
 A name starting with `-` would be read as an **option** by every package
-manager — `--allow-downgrades`, `-U <url>` — rather than as a package. RWR
+manager - `--allow-downgrades`, `-U <url>` - rather than as a package. RWR
 refuses such a name and records it as a failure for that entry; the rest of the
 run continues. Commands are executed as argv rather than through a shell, so
 this is not shell injection, but it would still let a blueprint change what the
@@ -65,9 +65,9 @@ elevated package manager does.
 
 ### Actions
 
-`install` and `remove` are implemented. Any other value — including `update` —
+`install` and `remove` are implemented. Any other value - including `update` -
 is reported by `rwr validate` and recorded as a failure with "unknown action"
-at run time. To refresh package lists, run a repositories blueprint — RWR runs
+at run time. To refresh package lists, run a repositories blueprint - RWR runs
 each available provider's update command after processing it.
 
 ## Blueprint Imports

--- a/docs/blueprints/repositories.md
+++ b/docs/blueprints/repositories.md
@@ -28,7 +28,7 @@ blueprint did not supply is an error naming the repository, not a blank.
 | `name` | Yes, if `import` is not provided | The name of the repository. Also names the file most providers write (`/etc/apt/sources.list.d/<name>.list`) and the keyring (`<keys_dir>/<name>.gpg`) |
 | `package_manager` | Yes | The provider that owns the repository (`apt`, `dnf`, `pacman`, `zypper`, `apk`, `xbps`, `eopkg`, `emerge`, `slackpkg`, `brew`, `macports`, `nix`, `flatpak`, `snap`, `cargo`, `chocolatey`, `scoop`, `winget`, `mas`, `gnome-extensions`, and the AUR helpers) |
 | `action` | Yes | `add` or `remove` |
-| `url` | Yes for `add` | The repository URL. A value with no scheme, or a `file://` URL, is treated as a local path — that is what selects the sideload steps for `snap` and `gnome-extensions` |
+| `url` | Yes for `add` | The repository URL. A value with no scheme, or a `file://` URL, is treated as a local path - that is what selects the sideload steps for `snap` and `gnome-extensions` |
 | `key_url` | No | URL of the repository's signing key, downloaded to the provider's key directory (apt, dnf, zypper, apk, xbps, eopkg, slackpkg) |
 | `key_sha256` | No | SHA-256 digest of the signing key at `key_url`; the key download is verified against it |
 | `key_id` | No | Key ID to import or delete rather than a URL (pacman family, and the `rpm --erase gpg-pubkey-<id>` step in dnf/zypper removal) |
@@ -60,17 +60,17 @@ rendered, so the settings above take effect.
 
 > [!WARNING]
 > `username`, `password` and `token` are passed to the package manager as
-> **command-line arguments** — `choco source add --password=…`, `cargo login …`
-> — because those tools accept them no other way. They are therefore visible in
+> **command-line arguments** - `choco source add --password=…`, `cargo login …`
+> - because those tools accept them no other way. They are therefore visible in
 > `ps` to every local user on the machine for the lifetime of the call. RWR
 > keeps them out of its own output (logs, `--debug` argv dumps and `--dry-run`
 > lines redact them), but nothing rwr can do hides them from the process list.
 
 ## Actions and what actually works
 
-Every shipped provider — apt, dnf, zypper, pacman/yay/paru/aura/pamac/trizen,
+Every shipped provider - apt, dnf, zypper, pacman/yay/paru/aura/pamac/trizen,
 apk, xbps, eopkg, emerge, slackpkg, brew, macports, nix, flatpak, snap, cargo,
-chocolatey, scoop, winget, mas, gnome-extensions — defines both `add` and
+chocolatey, scoop, winget, mas, gnome-extensions - defines both `add` and
 `remove` steps, and both work. Provider steps may be gated on predicates RWR
 derives from the entry (`HasKey`, `HasInterfaces`, `ResetSettings`, …), so a
 step for a feature you did not ask for is simply skipped: a snap add without

--- a/docs/blueprints/ssh-keys.md
+++ b/docs/blueprints/ssh-keys.md
@@ -29,7 +29,7 @@ The following settings are available for each SSH key in the SSH Keys blueprint:
 | -------------------- | -------- | ---------------------------------------------------------------------------------- |
 | `name`               | Yes, if `import` is not provided      | The name of the SSH key file (e.g., `id_rsa`)                                      |
 | `import`             | Yes, if `name` is not provided | Path to import SSH key definitions from another file (relative to blueprint directory) |
-| `type`               | Yes      | The key type, passed straight to `ssh-keygen -t`. There is **no default** — omitting it makes `ssh-keygen` fail. `rwr validate` warns for anything other than `rsa`, `ed25519` or `ecdsa` |
+| `type`               | Yes      | The key type, passed straight to `ssh-keygen -t`. There is **no default** - omitting it makes `ssh-keygen` fail. `rwr validate` warns for anything other than `rsa`, `ed25519` or `ecdsa` |
 | `path`               | Yes      | The directory where the SSH key will be stored. There is **no default**; write it explicitly, e.g. `~/.ssh`. A leading `~` is expanded |
 | `comment`            | No       | A comment to include in the SSH key (e.g., email address)                          |
 | `no_passphrase`      | No       | Set to `true` to generate the SSH key without a passphrase. Default is `false`     |

--- a/docs/blueprints/users-and-groups.md
+++ b/docs/blueprints/users-and-groups.md
@@ -56,7 +56,7 @@ accepted alias for `remove`.
 fail: it converges the existing one to the attributes the entry declares
 (`usermod` on Linux, `dscl -create` on macOS) and sets the password if one is
 given. A declared `home` on an existing account is treated as the intended home,
-not as a request to relocate the current one — use `modify` with `new_home` for
+not as a request to relocate the current one - use `modify` with `new_home` for
 that.
 
 `remove` on an account or group that does not exist succeeds and does nothing.
@@ -105,8 +105,8 @@ command argument, so it does not appear in `ps` or in rwr's debug output. The
 value may be either:
 
 - **Cleartext**, which `chpasswd` hashes itself, or
-- **A crypt(3) hash** — `$6$…`, `$y$…`, a 13-character DES hash, or one of the
-  locked markers `!`, `!!`, `*`, `*LK*` — which is passed through with
+- **A crypt(3) hash** - `$6$…`, `$y$…`, a 13-character DES hash, or one of the
+  locked markers `!`, `!!`, `*`, `*LK*` - which is passed through with
   `chpasswd -e`.
 
 RWR detects which of the two you wrote; there is no field to declare it.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -117,7 +117,7 @@ rwr all --force-bootstrap
 
 This flag will ensure that the Bootstrap Process is executed even if it has been run previously.
 
-To re-run only the bootstrap — after editing `bootstrap.yaml`, say — use the
+To re-run only the bootstrap - after editing `bootstrap.yaml`, say - use the
 standalone command instead of re-running everything:
 
 ```bash

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,9 +1,9 @@
 # CLI Docs
 
-- [Commands and Flags](command-and-flags.md) — every command and global flag: `rwr all`, `rwr run`, `rwr config`, `rwr version`, and more.
-- [Configuration File](configuration.md) — the `config.yaml` settings, file location, environment variables, and precedence.
-- [Profile CLI Commands](profiles.md) — the `--profile` flag and the `rwr profiles` command.
-- [Validate Command](validate.md) — `rwr validate`: check blueprints and provider configurations before a run.
-- [Convert Command](convert.md) — `rwr convert`: rewrite a blueprint tree between formats or migrate deprecated constructs.
-- [Diff Command](diff.md) — `rwr diff`: machine drift as blueprint material — lists, paste-ready blocks, or routed tree edits.
-- [Capture Command](capture.md) — `rwr capture`: turn a handcrafted machine into a validated blueprint tree.
+- [Commands and Flags](command-and-flags.md) - every command and global flag: `rwr all`, `rwr run`, `rwr config`, `rwr version`, and more.
+- [Configuration File](configuration.md) - the `config.yaml` settings, file location, environment variables, and precedence.
+- [Profile CLI Commands](profiles.md) - the `--profile` flag and the `rwr profiles` command.
+- [Validate Command](validate.md) - `rwr validate`: check blueprints and provider configurations before a run.
+- [Convert Command](convert.md) - `rwr convert`: rewrite a blueprint tree between formats or migrate deprecated constructs.
+- [Diff Command](diff.md) - `rwr diff`: machine drift as blueprint material - lists, paste-ready blocks, or routed tree edits.
+- [Capture Command](capture.md) - `rwr capture`: turn a handcrafted machine into a validated blueprint tree.

--- a/docs/cli/capture.md
+++ b/docs/cli/capture.md
@@ -1,10 +1,10 @@
 # rwr capture
 
 Turn a handcrafted machine into a blueprint tree. The scan finds what you
-put there — explicitly-installed packages per manager (`pacman -Qe`,
+put there - explicitly-installed packages per manager (`pacman -Qe`,
 `brew leaves`, `cargo install --list`, …, so dependency noise never
 appears), dotfiles and `~/.config` entries minus known cache/state noise,
-enabled services, git checkouts — and a per-category form decides what to
+enabled services, git checkouts - and a per-category form decides what to
 keep.
 
 ```bash
@@ -24,6 +24,6 @@ paths (ssh, gnupg, netrc, credential dirs) are never pre-selected and warn
 if chosen. Selected configs are copied under `files/src/` with entries
 targeting their origin via `{{ .User.home }}`.
 
-The generated tree is validated before capture reports success — output
+The generated tree is validated before capture reports success - output
 that needs hand-repair is a failure, not a capture. From there:
 `rwr all --init-file <dir>` provisions the next machine.

--- a/docs/cli/command-and-flags.md
+++ b/docs/cli/command-and-flags.md
@@ -18,7 +18,7 @@ The following flags are available for all commands:
 | `--show-secrets` | Print credential values in logs instead of redacting them. Off by default; use it only to confirm RWR is reading the token or key you expect |
 | `--dry-run`, `-n` | Simulate operations without making changes (no-op mode) |
 | `--no-op` | Alias for `--dry-run` |
-| `--interactive`, `-I` | Enable interactive per-item prompts (default: true). Use `--interactive=false` to disable. Capital `-I` — lowercase `-i` is `--init-file` |
+| `--interactive`, `-I` | Enable interactive per-item prompts (default: true). Use `--interactive=false` to disable. Capital `-I` - lowercase `-i` is `--init-file` |
 | `--gh-key` | Deprecated alias for `--gh-api-key`; use `--gh-api-key` |
 | `--gh-auth` | Get a GitHub token with the OAuth device flow. Only `rwr all` and `rwr run ssh_keys` act on it |
 | `--profile`, `-p` | Make a profile active. Repeat the flag, or give a comma-separated list |
@@ -37,7 +37,7 @@ rwr: https://github.com/fynxlabs/rwr/releases/latest (silence with --skip-versio
 ```
 
 The check is advisory and never fails the run: a two-second timeout, and every
-error — no network, a rate limit, an unexpected response — is a debug log and
+error - no network, a rate limit, an unexpected response - is a debug log and
 nothing more. It is also skipped for a development build (one built with plain
 `go build`, or from a modified tree), and for `rwr help`, `rwr config`,
 `rwr version` and `rwr validate`, which do no version check at all.
@@ -107,7 +107,7 @@ Run all blueprints and set up the system.
 
 Run just the bootstrap processor (`rwr run bootstrap` works too). Asking for
 bootstrap by name implies wanting it to run, so this ignores the run-once
-marker that keeps `rwr all` idempotent — no `--force-bootstrap` needed. The
+marker that keeps `rwr all` idempotent - no `--force-bootstrap` needed. The
 marker is refreshed on success, `--dry-run` is honored, and a tree without a
 bootstrap file is an error naming the filenames searched.
 ### `rwr status`
@@ -117,7 +117,7 @@ elevates, exits 1 on drift. See [Run records](../state.md).
 
 ### `rwr uninstall`
 
-Reverse what recorded runs applied — and only that. Refuses without a run
+Reverse what recorded runs applied - and only that. Refuses without a run
 record; prints the not-reversible list up front; `--yes` skips the prompt.
 See [Run records](../state.md).
 
@@ -204,7 +204,7 @@ Run the fonts processor.
 > files blueprint. Use `rwr run files` to process it.
 >
 > `rwr run` takes one processor, not a list. `rwr run all` runs every
-> processor — it is the same run as `rwr all`.
+> processor - it is the same run as `rwr all`.
 >
 > Every processor name also works straight off the root, task-runner style:
 > `rwr packages` is `rwr run packages`.

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -11,10 +11,10 @@ The `config.yaml` file is located in the RWR configuration directory. By default
 
 `--config` is a global flag that changes where RWR looks. It accepts either:
 
-- **a file** — RWR reads that file as the configuration, whatever it is named.
+- **a file** - RWR reads that file as the configuration, whatever it is named.
   The directory holding it becomes the configuration directory, so `run_once`
   is created next to it.
-- **a directory** — RWR reads `config.yaml` from that directory and uses the
+- **a directory** - RWR reads `config.yaml` from that directory and uses the
   directory as the configuration directory.
 
 ```bash
@@ -40,7 +40,7 @@ The `rwr` section contains general settings for the RWR tool.
 
 | Option | Description |
 |--------|-------------|
-| `configdir` | The config directory: where `config.yaml` is looked up, where `rwr config create` writes it, and where the `bootstrap` marker lives. The default is `$HOME/.config/rwr`. Because it decides where the config file is, it only takes effect from the environment (`RWR_RWR_CONFIGDIR`) — a config file cannot name its own directory. `--config` overrides it |
+| `configdir` | The config directory: where `config.yaml` is looked up, where `rwr config create` writes it, and where the `bootstrap` marker lives. The default is `$HOME/.config/rwr`. Because it decides where the config file is, it only takes effect from the environment (`RWR_RWR_CONFIGDIR`) - a config file cannot name its own directory. `--config` overrides it |
 | `skipVersionCheck` | Set to `true` to turn off the startup check for a newer release. The `--skip-version-check` flag does the same for a single run |
 
 ### `repository` Section

--- a/docs/cli/convert.md
+++ b/docs/cli/convert.md
@@ -1,7 +1,7 @@
 # rwr convert
 
 Convert a blueprint tree between formats, or migrate deprecated constructs to
-their current equivalents. Dry-run by default — nothing is written without
+their current equivalents. Dry-run by default - nothing is written without
 `--write`.
 
 ## Format conversion
@@ -22,7 +22,7 @@ Limits, stated plainly:
 - **Template placeholders survive as quoted strings** (`"{{ .User.home }}"`).
   A file whose templates make it unparseable raw is reported and skipped,
   never mangled.
-- **CUE output is JSON-form CUE** — valid and lossless. Idiomatic CUE
+- **CUE output is JSON-form CUE** - valid and lossless. Idiomatic CUE
   (schemas, constraints) is authoring work the converter does not guess at.
 
 ## Migration
@@ -37,7 +37,7 @@ Rewrites deprecated constructs. Current rules:
 - **Init-file inline resource sections** (`packages:`, `repositories:`, …
   declared in `init.yaml`) move into blueprint files under the tree
   (`packages/from-init.yaml`, …). These sections were removed from the init
-  schema — they were decoded and never applied — and an init file still
+  schema - they were decoded and never applied - and an init file still
   carrying them is an error until migrated.
 
 `--to` and `--migrate` compose in one invocation.

--- a/docs/cli/diff.md
+++ b/docs/cli/diff.md
@@ -1,13 +1,13 @@
 # rwr diff
 
 Compare what is actually on the machine against the blueprint tree, and get
-the delta as blueprint material — never an apply.
+the delta as blueprint material - never an apply.
 
 The machine side comes from read-only scans: explicitly-installed packages
 per provider (`pacman -Qe`, `apt-mark showmanual`, …), operator-enabled
 services, git checkouts, and configs. The tree side is the resolved plan.
 Packages the [run journal](../state.md) shows a run applied never report as
-hand-added — the tree may have changed since, but you didn't install them.
+hand-added - the tree may have changed since, but you didn't install them.
 
 ```bash
 # The readable list: + additions (hand-done), - removals (declared, gone)
@@ -25,6 +25,6 @@ rwr diff --into ~/git/thefynx/rwr-blueprints/Archcraft
 ```
 
 `--into` needs a terminal; `--format` is the non-interactive path. Routed
-edits are written in the destination file's own format — run
+edits are written in the destination file's own format - run
 `rwr validate`, review, commit. Removals are reported but never
 auto-deleted from blueprints.

--- a/docs/cli/profiles.md
+++ b/docs/cli/profiles.md
@@ -16,7 +16,7 @@ There are two pieces:
 ## The `--profile` / `-p` flag
 
 `--profile` is a global flag, so it is accepted by every command. It only
-changes what is applied when a command applies something — that is `rwr all` and
+changes what is applied when a command applies something - that is `rwr all` and
 `rwr run <processor>`.
 
 > [!IMPORTANT]
@@ -158,7 +158,7 @@ rwr all --dry-run --profile work,gaming
 ## Error handling
 
 RWR does **not** check the names you pass against the ones your blueprints
-declare. A misspelled profile is not an error and produces no warning — it simply
+declare. A misspelled profile is not an error and produces no warning - it simply
 matches nothing, and the run applies the base items only. If a run installs less
 than you expected, check the spelling against `rwr profiles`; the names are
 case-sensitive.

--- a/docs/cli/validate.md
+++ b/docs/cli/validate.md
@@ -84,7 +84,7 @@ The provider validation process includes:
   or `remove` command, is a **warning**
 * **Steps**: Each install, remove and repository step must name an action the
   processor implements, and carry the fields that action needs (`exec` for
-  `command`, `source`/`dest` for `download` and `copy`, and so on) — errors.
+  `command`, `source`/`dest` for `download` and `copy`, and so on) - errors.
   Empty `content` on a `write` or `append` step is a warning
 * **Paths**: A declared repository sources path that does not exist on this
   system is a warning
@@ -111,7 +111,7 @@ With no errors it prints `Validation completed with N warnings`, or
 
 > [!NOTE]
 > Issues carry the file, not a line number. Where the underlying decoder reports
-> a line — a strict-decoding failure, for example — it appears inside the message
+> a line - a strict-decoding failure, for example - it appears inside the message
 > text.
 
 ## Examples

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,7 +1,7 @@
 # Credentials in blueprints
 
-RWR manages credentials for your blueprints. Two are built in — your GitHub API
-token and your SSH private key — and the init file can declare more. By
+RWR manages credentials for your blueprints. Two are built in - your GitHub API
+token and your SSH private key - and the init file can declare more. By
 default, blueprints cannot read any of them.
 
 ## Why RWR holds back the credentials
@@ -19,7 +19,7 @@ different author. RWR cannot tell the difference between the two.
 
 ## Declare the credentials that a tree needs
 
-A blueprint sometimes needs a secret that is not the GitHub token — a registry
+A blueprint sometimes needs a secret that is not the GitHub token - a registry
 token, an API key, a license key. Declare it in the init file, and RWR finds
 the value for you:
 
@@ -41,7 +41,7 @@ credentials:
 RWR resolves every declared credential at the start of the run, before any
 processor runs. A credential with no value from any source stops the run with
 an error that names the credential and the sources tried. When the run is not
-interactive — no terminal, or `--interactive=false` — RWR skips `prompt` and
+interactive - no terminal, or `--interactive=false` - RWR skips `prompt` and
 the error says so.
 
 After you answer a prompt, RWR offers to save the value to the OS keyring, so
@@ -53,8 +53,8 @@ under `exposeCredentials`, and the logs show `[redacted]` instead of the value.
 
 ### Where RWR stores a credential
 
-RWR persists a managed credential only in the OS keyring — Secret Service on
-Linux, Keychain on macOS, Credential Manager on Windows — and only when you
+RWR persists a managed credential only in the OS keyring - Secret Service on
+Linux, Keychain on macOS, Credential Manager on Windows - and only when you
 agree. RWR never writes a managed credential to a plaintext file.
 
 One exception is grandfathered: a GitHub token that an earlier RWR saved into

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ RWR's profile system allows you to organize and selectively install packages and
 - [Profile Commands](cli/profiles.md): Profile-specific CLI commands and flags.
 - [Validate Command](cli/validate.md): Check blueprints and provider configurations before a run.
 - [Convert Command](cli/convert.md): Rewrite a blueprint tree between formats or migrate deprecated constructs.
-- [Diff Command](cli/diff.md): Machine drift as blueprint material — lists, paste-ready blocks, or routed tree edits.
+- [Diff Command](cli/diff.md): Machine drift as blueprint material - lists, paste-ready blocks, or routed tree edits.
 - [Capture Command](cli/capture.md): Turn a handcrafted machine into a validated blueprint tree.
 
 ## The Init File
@@ -81,7 +81,7 @@ RWR supports various blueprint types for managing different aspects of your syst
 
 ## Extending RWR
 
-- [Package Manager Providers](providers.md): Declarative provider definitions —
+- [Package Manager Providers](providers.md): Declarative provider definitions -
   add or override a package manager without writing Go code.
 - Coming Soon: Adding a New Processor
 

--- a/docs/init-file.md
+++ b/docs/init-file.md
@@ -89,7 +89,7 @@ credentials:
     scope: [scripts]
 ```
 
-Declaring a credential does not give it to blueprints — for that, also name it
+Declaring a credential does not give it to blueprints - for that, also name it
 under `exposeCredentials`. See [Credentials](credentials.md) for the fields,
 the source order, and where values are stored.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.We
 
 Each script finds the correct build for your machine, downloads `checksums.txt`
 from the same release, compares the SHA-256 of the archive against the entry for
-that file, and refuses to install if the two do not agree — or if the release
+that file, and refuses to install if the two do not agree - or if the release
 publishes no checksum for the archive at all.
 
 `install.sh` installs to `/usr/local/bin`, with `LICENSE` and the README under

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -633,20 +633,20 @@ RWR does not check the names you pass against the ones your blueprints declare.
 `rwr all --profile worx` produces no error and no warning: nothing matches
 `worx`, so only the base items are applied.
 
-**Solution**: Compare against `rwr profiles`. Names are case-sensitive — `Work`
+**Solution**: Compare against `rwr profiles`. Names are case-sensitive - `Work`
 and `work` are different profiles.
 
 #### Fewer Items Than Expected
 
 1. Verify profile names match exactly (case-sensitive)
 2. Check that the items carry the `profiles` field you think they do
-3. Confirm the blueprint type supports `profiles` at all — fonts and
+3. Confirm the blueprint type supports `profiles` at all - fonts and
    configuration blueprints do not
 
 #### More Items Than Expected
 
 1. If you passed no `--profile`, that is the cause: no filtering happens
-2. Check for items without a `profiles` field — they are base items and always
+2. Check for items without a `profiles` field - they are base items and always
    apply
 3. Verify multi-profile items aren't matching a profile you did not intend
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -5,7 +5,7 @@ The Providers system is a flexible and extensible way to manage package managers
 ## Where providers live
 
 The providers shipped with RWR are authored in **CUE** under
-`internal/system/definitions/` — the single source. The binary embeds
+`internal/system/definitions/` - the single source. The binary embeds
 those files and evaluates them at load; the schema rejects an invalid
 provider (wrong action name, missing `commands.install`, a `/tmp/` staging
 path) naming the field. There is no exported or committed second
@@ -32,7 +32,7 @@ the first one that exists:
 The current working directory is deliberately **not** searched. A provider file
 declares `exec`, `args` and `elevated = true` and those run verbatim, so
 honouring `./providers` would hand root-level execution to any directory rwr
-happens to be run from — a cloned blueprint repo, `/tmp`, a shared downloads
+happens to be run from - a cloned blueprint repo, `/tmp`, a shared downloads
 folder.
 
 For the same reason, a provider file (or its directory) that is group- or
@@ -168,7 +168,7 @@ args = ["{{ .TempDir }}/provider-install.sh"]
 `[[provider.remove.steps]]` uses the same three actions to uninstall the
 provider.
 
-Do not stage files at fixed `/tmp/` paths — any local user can pre-create or
+Do not stage files at fixed `/tmp/` paths - any local user can pre-create or
 rewrite such a path between the download and the elevated step that executes
 it. `{{ .TempDir }}` renders to a per-run `0700` directory other users cannot
 reach, and the CUE schema refuses to export a shipped provider whose install
@@ -203,17 +203,17 @@ Each step may carry: `action`, `exec`, `args`, `source`, `dest`, `content`,
 `path`, `match`, `section`, `sha256` and `condition`.
 
 `condition` is a template that gates the step: only a step whose condition
-renders truthy runs. Conditions may reference the derived predicates —
+renders truthy runs. Conditions may reference the derived predicates -
 `HasKey`, `HasInterfaces`, `HasSlot`, `HasProxy`, `HasToken`,
 `HasAuthentication`, `RequiresAuth`, `IsCustomRegistry`, `IsOverlay`,
-`IsMainRepo`, `IsLocalFile`, `IsLocalSnap`, `IsSnapStore`, `UserMode` — plus
+`IsMainRepo`, `IsLocalFile`, `IsLocalSnap`, `IsSnapStore`, `UserMode` - plus
 the step-data fields `ResetSettings` and `URL`. A condition naming anything
 else is an error at the point the step would have run.
 
 ## Template Variables
 
-Every templated field of a step is rendered — `source`, `dest`, `exec`,
-`content`, `path`, `match`, `section`, `sha256` and each entry of `args` — with
+Every templated field of a step is rendered - `source`, `dest`, `exec`,
+`content`, `path`, `match`, `section`, `sha256` and each entry of `args` - with
 `missingkey=error`, so a placeholder rwr cannot fill is reported rather than
 written to disk as literal text.
 
@@ -244,7 +244,7 @@ Repository steps render against the repository entry being processed:
 
 Install and remove steps render against a single variable: `{{ .TempDir }}`,
 the run's private staging directory. Blueprint variables (`.UserDefined`,
-`.System`, …) are **not** in scope inside provider steps — provider steps
+`.System`, …) are **not** in scope inside provider steps - provider steps
 describe the machine's package manager, not the blueprint.
 
 ## Supported Providers
@@ -309,7 +309,7 @@ touching the source tree:
 
 1. Copy an exported JSON definition from
    `internal/system/definitions/providers/` (or write a TOML file in the shape
-   shown above) into one of the search paths — `~/.config/rwr/providers/` for
+   shown above) into one of the search paths - `~/.config/rwr/providers/` for
    a per-user override.
 2. Make sure the file is not group- or world-writable, or it will be skipped.
 3. Configure the provider sections: basic information, detection rules,
@@ -318,7 +318,7 @@ touching the source tree:
    blueprints.
 
 To contribute a provider to RWR itself, author it in CUE under
-`internal/system/definitions/` — the schema there documents every field
+`internal/system/definitions/` - the schema there documents every field
 and rejects invalid definitions. That's it: no export step, nothing else to
 regenerate.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -81,7 +81,7 @@ To run your first blueprint, follow these steps:
     rwr all
     ```
 
-    With no `--profile` flag, RWR installs **everything** — the base packages
+    With no `--profile` flag, RWR installs **everything** - the base packages
     (git, curl, wget, htop) and the profiled ones too. Profiles only start
     filtering once at least one is active.
 

--- a/docs/schema-versioning.md
+++ b/docs/schema-versioning.md
@@ -72,13 +72,13 @@ blueprint as v1, because `files` did not change.
 When `packages` moves to v2, a tree can move one file at a time:
 
 ```yaml
-# init.yaml — the tree is at v1
+# init.yaml - the tree is at v1
 blueprints:
   schema_version: 1
 ```
 
 ```yaml
-# packages/dev-tools.yaml — this file is at v2
+# packages/dev-tools.yaml - this file is at v2
 schema_version: 2
 packages:
   - name: git
@@ -86,7 +86,7 @@ packages:
 ```
 
 ```yaml
-# packages/base.yaml — still at v1, and it operates
+# packages/base.yaml - still at v1, and it operates
 packages:
   - name: curl
     action: install
@@ -101,7 +101,7 @@ RWR stops when a blueprint gives a version that this build cannot read. The erro
 gives the version:
 
 ```
-packages: schema version 2 is not supported by this build (supports 1) —
+packages: schema version 2 is not supported by this build (supports 1) -
 upgrade rwr, or write this blueprint in a supported version
 ```
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -59,7 +59,7 @@ Read-only, never elevates, exits 1 on drift. Classes per item:
 
 ## `rwr uninstall`
 
-Input is the record — never the blueprint tree. With no record it refuses.
+Input is the record - never the blueprint tree. With no record it refuses.
 The not-reversible list (scripts, configuration writes, users, uploaded SSH
 keys, repositories) prints before the confirmation. Removal runs in reverse
 apply order; files and git checkouts are hash-/cleanliness-guarded, modified

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -56,14 +56,14 @@ environment overwrites a key of exactly the same name from `userDefined`.
 
 The flow also works in the other direction: RWR exports its resolved
 configuration values into the environment of every command it spawns, as
-`RWR_VAR_<KEY>` with dots turned into underscores — `log.level` becomes
+`RWR_VAR_<KEY>` with dots turned into underscores - `log.level` becomes
 `RWR_VAR_LOG_LEVEL`. A script run by a `scripts` blueprint can read them.
 Credentials (the GitHub token, the SSH private key) are **not** exported unless
 the init file names them under `exposeCredentials`; see
 [credentials](credentials.md).
 
 A credential declared in the init file's `credentials:` section is exported as
-`RWR_CRED_<NAME>` — again only when `exposeCredentials` names it — and appears
+`RWR_CRED_<NAME>` - again only when `exposeCredentials` names it - and appears
 in templates as `{{ .Credentials.<name> }}` under the same opt-in.
 
 ### Built-in Variables
@@ -96,7 +96,7 @@ RWR provides a set of built-in variables that can be used in your blueprints. Th
 > [!NOTE]
 > `{{ .Flags.ghAPIToken }}` and `{{ .Flags.sshKey }}` are withheld unless the init
 > file opts into them, because a template is written to a path the blueprint
-> itself chooses — so exposing a credential by default let any blueprint copy it
+> itself chooses - so exposing a credential by default let any blueprint copy it
 > anywhere. If a blueprint genuinely needs one, name it under
 > `exposeCredentials`; see [credentials](credentials.md).
 
@@ -180,14 +180,14 @@ path or a package name.
 `rwr validate` is more lenient about `UserDefined`: it cannot know which
 `RWR_*` variables you will export when you actually run, so a reference to a
 missing user-defined key renders empty and is not reported. References into the
-fixed `User`, `System` and `Flags` namespaces have no such excuse — their keys
-are known — so a typo like `{{ .User.hoem }}` is reported by `validate`.
+fixed `User`, `System` and `Flags` namespaces have no such excuse - their keys
+are known - so a typo like `{{ .User.hoem }}` is reported by `validate`.
 
 ### Provider steps are a different namespace
 
 The four groups above (`UserDefined`, `User`, `System`, `Flags`) are the
 template scope for **blueprint files**. The steps inside a provider definition
-render against a different namespace — the fields of the repository entry being
+render against a different namespace - the fields of the repository entry being
 processed (`{{ .URL }}`, `{{ .KeyURL }}`, `{{ .Name }}`, …) or, for install
 steps, `{{ .TempDir }}`. Blueprint variables are not visible from provider
 steps, and vice versa. See [Providers](providers.md#template-variables).

--- a/examples/imports/Arch/README.md
+++ b/examples/imports/Arch/README.md
@@ -1,10 +1,10 @@
-# Arch — Machine Tree
+# Arch - Machine Tree
 
 The per-machine side of the import example: the tree a specific machine would actually run. It imports shared definitions from [`../Common/`](../Common/) and adds machine-specific entries on top.
 
 ## Contents
 
-- `packages/packages.yaml` — imports the shared AUR base set from `Common/packages/base-aur-arch.yaml`, then adds Arch-specific packages (`nvm`, `gosec`, `protontricks`, and others) via `paru`
+- `packages/packages.yaml` - imports the shared AUR base set from `Common/packages/base-aur-arch.yaml`, then adds Arch-specific packages (`nvm`, `gosec`, `protontricks`, and others) via `paru`
 
 ## How the import works
 

--- a/examples/imports/Common/README.md
+++ b/examples/imports/Common/README.md
@@ -1,10 +1,10 @@
-# Common — Shared Definitions
+# Common - Shared Definitions
 
-Shared blueprint definitions that other trees pull in with the `import` directive. This directory is not run directly — it holds the reusable pieces.
+Shared blueprint definitions that other trees pull in with the `import` directive. This directory is not run directly - it holds the reusable pieces.
 
 ## Contents
 
-- `packages/base-aur-arch.yaml` — a base set of AUR packages (`yay`, `paru`, `visual-studio-code-bin`, `google-chrome`, `slack-desktop`, `discord`) installed via `paru`
+- `packages/base-aur-arch.yaml` - a base set of AUR packages (`yay`, `paru`, `visual-studio-code-bin`, `google-chrome`, `slack-desktop`, `discord`) installed via `paru`
 
 ## How it is used
 

--- a/examples/linux/Arch/README.md
+++ b/examples/linux/Arch/README.md
@@ -8,10 +8,10 @@ The most extensive example set in the repository. The same content appears in th
 
 ## Arch-specific details
 
-- **`pacman`** — system packages, grouped by profile (base, work, dev, gaming, personal, security)
-- **`yay`** — AUR packages (`visual-studio-code-bin`, `google-chrome`, and similar)
-- **pacman repositories** — multilib, archlinuxcn, chaotic-aur, blackarch, wine-staging, and more, gated by profiles
-- **Scripts** — use `pacman -Sy`, multilib enablement, and orphan cleanup (`pacman -Qtdq`)
+- **`pacman`** - system packages, grouped by profile (base, work, dev, gaming, personal, security)
+- **`yay`** - AUR packages (`visual-studio-code-bin`, `google-chrome`, and similar)
+- **pacman repositories** - multilib, archlinuxcn, chaotic-aur, blackarch, wine-staging, and more, gated by profiles
+- **Scripts** - use `pacman -Sy`, multilib enablement, and orphan cleanup (`pacman -Qtdq`)
 - Small `brew` (Homebrew on Linux) and `cargo` package sets are included too
 
 See the README inside each format directory for the full file list and run instructions.

--- a/examples/linux/Arch/cue/README.md
+++ b/examples/linux/Arch/cue/README.md
@@ -1,25 +1,25 @@
 # Arch Linux Examples (JSON)
 
-A full blueprint set for Arch Linux in JSON format. The sibling `yaml/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for Arch Linux in JSON format. The sibling `yaml/` and `toml/` directories contain the same content - only the file format differs.
 
 System packages install via `pacman`, AUR packages via `yay`; extra sets use `brew` and `cargo`.
 
 ## Contents
 
-- `init.json` — entry point: blueprint location, processing order, and the package managers to bootstrap and user-defined variables used by the templates
-- `bootstrap.json` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.json` — profile-grouped package sets (base, work, dev, gaming, personal, security) using `pacman` and `yay` (AUR)
-- `packages/brew.json` — a small Homebrew-on-Linux set (`neovim`, `jq`)
-- `packages/cargo.json` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.json` — pacman repositories (multilib, chaotic-aur, blackarch, and more), plus flatpak/snap examples, gated by profiles
-- `files/files.json` — file, directory, and template management (sources live in `files/src/`)
-- `fonts/fonts.json` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.json` — profile-gated repository clones (dotfiles, work, dev, gaming, personal)
-- `scripts/scripts.json` — inline shell scripts (system update via `pacman`, dev setup, gaming tweaks, security hardening)
-- `services/services.json` — systemd services (`sshd`, `docker`, `postgresql`, `nginx`, and more) per profile
-- `ssh_keys/ssh_keys.json` — ed25519/RSA key generation per profile, including a GitHub-upload example
-- `users/users.json` — user/group creation and group membership changes per profile
-- `configuration/configuration.json` — desktop settings via `gsettings` and `dconf`
+- `init.json` - entry point: blueprint location, processing order, and the package managers to bootstrap and user-defined variables used by the templates
+- `bootstrap.json` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.json` - profile-grouped package sets (base, work, dev, gaming, personal, security) using `pacman` and `yay` (AUR)
+- `packages/brew.json` - a small Homebrew-on-Linux set (`neovim`, `jq`)
+- `packages/cargo.json` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.json` - pacman repositories (multilib, chaotic-aur, blackarch, and more), plus flatpak/snap examples, gated by profiles
+- `files/files.json` - file, directory, and template management (sources live in `files/src/`)
+- `fonts/fonts.json` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.json` - profile-gated repository clones (dotfiles, work, dev, gaming, personal)
+- `scripts/scripts.json` - inline shell scripts (system update via `pacman`, dev setup, gaming tweaks, security hardening)
+- `services/services.json` - systemd services (`sshd`, `docker`, `postgresql`, `nginx`, and more) per profile
+- `ssh_keys/ssh_keys.json` - ed25519/RSA key generation per profile, including a GitHub-upload example
+- `users/users.json` - user/group creation and group membership changes per profile
+- `configuration/configuration.json` - desktop settings via `gsettings` and `dconf`
 
 ## Running
 

--- a/examples/linux/Arch/json/README.md
+++ b/examples/linux/Arch/json/README.md
@@ -1,25 +1,25 @@
 # Arch Linux Examples (JSON)
 
-A full blueprint set for Arch Linux in JSON format. The sibling `yaml/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for Arch Linux in JSON format. The sibling `yaml/` and `toml/` directories contain the same content - only the file format differs.
 
 System packages install via `pacman`, AUR packages via `yay`; extra sets use `brew` and `cargo`.
 
 ## Contents
 
-- `init.json` — entry point: blueprint location, processing order, and the package managers to bootstrap and user-defined variables used by the templates
-- `bootstrap.json` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.json` — profile-grouped package sets (base, work, dev, gaming, personal, security) using `pacman` and `yay` (AUR)
-- `packages/brew.json` — a small Homebrew-on-Linux set (`neovim`, `jq`)
-- `packages/cargo.json` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.json` — pacman repositories (multilib, chaotic-aur, blackarch, and more), plus flatpak/snap examples, gated by profiles
-- `files/files.json` — file, directory, and template management (sources live in `files/src/`)
-- `fonts/fonts.json` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.json` — profile-gated repository clones (dotfiles, work, dev, gaming, personal)
-- `scripts/scripts.json` — inline shell scripts (system update via `pacman`, dev setup, gaming tweaks, security hardening)
-- `services/services.json` — systemd services (`sshd`, `docker`, `postgresql`, `nginx`, and more) per profile
-- `ssh_keys/ssh_keys.json` — ed25519/RSA key generation per profile, including a GitHub-upload example
-- `users/users.json` — user/group creation and group membership changes per profile
-- `configuration/configuration.json` — desktop settings via `gsettings` and `dconf`
+- `init.json` - entry point: blueprint location, processing order, and the package managers to bootstrap and user-defined variables used by the templates
+- `bootstrap.json` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.json` - profile-grouped package sets (base, work, dev, gaming, personal, security) using `pacman` and `yay` (AUR)
+- `packages/brew.json` - a small Homebrew-on-Linux set (`neovim`, `jq`)
+- `packages/cargo.json` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.json` - pacman repositories (multilib, chaotic-aur, blackarch, and more), plus flatpak/snap examples, gated by profiles
+- `files/files.json` - file, directory, and template management (sources live in `files/src/`)
+- `fonts/fonts.json` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.json` - profile-gated repository clones (dotfiles, work, dev, gaming, personal)
+- `scripts/scripts.json` - inline shell scripts (system update via `pacman`, dev setup, gaming tweaks, security hardening)
+- `services/services.json` - systemd services (`sshd`, `docker`, `postgresql`, `nginx`, and more) per profile
+- `ssh_keys/ssh_keys.json` - ed25519/RSA key generation per profile, including a GitHub-upload example
+- `users/users.json` - user/group creation and group membership changes per profile
+- `configuration/configuration.json` - desktop settings via `gsettings` and `dconf`
 
 ## Running
 

--- a/examples/linux/Arch/toml/README.md
+++ b/examples/linux/Arch/toml/README.md
@@ -1,25 +1,25 @@
 # Arch Linux Examples (TOML)
 
-A full blueprint set for Arch Linux in TOML format. The sibling `yaml/` and `json/` directories contain the same content — only the file format differs.
+A full blueprint set for Arch Linux in TOML format. The sibling `yaml/` and `json/` directories contain the same content - only the file format differs.
 
 System packages install via `pacman`, AUR packages via `yay`; extra sets use `brew` and `cargo`.
 
 ## Contents
 
-- `init.toml` — entry point: blueprint location, processing order, and the package managers to bootstrap and user-defined variables used by the templates
-- `bootstrap.toml` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.toml` — profile-grouped package sets (base, work, dev, gaming, personal, security) using `pacman` and `yay` (AUR)
-- `packages/brew.toml` — a small Homebrew-on-Linux set (`neovim`, `jq`)
-- `packages/cargo.toml` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.toml` — pacman repositories (multilib, chaotic-aur, blackarch, and more), plus flatpak/snap examples, gated by profiles
-- `files/files.toml` — file, directory, and template management (sources live in `files/src/`)
-- `fonts/fonts.toml` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.toml` — profile-gated repository clones (dotfiles, work, dev, gaming, personal)
-- `scripts/scripts.toml` — inline shell scripts (system update via `pacman`, dev setup, gaming tweaks, security hardening)
-- `services/services.toml` — systemd services (`sshd`, `docker`, `postgresql`, `nginx`, and more) per profile
-- `ssh_keys/ssh_keys.toml` — ed25519/RSA key generation per profile, including a GitHub-upload example
-- `users/users.toml` — user/group creation and group membership changes per profile
-- `configuration/configuration.toml` — desktop settings via `gsettings` and `dconf`
+- `init.toml` - entry point: blueprint location, processing order, and the package managers to bootstrap and user-defined variables used by the templates
+- `bootstrap.toml` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.toml` - profile-grouped package sets (base, work, dev, gaming, personal, security) using `pacman` and `yay` (AUR)
+- `packages/brew.toml` - a small Homebrew-on-Linux set (`neovim`, `jq`)
+- `packages/cargo.toml` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.toml` - pacman repositories (multilib, chaotic-aur, blackarch, and more), plus flatpak/snap examples, gated by profiles
+- `files/files.toml` - file, directory, and template management (sources live in `files/src/`)
+- `fonts/fonts.toml` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.toml` - profile-gated repository clones (dotfiles, work, dev, gaming, personal)
+- `scripts/scripts.toml` - inline shell scripts (system update via `pacman`, dev setup, gaming tweaks, security hardening)
+- `services/services.toml` - systemd services (`sshd`, `docker`, `postgresql`, `nginx`, and more) per profile
+- `ssh_keys/ssh_keys.toml` - ed25519/RSA key generation per profile, including a GitHub-upload example
+- `users/users.toml` - user/group creation and group membership changes per profile
+- `configuration/configuration.toml` - desktop settings via `gsettings` and `dconf`
 
 ## Running
 

--- a/examples/linux/Arch/yaml/README.md
+++ b/examples/linux/Arch/yaml/README.md
@@ -1,25 +1,25 @@
 # Arch Linux Examples (YAML)
 
-A full blueprint set for Arch Linux in YAML format. The sibling `json/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for Arch Linux in YAML format. The sibling `json/` and `toml/` directories contain the same content - only the file format differs.
 
 System packages install via `pacman`, AUR packages via `yay`; extra sets use `brew` and `cargo`.
 
 ## Contents
 
-- `init.yaml` — entry point: blueprint location, processing order, and the package managers to bootstrap and user-defined variables used by the templates
-- `bootstrap.yaml` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.yaml` — profile-grouped package sets (base, work, dev, gaming, personal, security) using `pacman` and `yay` (AUR)
-- `packages/brew.yaml` — a small Homebrew-on-Linux set (`neovim`, `jq`)
-- `packages/cargo.yaml` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.yaml` — pacman repositories (multilib, chaotic-aur, blackarch, and more), plus flatpak/snap examples, gated by profiles
-- `files/files.yaml` — file, directory, and template management (sources live in `files/src/`)
-- `fonts/fonts.yaml` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.yaml` — profile-gated repository clones (dotfiles, work, dev, gaming, personal)
-- `scripts/scripts.yaml` — inline shell scripts (system update via `pacman`, dev setup, gaming tweaks, security hardening)
-- `services/services.yaml` — systemd services (`sshd`, `docker`, `postgresql`, `nginx`, and more) per profile
-- `ssh_keys/ssh_keys.yaml` — ed25519/RSA key generation per profile, including a GitHub-upload example
-- `users/users.yaml` — user/group creation and group membership changes per profile
-- `configuration/configuration.yaml` — desktop settings via `gsettings` and `dconf`
+- `init.yaml` - entry point: blueprint location, processing order, and the package managers to bootstrap and user-defined variables used by the templates
+- `bootstrap.yaml` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.yaml` - profile-grouped package sets (base, work, dev, gaming, personal, security) using `pacman` and `yay` (AUR)
+- `packages/brew.yaml` - a small Homebrew-on-Linux set (`neovim`, `jq`)
+- `packages/cargo.yaml` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.yaml` - pacman repositories (multilib, chaotic-aur, blackarch, and more), plus flatpak/snap examples, gated by profiles
+- `files/files.yaml` - file, directory, and template management (sources live in `files/src/`)
+- `fonts/fonts.yaml` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.yaml` - profile-gated repository clones (dotfiles, work, dev, gaming, personal)
+- `scripts/scripts.yaml` - inline shell scripts (system update via `pacman`, dev setup, gaming tweaks, security hardening)
+- `services/services.yaml` - systemd services (`sshd`, `docker`, `postgresql`, `nginx`, and more) per profile
+- `ssh_keys/ssh_keys.yaml` - ed25519/RSA key generation per profile, including a GitHub-upload example
+- `users/users.yaml` - user/group creation and group membership changes per profile
+- `configuration/configuration.yaml` - desktop settings via `gsettings` and `dconf`
 
 ## Running
 

--- a/examples/linux/Fedora/README.md
+++ b/examples/linux/Fedora/README.md
@@ -8,10 +8,10 @@ Example blueprint set for Fedora. The same content appears in three formats:
 
 ## Fedora-specific details
 
-- **`dnf`** — system packages, grouped by profile (base, dev, work, gaming, docker, database)
-- **dnf repositories** — RPM Fusion, vscode, docker-ce, and steam repositories, gated by profiles
-- **Scripts** — use `dnf update` for system updates
-- **Services** — systemd units including `firewalld` and `httpd`
+- **`dnf`** - system packages, grouped by profile (base, dev, work, gaming, docker, database)
+- **dnf repositories** - RPM Fusion, vscode, docker-ce, and steam repositories, gated by profiles
+- **Scripts** - use `dnf update` for system updates
+- **Services** - systemd units including `firewalld` and `httpd`
 - Small `brew` (Homebrew on Linux) and `cargo` package sets are included too
 
 See the README inside each format directory for the full file list and run instructions.

--- a/examples/linux/Fedora/cue/README.md
+++ b/examples/linux/Fedora/cue/README.md
@@ -1,25 +1,25 @@
 # Fedora Examples (JSON)
 
-A full blueprint set for Fedora in JSON format. The sibling `yaml/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for Fedora in JSON format. The sibling `yaml/` and `toml/` directories contain the same content - only the file format differs.
 
 System packages install via `dnf`; extra sets use `brew` and `cargo`.
 
 ## Contents
 
-- `init.json` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.json` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.json` — profile-grouped package sets (base, dev, work, gaming, docker, database) using `dnf`
-- `packages/brew.json` — a small Homebrew-on-Linux set (`neovim`, `jq`)
-- `packages/cargo.json` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.json` — dnf repositories (RPM Fusion, vscode, docker-ce, steam) gated by profiles
-- `files/files.json` — file, directory, and template management (sources live in `files/src/`)
-- `fonts/fonts.json` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.json` — clones the rwr repository as a sample
-- `scripts/scripts.json` — inline shell scripts (system update via `dnf`, dev setup, docker setup)
-- `services/services.json` — systemd services (`sshd`, `firewalld`, `docker`, `postgresql`, `httpd`) per profile
-- `ssh_keys/ssh_keys.json` — ed25519 key generation example
-- `users/users.json` — group creation and adding the current user to `docker`
-- `configuration/configuration.json` — desktop settings via `gsettings` and `dconf`
+- `init.json` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.json` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.json` - profile-grouped package sets (base, dev, work, gaming, docker, database) using `dnf`
+- `packages/brew.json` - a small Homebrew-on-Linux set (`neovim`, `jq`)
+- `packages/cargo.json` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.json` - dnf repositories (RPM Fusion, vscode, docker-ce, steam) gated by profiles
+- `files/files.json` - file, directory, and template management (sources live in `files/src/`)
+- `fonts/fonts.json` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.json` - clones the rwr repository as a sample
+- `scripts/scripts.json` - inline shell scripts (system update via `dnf`, dev setup, docker setup)
+- `services/services.json` - systemd services (`sshd`, `firewalld`, `docker`, `postgresql`, `httpd`) per profile
+- `ssh_keys/ssh_keys.json` - ed25519 key generation example
+- `users/users.json` - group creation and adding the current user to `docker`
+- `configuration/configuration.json` - desktop settings via `gsettings` and `dconf`
 
 ## Running
 

--- a/examples/linux/Fedora/json/README.md
+++ b/examples/linux/Fedora/json/README.md
@@ -1,25 +1,25 @@
 # Fedora Examples (JSON)
 
-A full blueprint set for Fedora in JSON format. The sibling `yaml/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for Fedora in JSON format. The sibling `yaml/` and `toml/` directories contain the same content - only the file format differs.
 
 System packages install via `dnf`; extra sets use `brew` and `cargo`.
 
 ## Contents
 
-- `init.json` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.json` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.json` — profile-grouped package sets (base, dev, work, gaming, docker, database) using `dnf`
-- `packages/brew.json` — a small Homebrew-on-Linux set (`neovim`, `jq`)
-- `packages/cargo.json` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.json` — dnf repositories (RPM Fusion, vscode, docker-ce, steam) gated by profiles
-- `files/files.json` — file, directory, and template management (sources live in `files/src/`)
-- `fonts/fonts.json` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.json` — clones the rwr repository as a sample
-- `scripts/scripts.json` — inline shell scripts (system update via `dnf`, dev setup, docker setup)
-- `services/services.json` — systemd services (`sshd`, `firewalld`, `docker`, `postgresql`, `httpd`) per profile
-- `ssh_keys/ssh_keys.json` — ed25519 key generation example
-- `users/users.json` — group creation and adding the current user to `docker`
-- `configuration/configuration.json` — desktop settings via `gsettings` and `dconf`
+- `init.json` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.json` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.json` - profile-grouped package sets (base, dev, work, gaming, docker, database) using `dnf`
+- `packages/brew.json` - a small Homebrew-on-Linux set (`neovim`, `jq`)
+- `packages/cargo.json` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.json` - dnf repositories (RPM Fusion, vscode, docker-ce, steam) gated by profiles
+- `files/files.json` - file, directory, and template management (sources live in `files/src/`)
+- `fonts/fonts.json` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.json` - clones the rwr repository as a sample
+- `scripts/scripts.json` - inline shell scripts (system update via `dnf`, dev setup, docker setup)
+- `services/services.json` - systemd services (`sshd`, `firewalld`, `docker`, `postgresql`, `httpd`) per profile
+- `ssh_keys/ssh_keys.json` - ed25519 key generation example
+- `users/users.json` - group creation and adding the current user to `docker`
+- `configuration/configuration.json` - desktop settings via `gsettings` and `dconf`
 
 ## Running
 

--- a/examples/linux/Fedora/toml/README.md
+++ b/examples/linux/Fedora/toml/README.md
@@ -1,25 +1,25 @@
 # Fedora Examples (TOML)
 
-A full blueprint set for Fedora in TOML format. The sibling `yaml/` and `json/` directories contain the same content — only the file format differs.
+A full blueprint set for Fedora in TOML format. The sibling `yaml/` and `json/` directories contain the same content - only the file format differs.
 
 System packages install via `dnf`; extra sets use `brew` and `cargo`.
 
 ## Contents
 
-- `init.toml` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.toml` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.toml` — profile-grouped package sets (base, dev, work, gaming, docker, database) using `dnf`
-- `packages/brew.toml` — a small Homebrew-on-Linux set (`neovim`, `jq`)
-- `packages/cargo.toml` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.toml` — dnf repositories (RPM Fusion, vscode, docker-ce, steam) gated by profiles
-- `files/files.toml` — file, directory, and template management (sources live in `files/src/`)
-- `fonts/fonts.toml` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.toml` — clones the rwr repository as a sample
-- `scripts/scripts.toml` — inline shell scripts (system update via `dnf`, dev setup, docker setup)
-- `services/services.toml` — systemd services (`sshd`, `firewalld`, `docker`, `postgresql`, `httpd`) per profile
-- `ssh_keys/ssh_keys.toml` — ed25519 key generation example
-- `users/users.toml` — group creation and adding the current user to `docker`
-- `configuration/configuration.toml` — desktop settings via `gsettings` and `dconf`
+- `init.toml` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.toml` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.toml` - profile-grouped package sets (base, dev, work, gaming, docker, database) using `dnf`
+- `packages/brew.toml` - a small Homebrew-on-Linux set (`neovim`, `jq`)
+- `packages/cargo.toml` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.toml` - dnf repositories (RPM Fusion, vscode, docker-ce, steam) gated by profiles
+- `files/files.toml` - file, directory, and template management (sources live in `files/src/`)
+- `fonts/fonts.toml` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.toml` - clones the rwr repository as a sample
+- `scripts/scripts.toml` - inline shell scripts (system update via `dnf`, dev setup, docker setup)
+- `services/services.toml` - systemd services (`sshd`, `firewalld`, `docker`, `postgresql`, `httpd`) per profile
+- `ssh_keys/ssh_keys.toml` - ed25519 key generation example
+- `users/users.toml` - group creation and adding the current user to `docker`
+- `configuration/configuration.toml` - desktop settings via `gsettings` and `dconf`
 
 ## Running
 

--- a/examples/linux/Fedora/yaml/README.md
+++ b/examples/linux/Fedora/yaml/README.md
@@ -1,25 +1,25 @@
 # Fedora Examples (YAML)
 
-A full blueprint set for Fedora in YAML format. The sibling `json/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for Fedora in YAML format. The sibling `json/` and `toml/` directories contain the same content - only the file format differs.
 
 System packages install via `dnf`; extra sets use `brew` and `cargo`.
 
 ## Contents
 
-- `init.yaml` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.yaml` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.yaml` — profile-grouped package sets (base, dev, work, gaming, docker, database) using `dnf`
-- `packages/brew.yaml` — a small Homebrew-on-Linux set (`neovim`, `jq`)
-- `packages/cargo.yaml` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.yaml` — dnf repositories (RPM Fusion, vscode, docker-ce, steam) gated by profiles
-- `files/files.yaml` — file, directory, and template management (sources live in `files/src/`)
-- `fonts/fonts.yaml` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.yaml` — clones the rwr repository as a sample
-- `scripts/scripts.yaml` — inline shell scripts (system update via `dnf`, dev setup, docker setup)
-- `services/services.yaml` — systemd services (`sshd`, `firewalld`, `docker`, `postgresql`, `httpd`) per profile
-- `ssh_keys/ssh_keys.yaml` — ed25519 key generation example
-- `users/users.yaml` — group creation and adding the current user to `docker`
-- `configuration/configuration.yaml` — desktop settings via `gsettings` and `dconf`
+- `init.yaml` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.yaml` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.yaml` - profile-grouped package sets (base, dev, work, gaming, docker, database) using `dnf`
+- `packages/brew.yaml` - a small Homebrew-on-Linux set (`neovim`, `jq`)
+- `packages/cargo.yaml` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.yaml` - dnf repositories (RPM Fusion, vscode, docker-ce, steam) gated by profiles
+- `files/files.yaml` - file, directory, and template management (sources live in `files/src/`)
+- `fonts/fonts.yaml` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.yaml` - clones the rwr repository as a sample
+- `scripts/scripts.yaml` - inline shell scripts (system update via `dnf`, dev setup, docker setup)
+- `services/services.yaml` - systemd services (`sshd`, `firewalld`, `docker`, `postgresql`, `httpd`) per profile
+- `ssh_keys/ssh_keys.yaml` - ed25519 key generation example
+- `users/users.yaml` - group creation and adding the current user to `docker`
+- `configuration/configuration.yaml` - desktop settings via `gsettings` and `dconf`
 
 ## Running
 

--- a/examples/linux/README.md
+++ b/examples/linux/README.md
@@ -4,9 +4,9 @@ Example blueprint sets for three Linux distributions. Each distribution director
 
 ## Distributions
 
-- [`Arch/`](./Arch/) — the most extensive example set. Uses `pacman` and `yay` (AUR), with profile-based packages, repositories, scripts, services, users, and more.
-- [`Fedora/`](./Fedora/) — uses `dnf`, with RPM Fusion and vendor repositories, systemd services, and profile-based package sets.
-- [`Ubuntu/`](./Ubuntu/) — uses `apt`, with GPG-keyed apt repositories, `ufw` scripts, and profile-based package sets.
+- [`Arch/`](./Arch/) - the most extensive example set. Uses `pacman` and `yay` (AUR), with profile-based packages, repositories, scripts, services, users, and more.
+- [`Fedora/`](./Fedora/) - uses `dnf`, with RPM Fusion and vendor repositories, systemd services, and profile-based package sets.
+- [`Ubuntu/`](./Ubuntu/) - uses `apt`, with GPG-keyed apt repositories, `ufw` scripts, and profile-based package sets.
 
 All three also include small `brew` (Homebrew on Linux) and `cargo` package examples.
 

--- a/examples/linux/Ubuntu/README.md
+++ b/examples/linux/Ubuntu/README.md
@@ -8,10 +8,10 @@ Example blueprint set for Ubuntu. The same content appears in three formats:
 
 ## Ubuntu-specific details
 
-- **`apt`** — system packages, grouped by profile (base, dev, work, gaming, docker, database)
-- **apt repositories** — docker and hashicorp repositories with GPG `key_url`, `channel`, `component`, and `arch` fields
-- **Scripts** — use `apt update && apt upgrade`, plus `ufw` firewall setup
-- **Services** — systemd units (`ssh`, `docker`, `ufw`)
+- **`apt`** - system packages, grouped by profile (base, dev, work, gaming, docker, database)
+- **apt repositories** - docker and hashicorp repositories with GPG `key_url`, `channel`, `component`, and `arch` fields
+- **Scripts** - use `apt update && apt upgrade`, plus `ufw` firewall setup
+- **Services** - systemd units (`ssh`, `docker`, `ufw`)
 - Small `brew` (Homebrew on Linux) and `cargo` package sets are included too
 
 See the README inside each format directory for the full file list and run instructions.

--- a/examples/linux/Ubuntu/cue/README.md
+++ b/examples/linux/Ubuntu/cue/README.md
@@ -1,25 +1,25 @@
 # Ubuntu Examples (JSON)
 
-A full blueprint set for Ubuntu in JSON format. The sibling `yaml/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for Ubuntu in JSON format. The sibling `yaml/` and `toml/` directories contain the same content - only the file format differs.
 
 System packages install via `apt`; extra sets use `brew` and `cargo`.
 
 ## Contents
 
-- `init.json` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.json` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.json` — profile-grouped package sets (base, dev, work, gaming, docker, database) using `apt`
-- `packages/brew.json` — a small Homebrew-on-Linux set (`neovim`, `jq`)
-- `packages/cargo.json` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.json` — apt repositories with GPG keys (docker, hashicorp)
-- `files/files.json` — copies files from `files/src/` into the home directory
-- `fonts/fonts.json` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.json` — clones the rwr repository as a sample
-- `scripts/scripts.json` — inline shell scripts (system update via `apt`, firewall, dev/server/desktop setup per profile)
-- `services/services.json` — systemd services (`ssh`, `docker`, `ufw`)
-- `ssh_keys/ssh_keys.json` — ed25519 key generation example
-- `users/users.json` — group creation plus `builder` and `deploy` user examples
-- `configuration/configuration.json` — desktop settings via `gsettings` and `dconf`
+- `init.json` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.json` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.json` - profile-grouped package sets (base, dev, work, gaming, docker, database) using `apt`
+- `packages/brew.json` - a small Homebrew-on-Linux set (`neovim`, `jq`)
+- `packages/cargo.json` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.json` - apt repositories with GPG keys (docker, hashicorp)
+- `files/files.json` - copies files from `files/src/` into the home directory
+- `fonts/fonts.json` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.json` - clones the rwr repository as a sample
+- `scripts/scripts.json` - inline shell scripts (system update via `apt`, firewall, dev/server/desktop setup per profile)
+- `services/services.json` - systemd services (`ssh`, `docker`, `ufw`)
+- `ssh_keys/ssh_keys.json` - ed25519 key generation example
+- `users/users.json` - group creation plus `builder` and `deploy` user examples
+- `configuration/configuration.json` - desktop settings via `gsettings` and `dconf`
 
 ## Running
 

--- a/examples/linux/Ubuntu/json/README.md
+++ b/examples/linux/Ubuntu/json/README.md
@@ -1,25 +1,25 @@
 # Ubuntu Examples (JSON)
 
-A full blueprint set for Ubuntu in JSON format. The sibling `yaml/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for Ubuntu in JSON format. The sibling `yaml/` and `toml/` directories contain the same content - only the file format differs.
 
 System packages install via `apt`; extra sets use `brew` and `cargo`.
 
 ## Contents
 
-- `init.json` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.json` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.json` — profile-grouped package sets (base, dev, work, gaming, docker, database) using `apt`
-- `packages/brew.json` — a small Homebrew-on-Linux set (`neovim`, `jq`)
-- `packages/cargo.json` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.json` — apt repositories with GPG keys (docker, hashicorp)
-- `files/files.json` — copies files from `files/src/` into the home directory
-- `fonts/fonts.json` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.json` — clones the rwr repository as a sample
-- `scripts/scripts.json` — inline shell scripts (system update via `apt`, firewall, dev/server/desktop setup per profile)
-- `services/services.json` — systemd services (`ssh`, `docker`, `ufw`)
-- `ssh_keys/ssh_keys.json` — ed25519 key generation example
-- `users/users.json` — group creation plus `builder` and `deploy` user examples
-- `configuration/configuration.json` — desktop settings via `gsettings` and `dconf`
+- `init.json` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.json` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.json` - profile-grouped package sets (base, dev, work, gaming, docker, database) using `apt`
+- `packages/brew.json` - a small Homebrew-on-Linux set (`neovim`, `jq`)
+- `packages/cargo.json` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.json` - apt repositories with GPG keys (docker, hashicorp)
+- `files/files.json` - copies files from `files/src/` into the home directory
+- `fonts/fonts.json` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.json` - clones the rwr repository as a sample
+- `scripts/scripts.json` - inline shell scripts (system update via `apt`, firewall, dev/server/desktop setup per profile)
+- `services/services.json` - systemd services (`ssh`, `docker`, `ufw`)
+- `ssh_keys/ssh_keys.json` - ed25519 key generation example
+- `users/users.json` - group creation plus `builder` and `deploy` user examples
+- `configuration/configuration.json` - desktop settings via `gsettings` and `dconf`
 
 ## Running
 

--- a/examples/linux/Ubuntu/toml/README.md
+++ b/examples/linux/Ubuntu/toml/README.md
@@ -1,25 +1,25 @@
 # Ubuntu Examples (TOML)
 
-A full blueprint set for Ubuntu in TOML format. The sibling `yaml/` and `json/` directories contain the same content — only the file format differs.
+A full blueprint set for Ubuntu in TOML format. The sibling `yaml/` and `json/` directories contain the same content - only the file format differs.
 
 System packages install via `apt`; extra sets use `brew` and `cargo`.
 
 ## Contents
 
-- `init.toml` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.toml` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.toml` — profile-grouped package sets (base, dev, work, gaming, docker, database) using `apt`
-- `packages/brew.toml` — a small Homebrew-on-Linux set (`neovim`, `jq`)
-- `packages/cargo.toml` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.toml` — apt repositories with GPG keys (docker, hashicorp)
-- `files/files.toml` — copies files from `files/src/` into the home directory
-- `fonts/fonts.toml` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.toml` — clones the rwr repository as a sample
-- `scripts/scripts.toml` — inline shell scripts (system update via `apt`, firewall, dev/server/desktop setup per profile)
-- `services/services.toml` — systemd services (`ssh`, `docker`, `ufw`)
-- `ssh_keys/ssh_keys.toml` — ed25519 key generation example
-- `users/users.toml` — group creation plus `builder` and `deploy` user examples
-- `configuration/configuration.toml` — desktop settings via `gsettings` and `dconf`
+- `init.toml` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.toml` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.toml` - profile-grouped package sets (base, dev, work, gaming, docker, database) using `apt`
+- `packages/brew.toml` - a small Homebrew-on-Linux set (`neovim`, `jq`)
+- `packages/cargo.toml` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.toml` - apt repositories with GPG keys (docker, hashicorp)
+- `files/files.toml` - copies files from `files/src/` into the home directory
+- `fonts/fonts.toml` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.toml` - clones the rwr repository as a sample
+- `scripts/scripts.toml` - inline shell scripts (system update via `apt`, firewall, dev/server/desktop setup per profile)
+- `services/services.toml` - systemd services (`ssh`, `docker`, `ufw`)
+- `ssh_keys/ssh_keys.toml` - ed25519 key generation example
+- `users/users.toml` - group creation plus `builder` and `deploy` user examples
+- `configuration/configuration.toml` - desktop settings via `gsettings` and `dconf`
 
 ## Running
 

--- a/examples/linux/Ubuntu/yaml/README.md
+++ b/examples/linux/Ubuntu/yaml/README.md
@@ -1,25 +1,25 @@
 # Ubuntu Examples (YAML)
 
-A full blueprint set for Ubuntu in YAML format. The sibling `json/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for Ubuntu in YAML format. The sibling `json/` and `toml/` directories contain the same content - only the file format differs.
 
 System packages install via `apt`; extra sets use `brew` and `cargo`.
 
 ## Contents
 
-- `init.yaml` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.yaml` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.yaml` — profile-grouped package sets (base, dev, work, gaming, docker, database) using `apt`
-- `packages/brew.yaml` — a small Homebrew-on-Linux set (`neovim`, `jq`)
-- `packages/cargo.yaml` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.yaml` — apt repositories with GPG keys (docker, hashicorp)
-- `files/files.yaml` — copies files from `files/src/` into the home directory
-- `fonts/fonts.yaml` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.yaml` — clones the rwr repository as a sample
-- `scripts/scripts.yaml` — inline shell scripts (system update via `apt`, firewall, dev/server/desktop setup per profile)
-- `services/services.yaml` — systemd services (`ssh`, `docker`, `ufw`)
-- `ssh_keys/ssh_keys.yaml` — ed25519 key generation example
-- `users/users.yaml` — group creation plus `builder` and `deploy` user examples
-- `configuration/configuration.yaml` — desktop settings via `gsettings` and `dconf`
+- `init.yaml` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.yaml` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.yaml` - profile-grouped package sets (base, dev, work, gaming, docker, database) using `apt`
+- `packages/brew.yaml` - a small Homebrew-on-Linux set (`neovim`, `jq`)
+- `packages/cargo.yaml` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.yaml` - apt repositories with GPG keys (docker, hashicorp)
+- `files/files.yaml` - copies files from `files/src/` into the home directory
+- `fonts/fonts.yaml` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.yaml` - clones the rwr repository as a sample
+- `scripts/scripts.yaml` - inline shell scripts (system update via `apt`, firewall, dev/server/desktop setup per profile)
+- `services/services.yaml` - systemd services (`ssh`, `docker`, `ufw`)
+- `ssh_keys/ssh_keys.yaml` - ed25519 key generation example
+- `users/users.yaml` - group creation plus `builder` and `deploy` user examples
+- `configuration/configuration.yaml` - desktop settings via `gsettings` and `dconf`
 
 ## Running
 

--- a/examples/macos/README.md
+++ b/examples/macos/README.md
@@ -8,9 +8,9 @@ Example blueprint set for macOS, provided in three formats with identical conten
 
 ## What the examples use
 
-- **Homebrew (`brew`)** — the primary package manager for all packages, plus a tap example under `repositories/`
-- **`cargo`** — Rust CLI tools
-- **`macos_defaults`** — system configuration via `defaults` (Dock, Finder)
-- **launchd services** — Docker service management under `services/`
+- **Homebrew (`brew`)** - the primary package manager for all packages, plus a tap example under `repositories/`
+- **`cargo`** - Rust CLI tools
+- **`macos_defaults`** - system configuration via `defaults` (Dock, Finder)
+- **launchd services** - Docker service management under `services/`
 
 Each format directory has its own README that lists every blueprint type included and how to run the example.

--- a/examples/macos/cue/README.md
+++ b/examples/macos/cue/README.md
@@ -1,24 +1,24 @@
 # macOS Examples (JSON)
 
-A full blueprint set for macOS in JSON format. The sibling `yaml/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for macOS in JSON format. The sibling `yaml/` and `toml/` directories contain the same content - only the file format differs.
 
 Packages install via Homebrew (`brew`); Rust tools via `cargo`.
 
 ## Contents
 
-- `init.json` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.json` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/brew.json` — profile-grouped Homebrew packages (base, dev, work, gaming)
-- `packages/cargo.json` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.json` — Homebrew tap example (`homebrew/cask-fonts`)
-- `files/files.json` — file, directory, and template management (sources live in `files/src/`)
-- `fonts/fonts.json` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.json` — clones the rwr repository as a sample
-- `scripts/scripts.json` — inline shell scripts (Homebrew update, dev setup, Docker Desktop launch)
-- `services/services.json` — launchd service management (Docker)
-- `ssh_keys/ssh_keys.json` — ed25519 key generation example
-- `users/users.json` — `developers` group and `builder` user creation
-- `configuration/configuration.json` — macOS defaults via `macos_defaults` (Dock autohide, Finder hidden files)
+- `init.json` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.json` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/brew.json` - profile-grouped Homebrew packages (base, dev, work, gaming)
+- `packages/cargo.json` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.json` - Homebrew tap example (`homebrew/cask-fonts`)
+- `files/files.json` - file, directory, and template management (sources live in `files/src/`)
+- `fonts/fonts.json` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.json` - clones the rwr repository as a sample
+- `scripts/scripts.json` - inline shell scripts (Homebrew update, dev setup, Docker Desktop launch)
+- `services/services.json` - launchd service management (Docker)
+- `ssh_keys/ssh_keys.json` - ed25519 key generation example
+- `users/users.json` - `developers` group and `builder` user creation
+- `configuration/configuration.json` - macOS defaults via `macos_defaults` (Dock autohide, Finder hidden files)
 
 ## Running
 

--- a/examples/macos/json/README.md
+++ b/examples/macos/json/README.md
@@ -1,24 +1,24 @@
 # macOS Examples (JSON)
 
-A full blueprint set for macOS in JSON format. The sibling `yaml/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for macOS in JSON format. The sibling `yaml/` and `toml/` directories contain the same content - only the file format differs.
 
 Packages install via Homebrew (`brew`); Rust tools via `cargo`.
 
 ## Contents
 
-- `init.json` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.json` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/brew.json` — profile-grouped Homebrew packages (base, dev, work, gaming)
-- `packages/cargo.json` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.json` — Homebrew tap example (`homebrew/cask-fonts`)
-- `files/files.json` — file, directory, and template management (sources live in `files/src/`)
-- `fonts/fonts.json` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.json` — clones the rwr repository as a sample
-- `scripts/scripts.json` — inline shell scripts (Homebrew update, dev setup, Docker Desktop launch)
-- `services/services.json` — launchd service management (Docker)
-- `ssh_keys/ssh_keys.json` — ed25519 key generation example
-- `users/users.json` — `developers` group and `builder` user creation
-- `configuration/configuration.json` — macOS defaults via `macos_defaults` (Dock autohide, Finder hidden files)
+- `init.json` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.json` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/brew.json` - profile-grouped Homebrew packages (base, dev, work, gaming)
+- `packages/cargo.json` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.json` - Homebrew tap example (`homebrew/cask-fonts`)
+- `files/files.json` - file, directory, and template management (sources live in `files/src/`)
+- `fonts/fonts.json` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.json` - clones the rwr repository as a sample
+- `scripts/scripts.json` - inline shell scripts (Homebrew update, dev setup, Docker Desktop launch)
+- `services/services.json` - launchd service management (Docker)
+- `ssh_keys/ssh_keys.json` - ed25519 key generation example
+- `users/users.json` - `developers` group and `builder` user creation
+- `configuration/configuration.json` - macOS defaults via `macos_defaults` (Dock autohide, Finder hidden files)
 
 ## Running
 

--- a/examples/macos/toml/README.md
+++ b/examples/macos/toml/README.md
@@ -1,24 +1,24 @@
 # macOS Examples (TOML)
 
-A full blueprint set for macOS in TOML format. The sibling `yaml/` and `json/` directories contain the same content — only the file format differs.
+A full blueprint set for macOS in TOML format. The sibling `yaml/` and `json/` directories contain the same content - only the file format differs.
 
 Packages install via Homebrew (`brew`); Rust tools via `cargo`.
 
 ## Contents
 
-- `init.toml` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.toml` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/brew.toml` — profile-grouped Homebrew packages (base, dev, work, gaming)
-- `packages/cargo.toml` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.toml` — Homebrew tap example (`homebrew/cask-fonts`)
-- `files/files.toml` — file, directory, and template management (sources live in `files/src/`)
-- `fonts/fonts.toml` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.toml` — clones the rwr repository as a sample
-- `scripts/scripts.toml` — inline shell scripts (Homebrew update, dev setup, Docker Desktop launch)
-- `services/services.toml` — launchd service management (Docker)
-- `ssh_keys/ssh_keys.toml` — ed25519 key generation example
-- `users/users.toml` — `developers` group and `builder` user creation
-- `configuration/configuration.toml` — macOS defaults via `macos_defaults` (Dock autohide, Finder hidden files)
+- `init.toml` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.toml` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/brew.toml` - profile-grouped Homebrew packages (base, dev, work, gaming)
+- `packages/cargo.toml` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.toml` - Homebrew tap example (`homebrew/cask-fonts`)
+- `files/files.toml` - file, directory, and template management (sources live in `files/src/`)
+- `fonts/fonts.toml` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.toml` - clones the rwr repository as a sample
+- `scripts/scripts.toml` - inline shell scripts (Homebrew update, dev setup, Docker Desktop launch)
+- `services/services.toml` - launchd service management (Docker)
+- `ssh_keys/ssh_keys.toml` - ed25519 key generation example
+- `users/users.toml` - `developers` group and `builder` user creation
+- `configuration/configuration.toml` - macOS defaults via `macos_defaults` (Dock autohide, Finder hidden files)
 
 ## Running
 

--- a/examples/macos/yaml/README.md
+++ b/examples/macos/yaml/README.md
@@ -1,24 +1,24 @@
 # macOS Examples (YAML)
 
-A full blueprint set for macOS in YAML format. The sibling `json/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for macOS in YAML format. The sibling `json/` and `toml/` directories contain the same content - only the file format differs.
 
 Packages install via Homebrew (`brew`); Rust tools via `cargo`.
 
 ## Contents
 
-- `init.yaml` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.yaml` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/brew.yaml` — profile-grouped Homebrew packages (base, dev, work, gaming)
-- `packages/cargo.yaml` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.yaml` — Homebrew tap example (`homebrew/cask-fonts`)
-- `files/files.yaml` — file, directory, and template management (sources live in `files/src/`)
-- `fonts/fonts.yaml` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.yaml` — clones the rwr repository as a sample
-- `scripts/scripts.yaml` — inline shell scripts (Homebrew update, dev setup, Docker Desktop launch)
-- `services/services.yaml` — launchd service management (Docker)
-- `ssh_keys/ssh_keys.yaml` — ed25519 key generation example
-- `users/users.yaml` — `developers` group and `builder` user creation
-- `configuration/configuration.yaml` — macOS defaults via `macos_defaults` (Dock autohide, Finder hidden files)
+- `init.yaml` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.yaml` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/brew.yaml` - profile-grouped Homebrew packages (base, dev, work, gaming)
+- `packages/cargo.yaml` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.yaml` - Homebrew tap example (`homebrew/cask-fonts`)
+- `files/files.yaml` - file, directory, and template management (sources live in `files/src/`)
+- `fonts/fonts.yaml` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.yaml` - clones the rwr repository as a sample
+- `scripts/scripts.yaml` - inline shell scripts (Homebrew update, dev setup, Docker Desktop launch)
+- `services/services.yaml` - launchd service management (Docker)
+- `ssh_keys/ssh_keys.yaml` - ed25519 key generation example
+- `users/users.yaml` - `developers` group and `builder` user creation
+- `configuration/configuration.yaml` - macOS defaults via `macos_defaults` (Dock autohide, Finder hidden files)
 
 ## Running
 

--- a/examples/windows/README.md
+++ b/examples/windows/README.md
@@ -8,11 +8,11 @@ Example blueprint set for Windows, provided in three formats with identical cont
 
 ## What the examples use
 
-- **Chocolatey (`chocolatey`)** — primary package manager for most packages
-- **`winget`** — Microsoft Store / winget packages (Windows Terminal, PowerShell)
-- **`scoop`** — bucket example under `repositories/`
-- **`cargo`** — Rust CLI tools
-- **`windows_registry`** — system configuration via the registry (show file extensions)
-- **Batch scripts** — WSL setup, RDP configuration, gaming tweaks, and cleanup under `scripts/`
+- **Chocolatey (`chocolatey`)** - primary package manager for most packages
+- **`winget`** - Microsoft Store / winget packages (Windows Terminal, PowerShell)
+- **`scoop`** - bucket example under `repositories/`
+- **`cargo`** - Rust CLI tools
+- **`windows_registry`** - system configuration via the registry (show file extensions)
+- **Batch scripts** - WSL setup, RDP configuration, gaming tweaks, and cleanup under `scripts/`
 
 Each format directory has its own README that lists every blueprint type included and how to run the example.

--- a/examples/windows/cue/README.md
+++ b/examples/windows/cue/README.md
@@ -1,24 +1,24 @@
 # Windows Examples (JSON)
 
-A full blueprint set for Windows in JSON format. The sibling `yaml/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for Windows in JSON format. The sibling `yaml/` and `toml/` directories contain the same content - only the file format differs.
 
 Packages install via `chocolatey` and `winget`; a `scoop` bucket and `cargo` tools are included too.
 
 ## Contents
 
-- `init.json` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.json` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.json` — profile-grouped packages using `chocolatey` and `winget` (base, dev, work, gaming)
-- `packages/cargo.json` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.json` — Scoop bucket example (`extras`)
-- `files/files.json` — copies files from `files/src/` into the home directory
-- `fonts/fonts.json` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.json` — clones the rwr repository as a sample
-- `scripts/scripts.json` — batch scripts (choco/winget updates, WSL setup, RDP config, gaming tweaks, cleanup) per profile
-- `services/services.json` — Windows services (`sshd`, `W32Time`)
-- `ssh_keys/ssh_keys.json` — ed25519 key generation example
-- `users/users.json` — `Developers` group and `builder` user creation
-- `configuration/configuration.json` — registry settings via `windows_registry` (show file extensions)
+- `init.json` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.json` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.json` - profile-grouped packages using `chocolatey` and `winget` (base, dev, work, gaming)
+- `packages/cargo.json` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.json` - Scoop bucket example (`extras`)
+- `files/files.json` - copies files from `files/src/` into the home directory
+- `fonts/fonts.json` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.json` - clones the rwr repository as a sample
+- `scripts/scripts.json` - batch scripts (choco/winget updates, WSL setup, RDP config, gaming tweaks, cleanup) per profile
+- `services/services.json` - Windows services (`sshd`, `W32Time`)
+- `ssh_keys/ssh_keys.json` - ed25519 key generation example
+- `users/users.json` - `Developers` group and `builder` user creation
+- `configuration/configuration.json` - registry settings via `windows_registry` (show file extensions)
 
 ## Running
 

--- a/examples/windows/json/README.md
+++ b/examples/windows/json/README.md
@@ -1,24 +1,24 @@
 # Windows Examples (JSON)
 
-A full blueprint set for Windows in JSON format. The sibling `yaml/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for Windows in JSON format. The sibling `yaml/` and `toml/` directories contain the same content - only the file format differs.
 
 Packages install via `chocolatey` and `winget`; a `scoop` bucket and `cargo` tools are included too.
 
 ## Contents
 
-- `init.json` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.json` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.json` — profile-grouped packages using `chocolatey` and `winget` (base, dev, work, gaming)
-- `packages/cargo.json` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.json` — Scoop bucket example (`extras`)
-- `files/files.json` — copies files from `files/src/` into the home directory
-- `fonts/fonts.json` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.json` — clones the rwr repository as a sample
-- `scripts/scripts.json` — batch scripts (choco/winget updates, WSL setup, RDP config, gaming tweaks, cleanup) per profile
-- `services/services.json` — Windows services (`sshd`, `W32Time`)
-- `ssh_keys/ssh_keys.json` — ed25519 key generation example
-- `users/users.json` — `Developers` group and `builder` user creation
-- `configuration/configuration.json` — registry settings via `windows_registry` (show file extensions)
+- `init.json` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.json` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.json` - profile-grouped packages using `chocolatey` and `winget` (base, dev, work, gaming)
+- `packages/cargo.json` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.json` - Scoop bucket example (`extras`)
+- `files/files.json` - copies files from `files/src/` into the home directory
+- `fonts/fonts.json` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.json` - clones the rwr repository as a sample
+- `scripts/scripts.json` - batch scripts (choco/winget updates, WSL setup, RDP config, gaming tweaks, cleanup) per profile
+- `services/services.json` - Windows services (`sshd`, `W32Time`)
+- `ssh_keys/ssh_keys.json` - ed25519 key generation example
+- `users/users.json` - `Developers` group and `builder` user creation
+- `configuration/configuration.json` - registry settings via `windows_registry` (show file extensions)
 
 ## Running
 

--- a/examples/windows/toml/README.md
+++ b/examples/windows/toml/README.md
@@ -1,24 +1,24 @@
 # Windows Examples (TOML)
 
-A full blueprint set for Windows in TOML format. The sibling `yaml/` and `json/` directories contain the same content — only the file format differs.
+A full blueprint set for Windows in TOML format. The sibling `yaml/` and `json/` directories contain the same content - only the file format differs.
 
 Packages install via `chocolatey` and `winget`; a `scoop` bucket and `cargo` tools are included too.
 
 ## Contents
 
-- `init.toml` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.toml` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.toml` — profile-grouped packages using `chocolatey` and `winget` (base, dev, work, gaming)
-- `packages/cargo.toml` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.toml` — Scoop bucket example (`extras`)
-- `files/files.toml` — copies files from `files/src/` into the home directory
-- `fonts/fonts.toml` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.toml` — clones the rwr repository as a sample
-- `scripts/scripts.toml` — batch scripts (choco/winget updates, WSL setup, RDP config, gaming tweaks, cleanup) per profile
-- `services/services.toml` — Windows services (`sshd`, `W32Time`)
-- `ssh_keys/ssh_keys.toml` — ed25519 key generation example
-- `users/users.toml` — `Developers` group and `builder` user creation
-- `configuration/configuration.toml` — registry settings via `windows_registry` (show file extensions)
+- `init.toml` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.toml` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.toml` - profile-grouped packages using `chocolatey` and `winget` (base, dev, work, gaming)
+- `packages/cargo.toml` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.toml` - Scoop bucket example (`extras`)
+- `files/files.toml` - copies files from `files/src/` into the home directory
+- `fonts/fonts.toml` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.toml` - clones the rwr repository as a sample
+- `scripts/scripts.toml` - batch scripts (choco/winget updates, WSL setup, RDP config, gaming tweaks, cleanup) per profile
+- `services/services.toml` - Windows services (`sshd`, `W32Time`)
+- `ssh_keys/ssh_keys.toml` - ed25519 key generation example
+- `users/users.toml` - `Developers` group and `builder` user creation
+- `configuration/configuration.toml` - registry settings via `windows_registry` (show file extensions)
 
 ## Running
 

--- a/examples/windows/yaml/README.md
+++ b/examples/windows/yaml/README.md
@@ -1,24 +1,24 @@
 # Windows Examples (YAML)
 
-A full blueprint set for Windows in YAML format. The sibling `json/` and `toml/` directories contain the same content — only the file format differs.
+A full blueprint set for Windows in YAML format. The sibling `json/` and `toml/` directories contain the same content - only the file format differs.
 
 Packages install via `chocolatey` and `winget`; a `scoop` bucket and `cargo` tools are included too.
 
 ## Contents
 
-- `init.yaml` — entry point: blueprint location, processing order, and the package managers to bootstrap
-- `bootstrap.yaml` — minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
-- `packages/packages.yaml` — profile-grouped packages using `chocolatey` and `winget` (base, dev, work, gaming)
-- `packages/cargo.yaml` — Rust tools via `cargo` (`bat`, `bottom`)
-- `repositories/repositories.yaml` — Scoop bucket example (`extras`)
-- `files/files.yaml` — copies files from `files/src/` into the home directory
-- `fonts/fonts.yaml` — Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
-- `git/git.yaml` — clones the rwr repository as a sample
-- `scripts/scripts.yaml` — batch scripts (choco/winget updates, WSL setup, RDP config, gaming tweaks, cleanup) per profile
-- `services/services.yaml` — Windows services (`sshd`, `W32Time`)
-- `ssh_keys/ssh_keys.yaml` — ed25519 key generation example
-- `users/users.yaml` — `Developers` group and `builder` user creation
-- `configuration/configuration.yaml` — registry settings via `windows_registry` (show file extensions)
+- `init.yaml` - entry point: blueprint location, processing order, and the package managers to bootstrap
+- `bootstrap.yaml` - minimal first-run setup: `git` + `curl`, a `~/git` directory, and a GitHub SSH key
+- `packages/packages.yaml` - profile-grouped packages using `chocolatey` and `winget` (base, dev, work, gaming)
+- `packages/cargo.yaml` - Rust tools via `cargo` (`bat`, `bottom`)
+- `repositories/repositories.yaml` - Scoop bucket example (`extras`)
+- `files/files.yaml` - copies files from `files/src/` into the home directory
+- `fonts/fonts.yaml` - Nerd Font installs (FiraCode, JetBrainsMono, Hack, SourceCodePro)
+- `git/git.yaml` - clones the rwr repository as a sample
+- `scripts/scripts.yaml` - batch scripts (choco/winget updates, WSL setup, RDP config, gaming tweaks, cleanup) per profile
+- `services/services.yaml` - Windows services (`sshd`, `W32Time`)
+- `ssh_keys/ssh_keys.yaml` - ed25519 key generation example
+- `users/users.yaml` - `Developers` group and `builder` user creation
+- `configuration/configuration.yaml` - registry settings via `windows_registry` (show file extensions)
 
 ## Running
 

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -54,7 +54,7 @@ func Defaults(findings Findings) Selection {
 
 // Generate writes the tree: init, per-category blueprints, and the selected
 // config files copied under files/src/. The generated tree is validated
-// before success is reported — a generator whose output needs hand-repair
+// before success is reported - a generator whose output needs hand-repair
 // has not captured anything.
 func Generate(out io.Writer, dir, format string, selection Selection, findings Findings, manifest bool, osInfo *types.OSInfo) error {
 	ext := helpers.BlueprintExtension(format)
@@ -113,7 +113,7 @@ func Generate(out io.Writer, dir, format string, selection Selection, findings F
 	if len(selection.Configs) > 0 {
 		for _, config := range selection.Configs {
 			if scan.SecretShaped(config.Rel) {
-				helpers.Say(out, "warning: capturing secret-shaped path %s — review before committing\n", config.Rel)
+				helpers.Say(out, "warning: capturing secret-shaped path %s - review before committing\n", config.Rel)
 			}
 			dest := filepath.Join(dir, "files", "src", config.Rel)
 			if err := copyPath(config.Path, dest); err != nil {
@@ -158,7 +158,7 @@ func Generate(out io.Writer, dir, format string, selection Selection, findings F
 				helpers.Say(out, "  ✗ %s: %s\n", issue.File, issue.Message)
 			}
 		}
-		return fmt.Errorf("the generated tree fails validation with %d error(s) — capture aborted, fix the selection and re-run", results.ErrorCount)
+		return fmt.Errorf("the generated tree fails validation with %d error(s) - capture aborted, fix the selection and re-run", results.ErrorCount)
 	}
 	helpers.Say(out, "Captured to %s (validated).\n", dir)
 	return nil

--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -15,7 +15,7 @@ import (
 // Run walks root and converts every blueprint, init, bootstrap, and manifest
 // file: to toFormat when set (and different from the file's own), and through
 // the migration rules when migrate is set. Comments are not preserved across
-// formats — each file carrying them is warned about. A file whose template
+// formats - each file carrying them is warned about. A file whose template
 // placeholders make it unparseable is reported and skipped, never mangled.
 func Run(out io.Writer, root, toFormat string, migrate, write bool) error {
 	changed := 0
@@ -47,7 +47,7 @@ func Run(out io.Writer, root, toFormat string, migrate, write bool) error {
 
 		var doc map[string]interface{}
 		if err := helpers.UnmarshalBlueprint(data, format, &doc); err != nil {
-			helpers.Say(out, "  ! %s: cannot parse (%v) — skipped, not mangled\n", path, err)
+			helpers.Say(out, "  ! %s: cannot parse (%v) - skipped, not mangled\n", path, err)
 			return nil
 		}
 
@@ -99,7 +99,7 @@ func Run(out io.Writer, root, toFormat string, migrate, write bool) error {
 }
 
 // migrateInitInlineSections moves the removed inline resource sections out of
-// an init file into blueprint files — the first migration rule.
+// an init file into blueprint files - the first migration rule.
 func migrateInitInlineSections(out io.Writer, initPath string, doc map[string]interface{}, format string, write bool) (int, error) {
 	sections := map[string]string{
 		"repositories": "repositories", "packages": "packages", "services": "services",

--- a/internal/credentials/keyring.go
+++ b/internal/credentials/keyring.go
@@ -16,7 +16,7 @@ import (
 const keyringService = "rwr"
 
 // Keyring is the slice of the OS keyring rwr uses. It is an interface so tests
-// run keyring-less with a fake — CI has no Secret Service, and desktop keyring
+// run keyring-less with a fake - CI has no Secret Service, and desktop keyring
 // behavior varies too much to assert against.
 type Keyring interface {
 	// Get returns the stored value, or ErrKeyringNotFound when the entry does
@@ -49,7 +49,7 @@ func (osKeyring) Set(name, value string) error {
 
 // FromKeyring reads a credential from the keyring. A missing entry or an
 // unavailable backend both yield "not found": the keyring is never
-// load-bearing on read — precedence just moves to the next source.
+// load-bearing on read - precedence just moves to the next source.
 func FromKeyring(name string) (string, bool) {
 	value, err := Ring.Get(name)
 	if err != nil || value == "" {

--- a/internal/credentials/prompt.go
+++ b/internal/credentials/prompt.go
@@ -43,7 +43,7 @@ var promptForCredential = func(name, description string) (string, error) {
 
 // offerKeyringSave asks (default yes) whether to keep a just-prompted value in
 // the OS keyring so the next run does not ask again. Declining is fine; a
-// failed save is reported but does not fail the run — the value is already in
+// failed save is reported but does not fail the run - the value is already in
 // hand.
 var offerKeyringSave = func(name, value string) {
 	confirm := true

--- a/internal/credentials/resolve.go
+++ b/internal/credentials/resolve.go
@@ -15,7 +15,7 @@ type Options struct {
 	Interactive bool
 	// Selected names the blueprint types this run executes; empty means all. A
 	// credential scoped to processors none of which are selected is not
-	// resolved — no point prompting for a value nothing will read.
+	// resolved - no point prompting for a value nothing will read.
 	Selected []string
 }
 
@@ -123,8 +123,8 @@ func scopeSelected(scope, selected []string) bool {
 
 // ResolveBuiltins records the two built-in credentials with the registry so
 // they get the same managed treatment as declared ones. Their sources are the
-// pre-existing ones — flag/config (already merged into Flags by cobra/viper
-// binding), GITHUB_TOKEN, and now the keyring — and unlike declared
+// pre-existing ones - flag/config (already merged into Flags by cobra/viper
+// binding), GITHUB_TOKEN, and now the keyring - and unlike declared
 // credentials they are optional: a run that never needs a GitHub token must
 // not fail, or prompt, because none is configured.
 func ResolveBuiltins(flags *types.Flags) {

--- a/internal/credentials/resolve_test.go
+++ b/internal/credentials/resolve_test.go
@@ -112,7 +112,7 @@ func TestResolveSourcePrecedence(t *testing.T) {
 }
 
 // A declared credential that resolves nowhere fails the run up front, naming
-// the credential and the sources tried — and in a non-TTY run the error says
+// the credential and the sources tried - and in a non-TTY run the error says
 // prompt was skipped rather than silently hanging on an invisible form.
 func TestResolveUnresolvableNamesSourcesTried(t *testing.T) {
 	withFakes(t, &fakeKeyring{}, false, nil)
@@ -203,7 +203,7 @@ func TestKeyringRoundtrip(t *testing.T) {
 	}
 }
 
-// A credential scoped to processors outside the run is not resolved — no point
+// A credential scoped to processors outside the run is not resolved - no point
 // failing (or prompting) for a value nothing will read.
 func TestResolveSkipsOutOfScopeCredentials(t *testing.T) {
 	withFakes(t, &fakeKeyring{}, false, nil)

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,7 +1,7 @@
 // Package diff compares the system scan against the resolved blueprint
 // tree: what is on the machine that the tree does not declare, and what the
-// tree declares that is gone. Its output is blueprint material — a list, a
-// paste-ready block, or a routed edit — never an apply.
+// tree declares that is gone. Its output is blueprint material - a list, a
+// paste-ready block, or a routed edit - never an apply.
 package diff
 
 import (
@@ -33,7 +33,7 @@ type Machine struct {
 }
 
 // Compute joins machine, tree, and journal. A package the journal shows a
-// run applied is not hand-added, whatever the current tree says — the tree
+// run applied is not hand-added, whatever the current tree says - the tree
 // may have changed since the apply.
 func Compute(machine Machine, plan *types.Plan, records []*state.RecordFile) []Change {
 	desired := map[string]map[string]bool{} // category → name set

--- a/internal/exectest/recorder.go
+++ b/internal/exectest/recorder.go
@@ -1,7 +1,7 @@
 // Package exectest provides a recording system.Executor for tests.
 //
 // It lets a test drive a real processor end to end and then assert on exactly what
-// the processor asked to run — the argv, the elevation, the environment — without
+// the processor asked to run - the argv, the elevation, the environment - without
 // installing packages or touching the system.
 package exectest
 

--- a/internal/helpers/blueprint_encode.go
+++ b/internal/helpers/blueprint_encode.go
@@ -10,7 +10,7 @@ import (
 )
 
 // EncodeBlueprintDoc renders a document in a target format. CUE output is JSON-form
-// CUE: valid, lossless, mechanical — idiomatic CUE is authoring work.
+// CUE: valid, lossless, mechanical - idiomatic CUE is authoring work.
 func EncodeBlueprintDoc(doc map[string]interface{}, format string) ([]byte, error) {
 	switch format {
 	case "yaml":

--- a/internal/helpers/blueprints.go
+++ b/internal/helpers/blueprints.go
@@ -38,7 +38,7 @@ func UnmarshalBlueprint(data []byte, format string, v interface{}) error {
 //
 // A silently ignored key is a blueprint that looks applied and is not: `pacakges:`
 // yields an empty section, every processor finds nothing to do, and the run
-// reports success having changed nothing. A misspelled `profiles` is worse — the
+// reports success having changed nothing. A misspelled `profiles` is worse - the
 // entry loses its scoping and runs on every machine. Both failures are invisible
 // at any log level, so they surface as "rwr didn't do anything" long after the
 // typo was written.

--- a/internal/helpers/config_edit.go
+++ b/internal/helpers/config_edit.go
@@ -12,7 +12,7 @@ import (
 
 // EditConfig opens the config file in the operator's editor, creating a
 // default file first when none exists. After the editor exits the file is
-// re-parsed; a file that no longer parses is warned about, not reverted —
+// re-parsed; a file that no longer parses is warned about, not reverted -
 // it is the operator's file.
 func EditConfig() error {
 	path := ConfigFilePath()

--- a/internal/helpers/config_view.go
+++ b/internal/helpers/config_view.go
@@ -30,7 +30,7 @@ func ConfigFilePath() string {
 
 // ConfigView renders the effective merged configuration, one key per line,
 // annotated with where each value comes from (config file, environment, or
-// the running process — flags and defaults). Secrets render as the redaction
+// the running process - flags and defaults). Secrets render as the redaction
 // placeholder unless showSecrets is set: `rwr config view` output lands in
 // terminals, scrollback, and pasted issues.
 func ConfigView(showSecrets bool) (string, error) {

--- a/internal/helpers/configperms.go
+++ b/internal/helpers/configperms.go
@@ -11,7 +11,7 @@ import (
 //
 // The config file holds a GitHub token and a base64-encoded SSH private key, so
 // it is owner-only. These were previously created with os.ModePerm (0777) and
-// written at 0644, leaving credentials world-readable — and the directory
+// written at 0644, leaving credentials world-readable - and the directory
 // world-writable on any account with a permissive umask.
 const (
 	ConfigDirPerm  os.FileMode = 0o700

--- a/internal/helpers/cue.go
+++ b/internal/helpers/cue.go
@@ -9,13 +9,13 @@ import (
 )
 
 // EvalCUEToJSON evaluates a single CUE file and returns its concrete value as
-// JSON, which feeds the same strict decode path every other format uses — so a
+// JSON, which feeds the same strict decode path every other format uses - so a
 // .cue blueprint has semantics identical to its YAML twin.
 //
 // Evaluation is sandboxed by construction: the bytes are compiled with no
 // module loader and no filesystem root, so a `.cue` file can import only CUE's
 // built-in standard library. Package imports that would resolve through the
-// module system — a path on disk, a network registry — fail to compile, and
+// module system - a path on disk, a network registry - fail to compile, and
 // @embed is not enabled. Blueprints are untrusted input; evaluation must not
 // become a way to read arbitrary files or phone home.
 //

--- a/internal/helpers/cue_test.go
+++ b/internal/helpers/cue_test.go
@@ -49,7 +49,7 @@ packages:
 	}
 }
 
-// CUE's value: constraints hold at decode time — a violated constraint is an
+// CUE's value: constraints hold at decode time - a violated constraint is an
 // error naming the position, before anything touches the machine.
 func TestUnmarshalBlueprint_CUEConstraintViolation(t *testing.T) {
 	cueData := []byte(`
@@ -82,7 +82,7 @@ func TestUnmarshalBlueprint_CUENonConcreteIsError(t *testing.T) {
 }
 
 // Evaluation is sandboxed: with no module loader and no filesystem root, a
-// .cue file can import only the built-in standard library — a package path
+// .cue file can import only the built-in standard library - a package path
 // that would resolve through disk or a registry fails to compile.
 func TestEvalCUE_ImportsOutsideStdlibRefused(t *testing.T) {
 	for name, src := range map[string]string{

--- a/internal/helpers/format_registry.go
+++ b/internal/helpers/format_registry.go
@@ -11,7 +11,7 @@ import (
 // The format registry is the single source of blueprint format knowledge:
 // which extensions exist, which format a file is, and what candidate names
 // init/bootstrap discovery should try. Before it existed this knowledge was
-// duplicated across ~15 sites, each a hand edit for every new format — and the
+// duplicated across ~15 sites, each a hand edit for every new format - and the
 // copies had already diverged (half the tree assumed one format per tree via
 // Init.Format, half derived per file).
 //
@@ -43,7 +43,7 @@ func KnownExtensions() []string {
 }
 
 // FormatForPath resolves a file's format from its extension. An extensionless
-// or unknown-extension path is a diagnostic error naming the path — not a
+// or unknown-extension path is a diagnostic error naming the path - not a
 // panic, which is what `filepath.Ext(file)[1:]` produced for an extensionless
 // file.
 func FormatForPath(path string) (string, error) {
@@ -67,7 +67,7 @@ func IsBlueprintFile(path string) bool {
 }
 
 // CandidateFilenames returns the discovery candidates for a base name
-// ("init", "bootstrap") — one per known extension, in stable order.
+// ("init", "bootstrap") - one per known extension, in stable order.
 func CandidateFilenames(base string) []string {
 	exts := KnownExtensions()
 	names := make([]string, 0, len(exts))
@@ -77,8 +77,8 @@ func CandidateFilenames(base string) []string {
 	return names
 }
 
-// CanonicalFormat maps any accepted format spelling — canonical name, alias
-// ("yml"), or dotted extension (".yaml") — to the canonical format name.
+// CanonicalFormat maps any accepted format spelling - canonical name, alias
+// ("yml"), or dotted extension (".yaml") - to the canonical format name.
 func CanonicalFormat(format string) (string, error) {
 	f := strings.ToLower(strings.TrimSpace(format))
 	if canonical, ok := formatByExtension["."+strings.TrimPrefix(f, ".")]; ok {

--- a/internal/helpers/git.go
+++ b/internal/helpers/git.go
@@ -115,7 +115,7 @@ var githubHosts = map[string]bool{
 // blueprint is: this used to attach the user's GitHub token to every non-SSH
 // remote, which meant `{url: "http://attacker.tld/r.git", private: true}` mailed
 // the PAT to the attacker in cleartext. The token now goes to GitHub's hosts and
-// nowhere else, and http:// is refused for private repos outright — there is no
+// nowhere else, and http:// is refused for private repos outright - there is no
 // safe way to send a credential over it.
 func getAuthMethod(rawURL string, initConfig *types.InitConfig) (transport.AuthMethod, error) {
 	if !strings.HasPrefix(rawURL, "git@") {

--- a/internal/helpers/init_source.go
+++ b/internal/helpers/init_source.go
@@ -32,19 +32,19 @@ var probeClient = &http.Client{Timeout: 10 * time.Second}
 // the one form Initialize consumes: an existing local file path, or an
 // https:// URL to download. One documented precedence, top wins:
 //
-//  1. "" — probe the current directory for init.{yaml,yml,json,toml}.
+//  1. "" - probe the current directory for init.{yaml,yml,json,toml}.
 //  2. An https:// URL. A GitHub /blob/ page URL is rewritten to its
 //     raw.githubusercontent.com form.
-//  3. An http:// URL — refused: the init file drives everything rwr runs.
+//  3. An http:// URL - refused: the init file drives everything rwr runs.
 //  4. An existing local file.
-//  5. An existing local directory — probed like the current directory.
+//  5. An existing local directory - probed like the current directory.
 //  6. A GitHub shorthand: owner/repo, owner/repo@ref, owner/repo/path/to/file
 //     (with optional @ref). Resolved against raw.githubusercontent.com; a bare
 //     owner/repo probes the repository root for the init file names, @ref
 //     defaults to HEAD (the default branch).
 //
 // The local-before-shorthand order means a directory literally named
-// "owner/repo" keeps working — existence on disk wins over interpretation.
+// "owner/repo" keeps working - existence on disk wins over interpretation.
 func ResolveInitSource(ref string) (string, error) {
 	if ref == "" {
 		return probeInitDir(".")
@@ -151,8 +151,8 @@ func resolveShorthand(ref string) (string, error) {
 	}
 
 	// No init file at the repo root: a manifest there marks a
-	// multi-configuration repo, which needs the whole tree locally — entry
-	// init files reference siblings — so it is cloned and probed as a local
+	// multi-configuration repo, which needs the whole tree locally - entry
+	// init files reference siblings - so it is cloned and probed as a local
 	// root. Only reached when no init file exists, same as the local rule.
 	for _, name := range CandidateFilenames("manifest") {
 		candidate := base + "/" + name

--- a/internal/helpers/manifest.go
+++ b/internal/helpers/manifest.go
@@ -22,7 +22,7 @@ func FindManifest(root string) string {
 }
 
 // LoadManifest strictly decodes a manifest and refuses entries whose init
-// path escapes the repo root — the manifest is untrusted input, and its init
+// path escapes the repo root - the manifest is untrusted input, and its init
 // paths are about to be resolved and executed.
 func LoadManifest(path string) (*types.Manifest, error) {
 	data, err := os.ReadFile(path) // #nosec G304 -- operator-supplied repo root

--- a/internal/helpers/resolve_imports.go
+++ b/internal/helpers/resolve_imports.go
@@ -11,7 +11,7 @@ import (
 // ResolveImports expands `import:` entries into the items they name, following
 // imports that the imported files declare in turn.
 //
-// Every blueprint type carried its own copy of this loop — ten of them — and none
+// Every blueprint type carried its own copy of this loop - ten of them - and none
 // recursed: an imported file's own imports were decoded into a struct and then
 // dropped, so a shared file that imports a base file contributed nothing from the
 // base. Each copy also carried cycle detection that could never fire, because it

--- a/internal/helpers/schema.go
+++ b/internal/helpers/schema.go
@@ -8,8 +8,8 @@ import (
 
 // DecodeBlueprint reads a blueprint file as the schema version it is written in.
 //
-// The version is resolved most-specific-first — the file's own `schema_version`,
-// then the tree-wide version from the init file, then v1 — and that decides which
+// The version is resolved most-specific-first - the file's own `schema_version`,
+// then the tree-wide version from the init file, then v1 - and that decides which
 // struct the bytes are decoded into. The result is converted to the canonical
 // type the processors consume, so nothing past this function needs to know more
 // than one version exists.
@@ -48,8 +48,8 @@ func DecodeBlueprint(data []byte, format, blueprintType string, treeVersion int)
 // This is the function processors call. DecodeBlueprint returning interface{} is
 // why nothing called it: every processor decodes into a concrete struct, and
 // nobody was going to write a type assertion at each of twenty call sites. The
-// result was that the whole versioning path — resolution, validation, the variant
-// registry — sat behind a function with no callers, so a blueprint declaring an
+// result was that the whole versioning path - resolution, validation, the variant
+// registry - sat behind a function with no callers, so a blueprint declaring an
 // unsupported schema_version was read as the current schema and applied to the
 // machine instead of being refused.
 func DecodeBlueprintInto[T any](data []byte, format, blueprintType string, treeVersion int, out *T) error {

--- a/internal/helpers/template.go
+++ b/internal/helpers/template.go
@@ -22,7 +22,7 @@ func ResolveTemplate(templateData []byte, variables types.Variables) ([]byte, er
 //
 // `rwr validate` cannot know which RWR_* variables the operator will export when
 // they run, so a reference to one is not a defect it can report. A run has no such
-// excuse — by then the value really is absent and would be written to disk — which
+// excuse - by then the value really is absent and would be written to disk - which
 // is why ResolveTemplate is strict and this is not.
 func ResolveTemplateForValidation(templateData []byte, variables types.Variables) ([]byte, error) {
 	rendered, err := resolveTemplate(templateData, variables, "zero")
@@ -31,7 +31,7 @@ func ResolveTemplateForValidation(templateData []byte, variables types.Variables
 	}
 	// missingkey=zero on a map[string]interface{} yields a nil interface, which
 	// text/template prints as "<no value>". Validation is checking structure, and
-	// "<no value>" in the middle of a path breaks nothing here — but leaving it in
+	// "<no value>" in the middle of a path breaks nothing here - but leaving it in
 	// would put the very string this change exists to eliminate back into the
 	// document being checked.
 	return bytes.ReplaceAll(rendered, []byte("<no value>"), nil), nil
@@ -62,7 +62,7 @@ func resolveTemplate(templateData []byte, variables types.Variables, missingKey 
 	// This used to parse with missingkey=error and then execute with
 	// missingkey=invalid, so a reference to a variable that does not exist rendered
 	// the literal string "<no value>" and the run carried on. That string then
-	// became a file path, a package name, or a service name — rwr wrote
+	// became a file path, a package name, or a service name - rwr wrote
 	// "<no value>/.vimrc" rather than telling anybody the variable was missing.
 	var renderedTemplate bytes.Buffer
 	err = t.Option("missingkey="+missingKey).Execute(&renderedTemplate, data)
@@ -74,14 +74,14 @@ func resolveTemplate(templateData []byte, variables types.Variables, missingKey 
 }
 
 // builtinRefPattern matches simple references into the fixed template
-// namespaces — {{ .User.home }}, {{ if .System.os }} — whose keys are known at
+// namespaces - {{ .User.home }}, {{ if .System.os }} - whose keys are known at
 // validate time, unlike UserDefined's.
 var builtinRefPattern = regexp.MustCompile(`\.(User|System|Flags)\.([A-Za-z0-9_]+)`)
 
 // UnknownTemplateReferences reports references into the User, System, and
 // Flags namespaces that name no existing key. UserDefined is deliberately
 // exempt: its values vary per machine, so a reference to one is not a defect
-// validate can report. The fixed namespaces have no such excuse — validate
+// validate can report. The fixed namespaces have no such excuse - validate
 // used to render every namespace with missingkey=zero, so a typo like
 // {{ .User.hoem }} validated clean and failed at run time.
 func UnknownTemplateReferences(templateData []byte, variables types.Variables) []string {

--- a/internal/helpers/template_test.go
+++ b/internal/helpers/template_test.go
@@ -211,7 +211,7 @@ func TestResolveTemplate_InvalidTemplate(t *testing.T) {
 // This used to render the literal string "<no value>" and continue, because the
 // template was parsed with missingkey=error and then executed with
 // missingkey=invalid. That string went on to become a file path, a package name or
-// a service name — rwr would write "<no value>/.vimrc" rather than say the
+// a service name - rwr would write "<no value>/.vimrc" rather than say the
 // variable was missing. Two fixtures in this repository had been rendering
 // "<no value>" for exactly this reason without anybody noticing.
 func TestResolveTemplate_MissingVariableIsAnError(t *testing.T) {

--- a/internal/processors/all.go
+++ b/internal/processors/all.go
@@ -210,7 +210,7 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 				if err != nil {
 					// Interactive runs halt so the operator can react; a
 					// headless run pushes through, collects, and exits
-					// nonzero — the first error aborting used to leave every
+					// nonzero - the first error aborting used to leave every
 					// later processor silently unrun in CI.
 					if initConfig.Variables.Flags.Interactive {
 						return fmt.Errorf("error processing %s: %w", processor, err)

--- a/internal/processors/blueprints.go
+++ b/internal/processors/blueprints.go
@@ -97,7 +97,7 @@ func GetBlueprints(initConfig *types.InitConfig) (string, error) {
 // here only produced an "Unknown processor" warning.
 //
 // users is present because it was previously missing, which meant `rwr all` never
-// created users unless the init file hand-wrote its own order — while
+// created users unless the init file hand-wrote its own order - while
 // `rwr run users` worked, making the omission easy to miss.
 var defaultRunOrder = []string{
 	types.BlueprintTypeRepositories,
@@ -125,7 +125,7 @@ func GetBlueprintRunOrder(initConfig *types.InitConfig) ([]string, error) {
 				runOrder = append(runOrder, str)
 			} else if subOrder, ok := item.(map[string]interface{}); ok {
 				// Go randomizes map iteration, so a nested order entry produced a
-				// different sequence on each run — the one thing an explicit order
+				// different sequence on each run - the one thing an explicit order
 				// is written to control. Sort so the result is at least stable;
 				// a map cannot preserve authored order, which is why the sorted
 				// keys are logged loudly enough to notice.
@@ -183,7 +183,7 @@ func GetBlueprintFileOrder(blueprintDir string, order []interface{}, runOnlyList
 	}
 
 	// The run loop only executes buckets named after a processor. A file whose
-	// path names none is typed by its content instead — the flattened and
+	// path names none is typed by its content instead - the flattened and
 	// minimal_files layouts the examples ship have no processor directories at
 	// all, and used to land in a dead bucket and exit 0 having executed
 	// nothing. A multi-type file (minimal_files' all_in_one) routes to every
@@ -199,12 +199,12 @@ func GetBlueprintFileOrder(blueprintDir string, order []interface{}, runOnlyList
 			return detected
 		}
 		log.Warnf("Blueprint file %s is not under a recognized processor directory and its content matches no blueprint type; it will NOT be executed. "+
-			"Move it under one of: packages/, repositories/, files/, services/, users/, git/, scripts/, ssh_keys/, fonts/, configuration/ — or give it top-level blueprint keys.", relPath)
+			"Move it under one of: packages/, repositories/, files/, services/, users/, git/, scripts/, ssh_keys/, fonts/, configuration/ - or give it top-level blueprint keys.", relPath)
 		return []string{processor}
 	}
 
 	// The init file configures the run, bootstrap is dispatched separately
-	// (findBootstrapFile), and a root manifest names configurations — none is
+	// (findBootstrapFile), and a root manifest names configurations - none is
 	// a processor blueprint, so none belongs in a processor bucket, nor in
 	// the unrouted warning above. The manifest matters doubly: its top-level
 	// configurations key would otherwise content-route it to the
@@ -322,7 +322,7 @@ var blueprintKeyToType = map[string]string{
 
 // detectBlueprintTypesFromContent types a blueprint by its top-level keys,
 // returning every matched type in run-order-stable form. Templates are
-// resolved leniently first — content routing happens before the run renders
+// resolved leniently first - content routing happens before the run renders
 // anything for real.
 func detectBlueprintTypesFromContent(path string, initConfig *types.InitConfig) []string {
 	top, _, err := decodeTopLevel(path, initConfig)
@@ -368,8 +368,8 @@ func decodeTopLevel(path string, initConfig *types.InitConfig) (map[string]inter
 // subsetForProcessor prepares one processor's view of a blueprint. A
 // single-type file passes through untouched, so strict decode keeps its
 // unknown-key typo protection. A multi-type file (minimal_files'
-// all_in_one.yaml) is cut down to the keys this processor reads — plus
-// schema_version — re-encoded as JSON; a top-level key belonging to no type at
+// all_in_one.yaml) is cut down to the keys this processor reads - plus
+// schema_version - re-encoded as JSON; a top-level key belonging to no type at
 // all is an error rather than something to silently drop.
 func subsetForProcessor(resolved []byte, format, processor string) ([]byte, string, error) {
 	var top map[string]interface{}

--- a/internal/processors/blueprints_walk_test.go
+++ b/internal/processors/blueprints_walk_test.go
@@ -76,7 +76,7 @@ func TestGetBlueprintFileOrder_MixedFormatTree(t *testing.T) {
 	}
 }
 
-// A flattened tree — blueprint files at the root, no processor directories —
+// A flattened tree - blueprint files at the root, no processor directories -
 // is routed by content: a file with a single recognized top-level key executes
 // under that processor. This is the layout examples/alternative_layouts ships,
 // which used to land in a dead bucket and exit 0 having executed nothing.

--- a/internal/processors/bootstrap.go
+++ b/internal/processors/bootstrap.go
@@ -15,7 +15,7 @@ import (
 
 // RunBootstrap is the standalone `rwr bootstrap` entry. Asking for bootstrap
 // by name implies wanting it to run, so an explicit invocation bypasses the
-// run-once marker — the marker exists to keep `rwr all` idempotent, not to
+// run-once marker - the marker exists to keep `rwr all` idempotent, not to
 // refuse an explicit request. The marker is still refreshed on success and
 // dry-run is still honored (no marker write, no mutations).
 func RunBootstrap(initConfig *types.InitConfig, osInfo *types.OSInfo) error {

--- a/internal/processors/bootstrap_standalone_test.go
+++ b/internal/processors/bootstrap_standalone_test.go
@@ -68,7 +68,7 @@ func TestRunBootstrap_BypassesMarker(t *testing.T) {
 		t.Fatal("marker not refreshed")
 	}
 
-	// And ProcessBootstrap without force still skips — all's gating intact.
+	// And ProcessBootstrap without force still skips - all's gating intact.
 	if err := ProcessBootstrap(filepath.Join(tree, "bootstrap.yaml"), init, &types.OSInfo{}); err != nil {
 		t.Fatalf("gated ProcessBootstrap errored instead of skipping: %v", err)
 	}

--- a/internal/processors/configuration.go
+++ b/internal/processors/configuration.go
@@ -104,7 +104,7 @@ func processDconf(blueprintDir string, config types.Configuration, initConfig *t
 	}
 
 	// dconf load reads the keyfile from stdin; there is no file argument. A
-	// literal "<" in argv is not a redirection — commands run without a shell.
+	// literal "<" in argv is not a redirection - commands run without a shell.
 	keyfile, err := os.ReadFile(file) // #nosec G304 -- blueprint-relative path, resolved above
 	if err != nil {
 		return fmt.Errorf("error reading dconf keyfile: %w", err)
@@ -256,7 +256,7 @@ var registryScripts = map[string]string{
 // whatever follows -Command, so a value such as `a'; Remove-Item C:\ -Recurse; #`
 // used to close the surrounding quote and run as a second statement; $env: lookups
 // are values, never re-parsed as code. For the same reason there is no
-// `Start-Process -Verb RunAs -ArgumentList "-Command ..."` branch any more — that
+// `Start-Process -Verb RunAs -ArgumentList "-Command ..."` branch any more - that
 // re-tokenized the already-built string a second time. Windows elevation follows
 // the same rule as every other command in rwr: the process must already be
 // elevated (see system.buildCommand).
@@ -299,8 +299,8 @@ func processWindowsRegistry(config types.Configuration, initConfig *types.InitCo
 // applyRegistryElevated performs the write through a UAC prompt.
 //
 // Windows has no sudo, so elevation means Start-Process -Verb RunAs. The obvious
-// way to do that — building the inner command as a string and handing it to
-// -ArgumentList — is what the injection fix removed: the string is tokenized a
+// way to do that - building the inner command as a string and handing it to
+// -ArgumentList - is what the injection fix removed: the string is tokenized a
 // second time by the elevated shell, so a quote in a blueprint value escapes into
 // code running as administrator.
 //

--- a/internal/processors/configuration_dconf_test.go
+++ b/internal/processors/configuration_dconf_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // dconf load takes the keyfile on stdin. Commands run without a shell, so a
-// "<" in argv is not a redirection — it reaches dconf as a literal argument
+// "<" in argv is not a redirection - it reaches dconf as a literal argument
 // and the keyfile is never read.
 func TestProcessDconf_LoadsKeyfileViaStdin(t *testing.T) {
 	rec := exectest.New()

--- a/internal/processors/credentials_test.go
+++ b/internal/processors/credentials_test.go
@@ -19,7 +19,7 @@ const (
 )
 
 // setUserDefinedAndEnvVariables exported every viper key as RWR_VAR_*, and
-// setupCommandEnvironment copies os.Environ() into every command rwr spawns — so
+// setupCommandEnvironment copies os.Environ() into every command rwr spawns - so
 // the GitHub token and the base64 SSH private key were readable by any script a
 // blueprint chose to run. Blueprints are cloned from git repositories.
 //
@@ -80,7 +80,7 @@ func TestSpawnedCommandsDoNotInheritCredentials(t *testing.T) {
 		t.Error("RWR_VAR_REPOSITORY_SSH_PRIVATE_KEY was exported")
 	}
 
-	// Non-secret config must still be exported — that is the point of the feature.
+	// Non-secret config must still be exported - that is the point of the feature.
 	if !strings.Contains(env, "RWR_VAR_REPOSITORY_INIT-FILE") {
 		t.Error("non-secret config values should still be exported to commands")
 	}

--- a/internal/processors/failures.go
+++ b/internal/processors/failures.go
@@ -11,7 +11,7 @@ import (
 // Several processors deliberately keep going when one item fails: a package that
 // is not in the repositories should not stop the twenty after it, and a git repo
 // that is temporarily unreachable should not abandon the rest of the run. That is
-// the right behavior. What was wrong is that those failures then vanished — they
+// the right behavior. What was wrong is that those failures then vanished - they
 // were logged and the run exited 0 with "RWR Run Complete!", so a run in which
 // every single package failed to install was indistinguishable from a clean one.
 //

--- a/internal/processors/failures_coverage_test.go
+++ b/internal/processors/failures_coverage_test.go
@@ -77,7 +77,7 @@ func TestProcessServices_BadServiceDoesNotStopTheRest(t *testing.T) {
 	}
 
 	if len(rec.Calls) != 2 {
-		t.Errorf("recorded %d calls, want 2 — the second service must still be attempted: %v", len(rec.Calls), rec.Calls)
+		t.Errorf("recorded %d calls, want 2 - the second service must still be attempted: %v", len(rec.Calls), rec.Calls)
 	}
 	if got := failureCount(); got != 2 {
 		t.Errorf("failureCount() = %d, want 2", got)

--- a/internal/processors/files.go
+++ b/internal/processors/files.go
@@ -154,7 +154,7 @@ func processFile(file types.File, blueprintDir string, osInfo *types.OSInfo) err
 	log.Debugf("Processing file: %s", file.Name)
 
 	// Only the actions that consume content need it. chmod/chown/chgrp/delete
-	// operate on an existing target — demanding content or source for them
+	// operate on an existing target - demanding content or source for them
 	// broke the documented metadata examples (docs/blueprints/files.md), which
 	// pair a copy entry with a follow-up chmod/chown entry. The validator
 	// (internal/validate/components.go) has always gated this by action.
@@ -184,7 +184,7 @@ func processFile(file types.File, blueprintDir string, osInfo *types.OSInfo) err
 		// A URL source without a declared digest is trusted on nothing but the
 		// TLS connection that served it. Warn now; a later major refuses.
 		if file.Sha256 == "" {
-			log.Warnf("File %s downloads %s with no sha256 declared — the content is unpinned. "+
+			log.Warnf("File %s downloads %s with no sha256 declared - the content is unpinned. "+
 				"Add sha256 to the entry; a future major version will refuse this.", file.Name, file.Source)
 		}
 		err = system.DownloadFileWithChecksum(file.Source, downloadPath, false, file.Sha256)
@@ -309,7 +309,7 @@ func createFile(file types.File, targetPath string) error {
 	}
 
 	// The mode is carried into the open so the content is never readable by anyone
-	// the blueprint did not name — a later chmod would leave a window in which a
+	// the blueprint did not name - a later chmod would leave a window in which a
 	// rendered credential sat on disk world-readable.
 	f, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY, mode) // #nosec G304 G703 -- path is operator-supplied blueprint/config input; containment added in PR8
 	if err != nil {

--- a/internal/processors/files_idempotency_test.go
+++ b/internal/processors/files_idempotency_test.go
@@ -179,8 +179,8 @@ func TestCreate_RerunIsANoOpAndKeepsTheMode(t *testing.T) {
 	}
 }
 
-// A template can render a .netrc or a gh config — that is what exposing
-// credentials to templates is for — so a rendered template with no declared mode
+// A template can render a .netrc or a gh config - that is what exposing
+// credentials to templates is for - so a rendered template with no declared mode
 // must not be created world-readable and narrowed afterwards.
 
 func TestTemplate_DefaultsToPrivateMode(t *testing.T) {

--- a/internal/processors/files_template_vars_test.go
+++ b/internal/processors/files_template_vars_test.go
@@ -66,7 +66,7 @@ templates:
 		t.Errorf("a.conf = %q, want its own override %q", got, "local")
 	}
 	if got := read("b.conf"); !strings.Contains(got, "greeting=global") {
-		t.Errorf("b.conf = %q, want the run-wide value %q — a.conf's override leaked", got, "global")
+		t.Errorf("b.conf = %q, want the run-wide value %q - a.conf's override leaked", got, "global")
 	}
 	if got := config.Variables.UserDefined["greeting"]; got != "global" {
 		t.Errorf("initConfig.Variables.UserDefined[greeting] = %v, want %q untouched", got, "global")

--- a/internal/processors/files_test.go
+++ b/internal/processors/files_test.go
@@ -696,7 +696,7 @@ func TestProcessFiles_NumericOctalModeResolvesTo0644(t *testing.T) {
 	}
 }
 
-// `mode: 644` is decimal 644, which is 0o1204 — a setuid mode with almost none
+// `mode: 644` is decimal 644, which is 0o1204 - a setuid mode with almost none
 // of the permissions the writer asked for. The run has to stop at the blueprint
 // rather than put that on disk.
 func TestProcessFiles_DecimalModeIsRefusedBeforeAnythingIsWritten(t *testing.T) {
@@ -907,7 +907,7 @@ files:
 }
 
 // The metadata actions act on an existing target and carry no content, but
-// processFile demanded content or source for every entry — which broke the
+// processFile demanded content or source for every entry - which broke the
 // documented pattern of a copy entry followed by a chmod/chown entry
 // (docs/blueprints/files.md). The validator has always allowed them.
 func TestProcessFile_MetadataActionsNeedNoContentOrSource(t *testing.T) {

--- a/internal/processors/fonts.go
+++ b/internal/processors/fonts.go
@@ -280,7 +280,7 @@ func downloadFontTarball(url, filepath string) error {
 // resolveTarEntryPath joins a tar entry name onto destDir and refuses anything that
 // would land outside it. Archive entry names are attacker-controlled data: a member
 // named "../../../etc/cron.d/x" otherwise resolves through filepath.Join to a real
-// path outside the font directory, which rwr then writes — as root, for a
+// path outside the font directory, which rwr then writes - as root, for a
 // system-scoped install.
 func resolveTarEntryPath(destDir, name string) (string, error) {
 	if name == "" {
@@ -398,8 +398,8 @@ func extractFontTarball(tarballPath, destDir string, elevated bool, osInfo *type
 }
 
 // isFontFace reports whether an archive entry is a font face rwr installs.
-// The filter used to be ".ttf" alone, so an OTF-only archive — several Nerd
-// Fonts ship only .otf — "installed successfully" with zero files written.
+// The filter used to be ".ttf" alone, so an OTF-only archive - several Nerd
+// Fonts ship only .otf - "installed successfully" with zero files written.
 func isFontFace(name string) bool {
 	lower := strings.ToLower(name)
 	return strings.HasSuffix(lower, ".ttf") || strings.HasSuffix(lower, ".otf")

--- a/internal/processors/fonts_extract_test.go
+++ b/internal/processors/fonts_extract_test.go
@@ -296,8 +296,8 @@ func assertNoFileOutside(t *testing.T, root, destDir, base string) {
 	}
 }
 
-// The face filter used to be ".ttf" alone: an OTF-only archive — several Nerd
-// Fonts ship only .otf — "installed successfully" with zero files written.
+// The face filter used to be ".ttf" alone: an OTF-only archive - several Nerd
+// Fonts ship only .otf - "installed successfully" with zero files written.
 func TestExtractFontTarball_InstallsEveryFontFace(t *testing.T) {
 	rec := exectest.New()
 	defer system.SetExecutor(rec)()

--- a/internal/processors/git.go
+++ b/internal/processors/git.go
@@ -61,7 +61,7 @@ func processGitRepositories(gitRepos []types.Git, initConfig *types.InitConfig) 
 		}
 		// The action field was decoded and never read, so `action: pull` cloned and
 		// `action: banana` was accepted. Empty and "clone" keep the original
-		// behavior — clone when missing, pull when present.
+		// behavior - clone when missing, pull when present.
 		switch repo.Action {
 		case "", types.GitActionClone, types.GitActionPull:
 		default:

--- a/internal/processors/imports_recursive_test.go
+++ b/internal/processors/imports_recursive_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/fynxlabs/rwr/internal/types"
 )
 
-// Imports never recursed. Every blueprint type carried its own copy of the loop —
-// ten of them — and each one decoded an imported file and took its items without
+// Imports never recursed. Every blueprint type carried its own copy of the loop -
+// ten of them - and each one decoded an imported file and took its items without
 // following the imports that file declared. A shared blueprint that imports a base
 // blueprint contributed nothing from the base, silently.
 //
@@ -216,7 +216,7 @@ func TestImports_SchemaVersionEnforcedThroughTheChain(t *testing.T) {
 // processor. Six processors (packages among them) used to resolve top-level
 // imports against the tree root instead, so `import: ../shared/common.yaml`
 // written in packages/base.yaml meant a different file than the same string in
-// files/base.yaml — and the spec has always mandated file-relative.
+// files/base.yaml - and the spec has always mandated file-relative.
 func TestImports_TopLevelResolvesRelativeToTheBlueprintFile(t *testing.T) {
 	useTestProvider(t)
 	root := writeFiles(t, map[string]string{

--- a/internal/processors/initialize.go
+++ b/internal/processors/initialize.go
@@ -121,7 +121,7 @@ func Initialize(initFilePath string, flags types.Flags, selectedProcessors ...st
 	// The inline resource sections were removed from the schema: they were
 	// decoded, validated, and never applied at runtime. Viper ignores unknown
 	// keys, so without this check a tree still carrying them would go from
-	// silent no-op to silent drop — an error naming the key is the only honest
+	// silent no-op to silent drop - an error naming the key is the only honest
 	// answer. (`rwr convert --migrate` is the planned mover.)
 	for _, removed := range []string{"repositories", "packages", "services", "files", "templates", "directories", "configuration"} {
 		if viper.IsSet(removed) {
@@ -158,7 +158,7 @@ func Initialize(initFilePath string, flags types.Flags, selectedProcessors ...st
 	// command, so the choice is in effect for the whole run.
 	types.SetExposedCredentials(initConfig.ExposeCredentials)
 	if len(initConfig.ExposeCredentials) > 0 {
-		log.Warnf("Blueprints in this tree can read these credentials: %v — "+
+		log.Warnf("Blueprints in this tree can read these credentials: %v - "+
 			"they are readable by any script or template the blueprints run",
 			types.ExposedCredentials())
 	}
@@ -255,7 +255,7 @@ func setUserDefinedAndEnvVariables(initConfig *types.InitConfig) error {
 		}
 	}
 
-	// Export config values as RWR_VAR_* so blueprints and scripts can read them —
+	// Export config values as RWR_VAR_* so blueprints and scripts can read them -
 	// except the credentials. setupCommandEnvironment copies os.Environ() into
 	// every command rwr spawns, so exporting the GitHub token and the base64 SSH
 	// private key put both in reach of any script a blueprint chooses to run, and
@@ -275,7 +275,7 @@ func setUserDefinedAndEnvVariables(initConfig *types.InitConfig) error {
 	}
 
 	// Managed credentials export as RWR_CRED_<NAME>, and only the ones the
-	// operator opted into with exposeCredentials whose scope admits scripts —
+	// operator opted into with exposeCredentials whose scope admits scripts -
 	// the same gate that keeps the two built-ins out of RWR_VAR_*.
 	for envKey, value := range types.ExportedCredentialEnv() {
 		if err := os.Setenv(envKey, value); err != nil {

--- a/internal/processors/initialize_test.go
+++ b/internal/processors/initialize_test.go
@@ -376,7 +376,7 @@ variables:
 	}
 }
 
-// A .cue init file is evaluated to concrete JSON and fed to viper — same
+// A .cue init file is evaluated to concrete JSON and fed to viper - same
 // treatment TOML gets via its YAML pre-conversion.
 func TestInitialize_CueInitFile(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/processors/journal.go
+++ b/internal/processors/journal.go
@@ -45,7 +45,7 @@ func closeJournal() {
 }
 
 // fileJournalIdentity resolves a file entry's on-disk destination and its
-// post-apply content hash — what a later uninstall needs for a hash-guarded
+// post-apply content hash - what a later uninstall needs for a hash-guarded
 // delete. Best effort: the identity observes the apply, it never fails it.
 func fileJournalIdentity(file types.File, blueprintDir string) map[string]string {
 	_, target, err := determineSourceAndTargetPaths(file, blueprintDir)

--- a/internal/processors/managed_auth_test.go
+++ b/internal/processors/managed_auth_test.go
@@ -45,7 +45,7 @@ credentials:
 `
 
 // A declared credential resolves at init time and stays withheld: absent from
-// template scope and the RWR_CRED_* export until exposeCredentials names it —
+// template scope and the RWR_CRED_* export until exposeCredentials names it -
 // the same treatment the two built-ins get.
 func TestInitializeResolvesAndWithholdsDeclaredCredential(t *testing.T) {
 	resetManagedAuthState(t)

--- a/internal/processors/packageManager.go
+++ b/internal/processors/packageManager.go
@@ -20,7 +20,7 @@ var (
 
 // packageManagerTempDir returns the run's private staging directory, or the
 // error that prevented creating it. A failure used to fall back to the
-// predictable <tmp>/rwr-pm-unavailable — a fixed, world-known name any local
+// predictable <tmp>/rwr-pm-unavailable - a fixed, world-known name any local
 // user can pre-create, which is exactly the class {{ .TempDir }} exists to
 // eliminate.
 func packageManagerTempDir() (string, error) {
@@ -63,7 +63,7 @@ func ProcessPackageManagers(packageManagers []types.PackageManagerInfo, osInfo *
 		// The definition-level lookup, not GetProvider: GetProvider reports a
 		// provider whose binary is missing as unavailable, and a missing
 		// binary is exactly the state an install starts from. With GetProvider
-		// here, install steps could never run at all — absent binary errored,
+		// here, install steps could never run at all - absent binary errored,
 		// present binary skipped as already installed.
 		provider, exists := system.GetProviderDefinition(pm.Name)
 		if !exists {
@@ -91,8 +91,8 @@ func ProcessPackageManagers(packageManagers []types.PackageManagerInfo, osInfo *
 		for _, rawStep := range steps {
 			// Install steps historically staged at fixed, world-known /tmp
 			// names (/tmp/brew-install.sh, a git clone into /tmp/yay). Any
-			// local user can pre-create such a path — or rewrite it between
-			// the download and the elevated step that executes it — which is
+			// local user can pre-create such a path - or rewrite it between
+			// the download and the elevated step that executes it - which is
 			// root code execution. {{ .TempDir }} renders to a per-run 0700
 			// directory other users cannot reach.
 			tempDir, err := packageManagerTempDir()

--- a/internal/processors/package_manager_staging_test.go
+++ b/internal/processors/package_manager_staging_test.go
@@ -112,23 +112,23 @@ func TestEmbeddedProviders_NoSharedOrCWDStagingInInstallSteps(t *testing.T) {
 				fields := append([]string{step.Source, step.Dest, step.Exec, step.Content}, step.Args...)
 				for _, field := range fields {
 					if strings.Contains(field, "/tmp/") {
-						t.Errorf("provider %s stages at a fixed /tmp path: %q — use {{ .TempDir }}", name, field)
+						t.Errorf("provider %s stages at a fixed /tmp path: %q - use {{ .TempDir }}", name, field)
 					}
 				}
 
 				if step.Action == "download" && !contained(step.Dest) {
-					t.Errorf("provider %s downloads to a relative dest: %q — use {{ .TempDir }}", name, step.Dest)
+					t.Errorf("provider %s downloads to a relative dest: %q - use {{ .TempDir }}", name, step.Dest)
 				}
 
 				for i, arg := range step.Args {
 					// curl -O / --remote-name writes into the CWD by construction.
 					if step.Exec == "curl" && (arg == "-O" || arg == "--remote-name") {
-						t.Errorf("provider %s uses `curl %s`, which stages in the CWD — use a download step with a {{ .TempDir }} dest", name, arg)
+						t.Errorf("provider %s uses `curl %s`, which stages in the CWD - use a download step with a {{ .TempDir }} dest", name, arg)
 					}
 					// A bare relative file name consumed or produced by a step
 					// resolves against whatever directory rwr happens to run in.
 					if stagedFile(arg) && !contained(arg) {
-						t.Errorf("provider %s references a relative staged file: args[%d] = %q — use {{ .TempDir }}", name, i, arg)
+						t.Errorf("provider %s references a relative staged file: args[%d] = %q - use {{ .TempDir }}", name, i, arg)
 					}
 				}
 			}

--- a/internal/processors/packages.go
+++ b/internal/processors/packages.go
@@ -107,7 +107,7 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 		}
 
 		// Get package names. `names` wins over `name` when both are set,
-		// matching files and fonts — packages had the precedence backwards,
+		// matching files and fonts - packages had the precedence backwards,
 		// so the same both-declared entry meant different things per type.
 		var names []string
 		if len(pkg.Names) > 0 {

--- a/internal/processors/packages_test.go
+++ b/internal/processors/packages_test.go
@@ -584,7 +584,7 @@ func TestProcessPackages_ResolveInteractiveIntegration(t *testing.T) {
 	}
 }
 
-// `names` wins over `name` when both are set — matching files and fonts.
+// `names` wins over `name` when both are set - matching files and fonts.
 // packages had it backwards.
 func TestProcessPackages_NamesWinsOverName(t *testing.T) {
 	useTestProvider(t)

--- a/internal/processors/plan.go
+++ b/internal/processors/plan.go
@@ -11,7 +11,7 @@ import (
 // ResolveStage1 reads and resolves the blueprint tree without executing
 // anything: file routing (path- and content-based), template resolution, and
 // strict decode per blueprint type. Problems become Diagnostics rather than
-// errors — one bad file must not hide the rest of the tree from a validator
+// errors - one bad file must not hide the rest of the tree from a validator
 // or a progress display. The returned error is reserved for the tree being
 // unreadable at all.
 func ResolveStage1(initConfig *types.InitConfig) (*types.Plan, error) {
@@ -48,7 +48,7 @@ func ResolveStage1(initConfig *types.InitConfig) (*types.Plan, error) {
 				continue
 			}
 
-			// Strict for the fixed namespaces, lenient only for UserDefined —
+			// Strict for the fixed namespaces, lenient only for UserDefined -
 			// the same contract validate enforces.
 			for _, ref := range helpers.UnknownTemplateReferences(raw, initConfig.Variables) {
 				plan.Diags = append(plan.Diags, types.Diagnostic{

--- a/internal/processors/plan_stage2.go
+++ b/internal/processors/plan_stage2.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ResolveStage2 completes the Plan after init and bootstrap: provider states
-// and the resource enumeration the lanes count. It cannot run earlier —
+// and the resource enumeration the lanes count. It cannot run earlier -
 // bootstrap can install the package manager later blueprints depend on, so
 // detecting providers before it produces wrong lanes.
 func ResolveStage2(plan *types.Plan) {

--- a/internal/processors/plan_test.go
+++ b/internal/processors/plan_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Stage 2 fills provider states and enumerates planned resources per
-// processor — the lane counts a progress display needs, computed after
+// processor - the lane counts a progress display needs, computed after
 // bootstrap could have installed the manager they depend on.
 func TestResolveStage2_ProvidersAndResources(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/processors/profiles.go
+++ b/internal/processors/profiles.go
@@ -27,7 +27,7 @@ type ProfileSummary struct {
 // CollectProfiles walks the blueprint tree and reports the profiles it declares.
 //
 // This reads the blueprints. `rwr profiles` used to read only the arrays written
-// inline in the init file, and profiles are declared on blueprint entries — so the
+// inline in the init file, and profiles are declared on blueprint entries - so the
 // command that exists to tell an operator what `--profile` accepts answered "No
 // profiles found" for every tree that uses profiles.
 func CollectProfiles(initConfig *types.InitConfig) (*ProfileSummary, error) {

--- a/internal/processors/progress.go
+++ b/internal/processors/progress.go
@@ -10,7 +10,7 @@ import (
 // progress tracks per-provider lane counts for one processor and emits the
 // events the TUI's lanes fill from: one ResourceDone per completed unit of
 // work plus a LaneUpdate carrying the lane's running done/total. Headless
-// runs are unaffected — LogReporter ignores both events.
+// runs are unaffected - LogReporter ignores both events.
 //
 // The lane provider key is "" for processors without providers (files,
 // services, git, scripts, …); the display layer names that lane.
@@ -47,7 +47,7 @@ func (p *progress) item(provider, name, action string, status types.Status, deta
 	p.itemIdentity(provider, name, action, status, detail, dur, nil)
 }
 
-// itemIdentity is item with extra journal identity — the fields a later
+// itemIdentity is item with extra journal identity - the fields a later
 // uninstall needs to find the thing again (a file's dest and sha256, a git
 // checkout's target). provider+name always land in the identity.
 func (p *progress) itemIdentity(provider, name, action string, status types.Status, detail string, dur time.Duration, identity map[string]string) {

--- a/internal/processors/reporter_output_test.go
+++ b/internal/processors/reporter_output_test.go
@@ -88,7 +88,7 @@ func TestAll_HeadlessOutputUnchanged(t *testing.T) {
 
 // A headless (non-interactive) run pushes through a failing processor,
 // still runs the rest, and exits nonzero. Before task 5 the first error
-// aborted the loop — this test fails on that behavior.
+// aborted the loop - this test fails on that behavior.
 func TestAll_NonInteractiveCollectsErrorsAndContinues(t *testing.T) {
 	dir := t.TempDir()
 	write := func(name, content string) {

--- a/internal/processors/repository.go
+++ b/internal/processors/repository.go
@@ -84,8 +84,8 @@ func processRepositories(repositories []types.Repository, osInfo *types.OSInfo, 
 // validateRepositoryName refuses names that would escape the paths derived
 // from them. repo.Name is blueprint-supplied and is joined into KeyPath,
 // TempKeyPath and provider-templated file names ("{{ .SourcesPath }}/
-// {{ .Name }}.list"), all written with the provider's privileges — root, for
-// every system package manager — so "../../etc/cron.d/x" would land the write
+// {{ .Name }}.list"), all written with the provider's privileges - root, for
+// every system package manager - so "../../etc/cron.d/x" would land the write
 // outside every declared boundary.
 func validateRepositoryName(name string) error {
 	if strings.TrimSpace(name) == "" {
@@ -112,7 +112,7 @@ func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *
 	// but the TLS connection that served it. Warn now; a later major refuses
 	// (the policy ratchets, never loosens).
 	if repo.Action == "add" && repo.KeyURL != "" && repo.KeySha256 == "" {
-		log.Warnf("Repository %s downloads its signing key from %s with no key_sha256 declared — "+
+		log.Warnf("Repository %s downloads its signing key from %s with no key_sha256 declared - "+
 			"the key is unpinned. Add key_sha256 to the repository entry; a future major version will refuse this.",
 			repo.Name, repo.KeyURL)
 	}
@@ -267,7 +267,7 @@ func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *
 
 // runRepositoryUpdates refreshes package lists for the providers this
 // blueprint file declared repositories for. It used to update every available
-// provider after every repositories file — a tree with three such files ran
+// provider after every repositories file - a tree with three such files ran
 // `apt update`, `dnf makecache` etc. three times each, for managers whose
 // repositories never changed.
 //

--- a/internal/processors/repository_paths.go
+++ b/internal/processors/repository_paths.go
@@ -1,7 +1,7 @@
 // Path containment: every path a repository step reads, writes, or
 // removes resolves through here, and anything outside the provider's
 // declared boundaries is refused. Steps run with the provider's
-// privileges — root, for system package managers.
+// privileges - root, for system package managers.
 
 package processors
 
@@ -74,7 +74,7 @@ func repositoryFilePath(path string, paths types.RepositoryPaths) (string, error
 // removeRepositoryPath deletes one path named by a provider's "remove" step.
 //
 // The path is a provider template rendered against blueprint values, and the
-// deletion runs with whatever privilege the provider declares — root, for every
+// deletion runs with whatever privilege the provider declares - root, for every
 // system package manager. So it is only carried out inside the directories the
 // provider itself declares in [provider.repository.paths]: neither a provider
 // definition nor a repository name may redirect a root-owned delete at
@@ -155,7 +155,7 @@ var (
 
 // repositoryTempDir returns the run's private staging directory, or the error
 // that prevented creating it. A failure used to fall back to the predictable
-// <tmp>/rwr-repo-unavailable — a fixed, world-known name any local user can
+// <tmp>/rwr-repo-unavailable - a fixed, world-known name any local user can
 // pre-create, which is exactly the class {{ .TempDir }} exists to eliminate.
 func repositoryTempDir() (string, error) {
 	repoTempDirOnce.Do(func() {
@@ -172,7 +172,7 @@ func repositoryTempDir() (string, error) {
 // repositoryWritePath resolves the destination a download/write/copy step
 // names and refuses anything outside the provider's declared repository paths
 // or the run's private staging directory. These steps run with the provider's
-// privileges — root, for every system package manager — and the destination
+// privileges - root, for every system package manager - and the destination
 // is a template rendered against blueprint values, so an unchecked dest is a
 // root-privileged write to an arbitrary path. The in-place edit and remove
 // steps have been contained since #163; this closes the same door for the

--- a/internal/processors/repository_snap_gnome_test.go
+++ b/internal/processors/repository_snap_gnome_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // The shipped snap provider gates its last add step on HasInterfaces, which was
-// absent from the predicates map — an underivable predicate is a hard error, so
+// absent from the predicates map - an underivable predicate is a hard error, so
 // every snap repository add failed at that step, interface or no interface.
 func TestProcessRepositories_SnapAddWithoutInterface(t *testing.T) {
 	sourcesDir, keysDir := repoDirs(t)
@@ -90,7 +90,7 @@ func TestProcessRepositories_SnapAddConnectsInterface(t *testing.T) {
 }
 
 // The shipped gnome-extensions provider gates its last remove step on
-// ResetSettings, which no blueprint field carried — so every extension remove
+// ResetSettings, which no blueprint field carried - so every extension remove
 // failed at the reset step.
 func TestProcessRepositories_GnomeExtensionsRemove(t *testing.T) {
 	sourcesDir, keysDir := repoDirs(t)

--- a/internal/processors/repository_steps.go
+++ b/internal/processors/repository_steps.go
@@ -1,5 +1,5 @@
 // The step machinery: rendering a provider's declared repository steps
-// into executable commands — the template field namespace, the condition
+// into executable commands - the template field namespace, the condition
 // predicates, and the per-field rendering.
 
 package processors
@@ -15,8 +15,8 @@ import (
 )
 
 // repositoryStepData is the value a provider's repository action steps are
-// rendered against. Provider definitions are Go templates — apt writes
-// "deb [arch={{ .Arch }} signed-by={{ .KeyPath }}] {{ .URL }} ..." — so every
+// rendered against. Provider definitions are Go templates - apt writes
+// "deb [arch={{ .Arch }} signed-by={{ .KeyPath }}] {{ .URL }} ..." - so every
 // placeholder they may use has to have a key here, and anything else is a
 // blueprint or provider defect rather than a value to silently drop.
 func repositoryStepData(repo types.Repository, paths types.RepositoryPaths, provider *types.Provider) (map[string]any, error) {
@@ -91,7 +91,7 @@ func repositoryStepData(repo types.Repository, paths types.RepositoryPaths, prov
 // predicate a provider names but that is absent from this map is an error at
 // the point the step would have run: the conditions used to decode into
 // nothing, so every step ran and flatpak added its remote both --user and
-// --system — silently skipping an underivable predicate would reintroduce the
+// --system - silently skipping an underivable predicate would reintroduce the
 // same class of bug in the other direction.
 func repositoryPredicates(repo types.Repository, provider *types.Provider) map[string]any {
 	localURL := isLocalPath(repo.URL)
@@ -131,7 +131,7 @@ func repositoryPredicates(repo types.Repository, provider *types.Provider) map[s
 // stepCondition reports whether a step's condition holds.
 //
 // Only an explicit truthy rendering runs the step. A condition that renders to
-// anything else — including the empty string a nil or missing value produces —
+// anything else - including the empty string a nil or missing value produces -
 // means the provider did not ask for this step on this repository.
 func stepCondition(condition string, data map[string]any) (bool, error) {
 	if strings.TrimSpace(condition) == "" {

--- a/internal/processors/repository_test.go
+++ b/internal/processors/repository_test.go
@@ -218,7 +218,7 @@ func TestProcessRepositories_UpdatesOnlyDeclaredProviders(t *testing.T) {
 }
 
 // A placeholder rwr has no value for is a provider or blueprint defect. Rendering
-// it as "<no value>" — or passing it through verbatim, as rwr used to — turns it
+// it as "<no value>" - or passing it through verbatim, as rwr used to - turns it
 // into a file path or a URL instead.
 func TestProcessRepositories_UnknownPlaceholderIsAnError(t *testing.T) {
 	rec := exectest.New()
@@ -796,7 +796,7 @@ func TestProcessRepositories_UnknownConditionPredicateIsAnError(t *testing.T) {
 	}
 }
 
-// A false condition is not an error, and the step it gates does not run — even
+// A false condition is not an error, and the step it gates does not run - even
 // when that step references data this repository does not carry.
 func TestProcessRepositories_FalseConditionSkipsStep(t *testing.T) {
 	rec := exectest.New()

--- a/internal/processors/run_order_test.go
+++ b/internal/processors/run_order_test.go
@@ -9,7 +9,7 @@ import (
 
 // Every processor named in the default run order must have a dispatch case in
 // All. An entry without one falls through to `default:` and logs "Unknown
-// processor", so a blueprint of that type is silently skipped — which is what
+// processor", so a blueprint of that type is silently skipped - which is what
 // packageManagers did.
 func TestDefaultRunOrder_EveryEntryIsDispatched(t *testing.T) {
 	dispatched := []string{
@@ -34,7 +34,7 @@ func TestDefaultRunOrder_EveryEntryIsDispatched(t *testing.T) {
 }
 
 // users was missing from the default order, so `rwr all` never processed user
-// blueprints unless the init file hand-wrote its own order — even though
+// blueprints unless the init file hand-wrote its own order - even though
 // `rwr run users` worked, which made the gap easy to miss.
 func TestDefaultRunOrder_IncludesEveryDispatchableProcessor(t *testing.T) {
 	// Every type that has a dispatch case in All and can appear as a blueprint

--- a/internal/processors/schema_version_test.go
+++ b/internal/processors/schema_version_test.go
@@ -33,7 +33,7 @@ func newTestOSInfo() *types.OSInfo {
 // platform has, so these tests assert how rwr builds a command rather than
 // asserting what the runner happens to have installed.
 //
-// Without it the tests pass on a machine with pacman and fail on one without —
+// Without it the tests pass on a machine with pacman and fail on one without -
 // which is exactly what happened: green on an Arch workstation, red on CI's
 // Ubuntu runner.
 func useTestProvider(t *testing.T) {
@@ -246,7 +246,7 @@ func TestProcessors_ImportedFileVersionIsEnforced(t *testing.T) {
 	}
 }
 
-// The error has to say which version was asked for and which are supported —
+// The error has to say which version was asked for and which are supported -
 // "invalid blueprint" sends the operator looking in the wrong place.
 func TestProcessors_UnsupportedVersionErrorIsActionable(t *testing.T) {
 	defer system.SetExecutor(exectest.New())()

--- a/internal/processors/scripts.go
+++ b/internal/processors/scripts.go
@@ -106,7 +106,7 @@ func runScript(script types.Script, osInfo *types.OSInfo, initConfig *types.Init
 	} else if script.Content != "" {
 		// Write the script content to a temporary file, named for the executor
 		// that will run it. The extension used to be .sh unconditionally, and
-		// `powershell -File` refuses any file not ending in .ps1 — so every
+		// `powershell -File` refuses any file not ending in .ps1 - so every
 		// inline script on Windows (where powershell is the default executor)
 		// failed before its first line ran.
 		tempFile, err := os.CreateTemp("", fmt.Sprintf("%s-*%s", script.Name, scriptTempExtension(script.Exec)))
@@ -180,7 +180,7 @@ func runScript(script types.Script, osInfo *types.OSInfo, initConfig *types.Init
 
 	// Append the script arguments. `args` is a single string in the blueprint, and
 	// the shell used to word-split it on the way to the script. Now that commands are
-	// argv, split it here — otherwise `args: "--verbose --out /tmp"` would arrive as
+	// argv, split it here - otherwise `args: "--verbose --out /tmp"` would arrive as
 	// one argument instead of three.
 	if script.Args != "" {
 		log.Debugf("Adding script arguments: %s", script.Args)

--- a/internal/processors/scripts_argv_test.go
+++ b/internal/processors/scripts_argv_test.go
@@ -104,7 +104,7 @@ scripts:
 
 // Inline `content:` scripts used to stage as *.sh unconditionally, but the
 // Windows default executor is `powershell -File`, which refuses any file not
-// ending in .ps1 — every inline script on Windows failed before its first line.
+// ending in .ps1 - every inline script on Windows failed before its first line.
 func TestProcessScripts_InlineContentExtensionMatchesExecutor(t *testing.T) {
 	rec := exectest.New()
 	defer system.SetExecutor(rec)()
@@ -132,6 +132,6 @@ scripts:
 		t.Fatalf("powershell args = %v, want [-File <path>]", calls[0].Args)
 	}
 	if got := calls[0].Args[1]; filepath.Ext(got) != ".ps1" {
-		t.Errorf("staged script = %q, want a .ps1 extension — powershell -File refuses anything else", got)
+		t.Errorf("staged script = %q, want a .ps1 extension - powershell -File refuses anything else", got)
 	}
 }

--- a/internal/processors/services_elevation_test.go
+++ b/internal/processors/services_elevation_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // services: action: create with inline content wrote via a plain os.WriteFile
-// on all three platforms, ignoring `elevated` — a unit file under /etc/systemd
+// on all three platforms, ignoring `elevated` - a unit file under /etc/systemd
 // died with EACCES for any non-root run that declared elevated: true.
 func TestCreateServiceFile_ContentHonorsElevated(t *testing.T) {
 	rec := exectest.New()

--- a/internal/processors/services_idempotency_test.go
+++ b/internal/processors/services_idempotency_test.go
@@ -106,7 +106,7 @@ func TestCreateWindowsService_MissingServiceIsCreated(t *testing.T) {
 		Target:  target,
 	}, &types.OSInfo{}, &types.InitConfig{})
 
-	// The recorder fails every call, so sc create errors — what matters is
+	// The recorder fails every call, so sc create errors - what matters is
 	// that it was attempted after the probe said the service is absent.
 	if err == nil {
 		t.Fatal("expected the failing sc create to surface")

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -218,7 +218,7 @@ func generateSSHKey(sshKey types.SSHKey, initConfig *types.InitConfig) (string, 
 	sshKey = withSSHKeyDefaults(sshKey)
 
 	// Expand a leading ~ here. Commands are argv now, so no shell expands it on
-	// the way to ssh-keygen — an unexpanded "~/.ssh" would create a directory
+	// the way to ssh-keygen - an unexpanded "~/.ssh" would create a directory
 	// literally named "~" in the working directory.
 	sshPath := filepath.Join(system.ExpandPath(sshKey.Path), sshKey.Name)
 
@@ -453,7 +453,7 @@ func getGitHubToken(initConfig *types.InitConfig) (string, string, error) {
 		return token, "GITHUB_TOKEN", nil
 	}
 
-	// Priority 3: OS keyring — where the device flow saves new tokens
+	// Priority 3: OS keyring - where the device flow saves new tokens
 	if token, ok := credentials.FromKeyring("gh_api_token"); ok {
 		log.Debugf("Using GitHub token from the OS keyring")
 		return token, "keyring", nil

--- a/internal/processors/ssh_key_test.go
+++ b/internal/processors/ssh_key_test.go
@@ -222,8 +222,8 @@ func TestCopySSHKeyToGitHub_Success(t *testing.T) {
 }
 
 // TestCopySSHKeyToGitHub_Errors drives the real upload against a local server.
-// The duplicate-key 422 is the converged state — the key already being on the
-// account is what copy_to_github asks for — so it succeeds; every other
+// The duplicate-key 422 is the converged state - the key already being on the
+// account is what copy_to_github asks for - so it succeeds; every other
 // failure still errors.
 func TestCopySSHKeyToGitHub_Errors(t *testing.T) {
 	duplicate := githubError{

--- a/internal/processors/templates.go
+++ b/internal/processors/templates.go
@@ -91,7 +91,7 @@ func processTemplate(template types.File, blueprintDir string, osInfo *types.OSI
 	log.Debug("Resolving template variables")
 	// Copying the struct still shares the UserDefined map, so writing template
 	// overrides into it mutated initConfig for every later template and
-	// blueprint — a per-template variable permanently clobbered a run-wide one
+	// blueprint - a per-template variable permanently clobbered a run-wide one
 	// of the same name. Merge into a fresh map instead.
 	mergedVariables := initConfig.Variables
 	mergedVariables.UserDefined = make(map[string]interface{}, len(initConfig.Variables.UserDefined)+len(template.Variables))

--- a/internal/processors/tilde_test.go
+++ b/internal/processors/tilde_test.go
@@ -13,7 +13,7 @@ import (
 
 // A blueprint that writes `path: ~/.ssh` must still put the key in the home
 // directory. Commands no longer pass through a shell, so nothing expands the ~
-// on the way to ssh-keygen — without expansion the key lands in a directory
+// on the way to ssh-keygen - without expansion the key lands in a directory
 // literally named "~" under the working directory.
 func TestSSHKeyPathExpandsTilde(t *testing.T) {
 	home, err := os.UserHomeDir()

--- a/internal/processors/user.go
+++ b/internal/processors/user.go
@@ -37,7 +37,7 @@ const macDefaultPrimaryGroupID = "20"
 //
 // Linux goes through shadow-utils (useradd/usermod/userdel, groupadd/groupmod,
 // gpasswd); macOS goes through Open Directory (dscl, sysadminctl, dseditgroup,
-// pwpolicy) — none of the shadow-utils binaries exist there. Windows has no
+// pwpolicy) - none of the shadow-utils binaries exist there. Windows has no
 // implementation and logs a warning per entry.
 func ProcessUsers(blueprintData []byte, blueprintDir string, format string, initConfig *types.InitConfig) error {
 	var usersData types.UsersData
@@ -202,7 +202,7 @@ func processUsers(users []types.User, initConfig *types.InitConfig, track *progr
 // ---------------------------------------------------------------------------
 
 // groupExists probes for a group. In dry-run mode nothing is executed, so the
-// probe returns assumeDryRun — callers pass whichever answer keeps the dry run
+// probe returns assumeDryRun - callers pass whichever answer keeps the dry run
 // printing the work it would do (absent before a create, present before a
 // remove) instead of a skip message.
 func groupExists(name string, initConfig *types.InitConfig, assumeDryRun bool) bool {

--- a/internal/processors/user_opendirectory.go
+++ b/internal/processors/user_opendirectory.go
@@ -1,5 +1,5 @@
 // The Open Directory backend: macOS user and group management via
-// dscl. Selected at runtime on the detected OS — deliberately NOT a
+// dscl. Selected at runtime on the detected OS - deliberately NOT a
 // _darwin.go file, which would carry an implicit GOOS build constraint
 // and break cross-platform validation.
 
@@ -370,7 +370,7 @@ func macAddGroups(name string, groups []string, initConfig *types.InitConfig) er
 // macSetPassword sets the account password through dscl.
 //
 // macOS stores a salted SHA-512 PBKDF2 blob it computes itself, so unlike Linux
-// it needs the cleartext password — there is no hash to pre-compute. That value
+// it needs the cleartext password - there is no hash to pre-compute. That value
 // therefore appears in the argv of a sudo'd process, visible in `ps` to every
 // local user and recorded in sudo's syslog entry.
 //

--- a/internal/processors/user_shadowutils.go
+++ b/internal/processors/user_shadowutils.go
@@ -1,5 +1,5 @@
 // The shadow-utils backend: Linux user and group management via
-// groupadd/usermod and friends. Selected at runtime on the detected OS —
+// groupadd/usermod and friends. Selected at runtime on the detected OS -
 // deliberately NOT a _linux.go file, which would carry an implicit GOOS
 // build constraint and break cross-platform validation.
 
@@ -232,7 +232,7 @@ func removeUserLinux(user types.User, initConfig *types.InitConfig) error {
 // setLinuxPassword sets the account password by piping "<name>:<value>" to
 // chpasswd on standard input.
 //
-// The obvious approach — useradd/usermod --password — is wrong twice over. That
+// The obvious approach - useradd/usermod --password - is wrong twice over. That
 // flag writes its argument verbatim into the hash field of /etc/shadow, so a
 // cleartext value does not become the account's password; it becomes a hash
 // nothing can ever match and the account silently has none. And because the

--- a/internal/processors/user_shadowutils_test.go
+++ b/internal/processors/user_shadowutils_test.go
@@ -688,7 +688,7 @@ func TestRemoveUser_InteractiveOverride(t *testing.T) {
 //
 // These live in user_test.go rather than user_darwin_test.go on purpose: Go
 // applies an implicit build constraint to any file ending in _darwin_test.go, so
-// the macOS cases would never compile on the Linux CI runner — which is the only
+// the macOS cases would never compile on the Linux CI runner - which is the only
 // place they can run at all.
 // ---------------------------------------------------------------------------
 

--- a/internal/prompts/github.go
+++ b/internal/prompts/github.go
@@ -135,14 +135,14 @@ func SaveGitHubTokenToConfig(token string, initConfig *types.InitConfig) error {
 	types.SetCredentialValue("gh_api_token", token)
 
 	// Keyring first: it is the only store that keeps the token off disk in
-	// plaintext. The config file is the fallback, not a second copy — when the
+	// plaintext. The config file is the fallback, not a second copy - when the
 	// keyring save succeeds, no file gains the token value.
 	saveErr := credentials.SaveToKeyring("gh_api_token", token)
 	if saveErr == nil {
 		log.Debugf("Token saved to the OS keyring")
 		return nil
 	}
-	log.Warnf("OS keyring unavailable (%v); saving the token to %s instead — "+
+	log.Warnf("OS keyring unavailable (%v); saving the token to %s instead - "+
 		"it is stored in plaintext, readable only by your user (0600)",
 		saveErr, viper.ConfigFileUsed())
 
@@ -152,7 +152,7 @@ func SaveGitHubTokenToConfig(token string, initConfig *types.InitConfig) error {
 	// The file holds the token, and viper writes at 0644 with no way to ask
 	// for less. Pre-creating it at 0600 means the token is never on disk
 	// world-readable, not even briefly. ConfigFileUsed is empty when no config
-	// was loaded — then SafeWriteConfig below creates the file and the tighten
+	// was loaded - then SafeWriteConfig below creates the file and the tighten
 	// after it is the only guard (a first-run-only window).
 	if path := viper.ConfigFileUsed(); path != "" {
 		if err := helpers.PrecreateSecureConfigFile(path); err != nil {

--- a/internal/prompts/github_save_test.go
+++ b/internal/prompts/github_save_test.go
@@ -53,7 +53,7 @@ func withSaveFixture(t *testing.T, ring credentials.Keyring) string {
 }
 
 // With a keyring available the device-flow token lands there and no plaintext
-// file gains the token value — the spec's hard rule for managed credentials.
+// file gains the token value - the spec's hard rule for managed credentials.
 func TestSaveGitHubTokenPrefersKeyring(t *testing.T) {
 	ring := &mapKeyring{entries: map[string]string{}}
 	configFile := withSaveFixture(t, ring)
@@ -74,7 +74,7 @@ func TestSaveGitHubTokenPrefersKeyring(t *testing.T) {
 	}
 }
 
-// The grandfathered path: no keyring backend falls back to the config file —
+// The grandfathered path: no keyring backend falls back to the config file -
 // still restricted to 0600, and the file keeps being read on later runs.
 func TestSaveGitHubTokenFallsBackToConfigFile(t *testing.T) {
 	configFile := withSaveFixture(t, &mapKeyring{unavailable: true})

--- a/internal/prompts/github_test.go
+++ b/internal/prompts/github_test.go
@@ -46,7 +46,7 @@ func TestValidateGitHubToken(t *testing.T) {
 // The huh v2 upgrade came with a module rename (github.com/charmbracelet/huh ->
 // charm.land/huh/v2), so it is worth exercising the builder API rather than only
 // compiling against it. These construct the same forms the prompts build, without
-// running them — Run needs a terminal.
+// running them - Run needs a terminal.
 func TestFormsBuildAgainstHuhV2(t *testing.T) {
 	t.Run("select", func(t *testing.T) {
 		var choice string

--- a/internal/reporting/reporter.go
+++ b/internal/reporting/reporter.go
@@ -58,7 +58,7 @@ type ResourceDone struct {
 }
 
 // TerminalReq asks the display layer to hand the real terminal to a command.
-// stderr of interactive commands is never piped — capturing it swallows
+// stderr of interactive commands is never piped - capturing it swallows
 // sudo's password prompt and hangs the run.
 type TerminalReq struct {
 	Processor string

--- a/internal/reporting/store.go
+++ b/internal/reporting/store.go
@@ -32,7 +32,7 @@ type LogRecord struct {
 
 // currentProcessor is the package-level stamp the capture path reads. The
 // run loop sets it around each dispatch, so every existing log call in the
-// ten processor files is attributed with zero edits to those files — the
+// ten processor files is attributed with zero edits to those files - the
 // same pattern as the executor's package state.
 var currentProcessor atomic.Value
 

--- a/internal/reporting/store_test.go
+++ b/internal/reporting/store_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// Every line written while a processor is stamped is attributed to it — the
+// Every line written while a processor is stamped is attributed to it - the
 // mechanism that gives per-processor log views with zero edits to the ten
 // processor files.
 func TestLineWriter_AttributesRecordsToCurrentProcessor(t *testing.T) {

--- a/internal/scan/configs.go
+++ b/internal/scan/configs.go
@@ -25,7 +25,7 @@ var knownDotfiles = []string{
 }
 
 // configNoise names the ~/.config entries that are cache, state, or session
-// plumbing — shown only with includeAll. The human selects from what is
+// plumbing - shown only with includeAll. The human selects from what is
 // shown, so what is shown must be worth reading.
 var configNoise = map[string]bool{
 	"pulse": true, "dconf": true, "ibus": true, "gtk-2.0": true,

--- a/internal/scan/emit.go
+++ b/internal/scan/emit.go
@@ -8,7 +8,7 @@ import (
 
 // EmitPackages renders package results as a packages blueprint block in the
 // given registry format. The block strict-decodes against the blueprint
-// schema — emission that produces invalid blueprints is worse than a list.
+// schema - emission that produces invalid blueprints is worse than a list.
 func EmitPackages(results []PackageResult, format string) ([]byte, error) {
 	var entries []interface{}
 	for _, result := range results {

--- a/internal/scan/packages.go
+++ b/internal/scan/packages.go
@@ -1,4 +1,4 @@
-// Package scan answers "what did the operator put on this machine" — the
+// Package scan answers "what did the operator put on this machine" - the
 // shared harvest layer under `rwr diff` and `rwr capture`. Scanners are
 // read-only and never elevate: they execute only provider list verbs and
 // read files and unit states.
@@ -55,7 +55,7 @@ func Packages(providers map[string]*types.Provider) []PackageResult {
 // RunListCommand executes a provider's list-class verb read-only and returns
 // the first-column names, nil on failure. Some verbs name a different binary
 // entirely (apt's explicit query is `apt-mark showmanual`); the first field
-// decides what actually runs — the same dispatch the status querier uses.
+// decides what actually runs - the same dispatch the status querier uses.
 func RunListCommand(provider *types.Provider, command string) []string {
 	fields := strings.Fields(command)
 	bin := provider.BinPath

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -42,7 +42,7 @@ func TestPackages_ExplicitPreferred(t *testing.T) {
 	}
 }
 
-// A scan executes only list verbs — a provider whose other commands are
+// A scan executes only list verbs - a provider whose other commands are
 // traps proves it.
 func TestPackages_OnlyListVerbsRun(t *testing.T) {
 	dir := t.TempDir()
@@ -106,7 +106,7 @@ func TestConfigs_KnownNoiseAndSecrets(t *testing.T) {
 
 func TestParseEnabledUnits_VendorPresetSkipped(t *testing.T) {
 	out := "sshd.service enabled disabled\n" + // operator enabled (preset says off)
-		"cups.service enabled enabled\n" + // vendor preset — not operator intent
+		"cups.service enabled enabled\n" + // vendor preset - not operator intent
 		"tailscaled.service enabled disabled\n"
 	units := parseEnabledUnits(out)
 	if strings.Join(units, ",") != "sshd,tailscaled" {

--- a/internal/scan/services_git.go
+++ b/internal/scan/services_git.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Services reports enabled unit names on the current platform; elsewhere it
-// reports nothing — an empty answer is honest, a guessed one is not.
+// reports nothing - an empty answer is honest, a guessed one is not.
 func Services() []string {
 	if runtime.GOOS != "linux" {
 		return nil
@@ -49,7 +49,7 @@ type GitCheckout struct {
 	URL  string
 }
 
-// GitCheckouts finds clones under the given roots (two levels deep — the
+// GitCheckouts finds clones under the given roots (two levels deep - the
 // host/org/repo layout most people keep).
 func GitCheckouts(roots []string) []GitCheckout {
 	var checkouts []GitCheckout

--- a/internal/state/records.go
+++ b/internal/state/records.go
@@ -20,7 +20,7 @@ func (r *RecordFile) Save() error {
 }
 
 // LoadAll reads every run record under configDir, oldest first. Unreadable
-// files are skipped — one corrupt record must not hide the others.
+// files are skipped - one corrupt record must not hide the others.
 func LoadAll(configDir string) ([]*RecordFile, error) {
 	dir := RunsDir(configDir)
 	entries, err := os.ReadDir(dir)
@@ -59,7 +59,7 @@ type EntryRef struct {
 func (ref EntryRef) Entry() *Entry { return &ref.File.Record.Entries[ref.Index] }
 
 // UnreversedApplies returns every successfully applied, not-yet-reversed
-// entry across records, one per identity (the latest apply wins — that is
+// entry across records, one per identity (the latest apply wins - that is
 // the state on disk). Uninstall consumes this: reversed work must not be
 // reversed again.
 func UnreversedApplies(records []*RecordFile) []EntryRef {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,5 +1,5 @@
 // Package state is rwr's run journal: an append-only record of what each run
-// actually applied. Blueprints stay the source of desired state — the record
+// actually applied. Blueprints stay the source of desired state - the record
 // is evidence of past applies, never an input to `rwr all`. `rwr status`
 // reads it for drift and `rwr uninstall` for reversal.
 package state
@@ -32,7 +32,7 @@ type Record struct {
 
 // Entry is one applied unit of work. Identity carries enough to find the
 // thing again: provider+name for packages, dest+sha256 for files, target for
-// git checkouts. Reversed is set by uninstall runs — entries are never
+// git checkouts. Reversed is set by uninstall runs - entries are never
 // deleted, the journal is history.
 type Entry struct {
 	Processor string            `json:"processor"`
@@ -121,7 +121,7 @@ func (w *Writer) Finalize() error {
 	if err := w.flush(); err != nil {
 		return err
 	}
-	// latest is a plain file naming the newest record — a symlink breaks on
+	// latest is a plain file naming the newest record - a symlink breaks on
 	// Windows without privileges.
 	latest := filepath.Join(w.dir, "latest")
 	return os.WriteFile(latest, []byte(filepath.Base(w.path)+"\n"), 0o600)

--- a/internal/status/query.go
+++ b/internal/status/query.go
@@ -102,7 +102,7 @@ func PathPresent(path string) Presence {
 
 // validUnitName accepts systemd unit-name characters only. The query is
 // argv-exec'd so a shell never sees the name, but a name starting with "-"
-// would be read as a systemctl option — refused here.
+// would be read as a systemctl option - refused here.
 var validUnitName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.@:\\-]*$`)
 
 // ServiceState queries a service read-only on the current platform; other

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -34,9 +34,9 @@ type Row struct {
 // entry does); without a record, classes the queries cannot honestly decide
 // are unknown.
 func Rows(plan *types.Plan, records []*state.RecordFile, querier *Querier) []Row {
-	// Identity enrichment uses every recorded apply — a reversal does not
+	// Identity enrichment uses every recorded apply - a reversal does not
 	// erase where an identity lives on disk; stale detection uses only the
-	// unreversed ones — deliberately removed work is not stale.
+	// unreversed ones - deliberately removed work is not stale.
 	recorded := map[string]*state.Entry{}
 	for _, ref := range state.LatestApplies(records) {
 		entry := ref.Entry()
@@ -157,7 +157,7 @@ func Render(rows []Row, hasRecord bool) string {
 		fmt.Fprintf(&b, "%-14s %-40s %-10s %s\n", row.Processor, truncate(row.Name, 40), row.Class, row.Note)
 	}
 	if !hasRecord {
-		b.WriteString("\n(no run record: recorded-identity checks unavailable — run `rwr all` once to establish one)\n")
+		b.WriteString("\n(no run record: recorded-identity checks unavailable - run `rwr all` once to establish one)\n")
 	}
 	return b.String()
 }

--- a/internal/system/clean.go
+++ b/internal/system/clean.go
@@ -13,7 +13,7 @@ func CleanPackageManagers(osInfo *types.OSInfo, initConfig *types.InitConfig) er
 	// Clean each available package manager
 	for name, pm := range osInfo.PackageManager.Managers {
 		// GetPackageManagerInfo builds Clean as "<bin> <clean args>", so a provider
-		// that defines no clean command still yields "<bin> " — never "". This guard
+		// that defines no clean command still yields "<bin> " - never "". This guard
 		// therefore never fired, and the bare provider binary was executed at the end
 		// of every run. For an AUR helper, a bare invocation can mean a full system
 		// upgrade. Compare the arguments, not the concatenation.

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -21,7 +21,7 @@ import (
 
 // buildCommand creates an *exec.Cmd from the given types.Command.
 //
-// Commands are built as argv and handed directly to the kernel — no shell is
+// Commands are built as argv and handed directly to the kernel - no shell is
 // interposed. Every element of cmd.Args reaches the target program as exactly one
 // argument, so blueprint-supplied values (package names, paths, comments, password
 // hashes) cannot be reinterpreted as shell syntax and arguments containing spaces
@@ -30,7 +30,7 @@ import (
 // A shell is still available when a provider genuinely wants one; it just has to
 // say so explicitly, e.g. exec = "sh" with args = ["-c", "cd /tmp/paru && makepkg"].
 //
-// Elevation is unchanged in policy — it remains per-command via Elevated/AsUser —
+// Elevation is unchanged in policy - it remains per-command via Elevated/AsUser -
 // only the spawn differs. "--" terminates sudo's own option parsing so a command
 // whose name begins with a dash cannot be absorbed as a sudo flag. Windows has no
 // sudo: Elevated is a no-op there and the process must already be elevated, which
@@ -117,7 +117,7 @@ func runCommand(cmd types.Command, debug bool) error {
 	}
 
 	if cmd.Interactive {
-		// Interactive commands must reach the terminal directly — capturing
+		// Interactive commands must reach the terminal directly - capturing
 		// stderr would swallow sudo's password prompt and hang the run. The
 		// display layer owns the terminal, so the handoff goes through the
 		// reporter: LogReporter wires os.Std* exactly as this code used to;
@@ -194,7 +194,7 @@ func runCommandOutput(cmd types.Command, debug bool) (string, error) {
 
 // setOutputStreams points the command's stdout at the terminal (debug) or at the
 // blueprint's log file. When a log file is opened it is returned so the caller can
-// close it *after* the command has run — closing it here would hand the command a
+// close it *after* the command has run - closing it here would hand the command a
 // dead descriptor and silently discard everything it wrote.
 func setOutputStreams(cmd *exec.Cmd, debug bool, logName string) (*os.File, error) {
 	log.Debugf("Debug: %v", debug)
@@ -214,7 +214,7 @@ func setOutputStreams(cmd *exec.Cmd, debug bool, logName string) (*os.File, erro
 	// attacker-influenced whenever the blueprint is. Appending through a symlink
 	// would let command output be written into ~/.ssh/authorized_keys or ~/.bashrc
 	// without the blueprint containing anything that looks like it writes a file.
-	// Refuse to follow a symlink, and create at 0600 — command output routinely
+	// Refuse to follow a symlink, and create at 0600 - command output routinely
 	// contains more than the operator expects.
 	if info, err := os.Lstat(logName); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return nil, fmt.Errorf("refusing to write command log through symlink %q", logName)

--- a/internal/system/commands_test.go
+++ b/internal/system/commands_test.go
@@ -124,7 +124,7 @@ func TestBuildCommand_NoShellIsInterposed(t *testing.T) {
 }
 
 // A blueprint is data from a git repo. Shell metacharacters in a package name
-// must reach the package manager as literal text, never as syntax — especially
+// must reach the package manager as literal text, never as syntax - especially
 // since package operations run elevated.
 func TestBuildCommand_ShellMetacharactersAreNotInterpreted(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -239,7 +239,7 @@ func TestBuildCommand_Elevation(t *testing.T) {
 }
 
 // Providers that genuinely want a shell ask for one explicitly, and that still
-// works — the shell is declared in the provider definition rather than imposed on
+// works - the shell is declared in the provider definition rather than imposed on
 // every command. Mirrors the AUR helper bootstrap steps in paru/yay/aura/etc.
 func TestBuildCommand_ExplicitShellStillWorks(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/internal/system/definitions/families.cue
+++ b/internal/system/definitions/families.cue
@@ -1,5 +1,5 @@
 // Family templates for the proven clusters. Everything else stays a
-// standalone definition — inventing hierarchies for single members obscures
+// standalone definition - inventing hierarchies for single members obscures
 // more than it saves.
 package providers
 
@@ -90,7 +90,7 @@ package providers
 }
 
 // #ArchAURHelper: #PacmanFamily plus the clone-and-makepkg install shape.
-// Parameterized by the AUR package to clone (#aur — aura ships as aura-bin,
+// Parameterized by the AUR package to clone (#aur - aura ships as aura-bin,
 // pamac as pamac-aur) and the package name pacman removes (#removePkg).
 #ArchAURHelper: #PacmanFamily & {
 	#aur:       string

--- a/internal/system/definitions/schema.cue
+++ b/internal/system/definitions/schema.cue
@@ -1,4 +1,4 @@
-// Package providers holds rwr's embedded provider definitions as CUE —
+// Package providers holds rwr's embedded provider definitions as CUE -
 // the single source. The binary embeds these files and evaluates them at
 // load; there is no exported or committed second representation.
 //
@@ -6,7 +6,7 @@
 // definition fails evaluation naming the field.
 package providers
 
-// #ConditionRef: what a step condition may reference — the predicates rwr
+// #ConditionRef: what a step condition may reference - the predicates rwr
 // derives (repositoryPredicates; a Go test asserts this list equals its keys)
 // plus the two step-data fields shipped conditions use. A condition naming
 // anything else decoded into nothing historically, so every step ran.
@@ -35,7 +35,7 @@ package providers
 }
 
 // Install/remove steps: the package-manager processor implements only these
-// three actions — and staging at a literal /tmp/ path is the pre-creatable
+// three actions - and staging at a literal /tmp/ path is the pre-creatable
 // world-known name {{ .TempDir }} exists to eliminate, so it cannot export.
 #InstallStep: {
 	action:  "command" | "download" | "write"

--- a/internal/system/distro.go
+++ b/internal/system/distro.go
@@ -31,7 +31,7 @@ var nativeManagers = map[string][]string{
 //
 // Used to infer the family from what is installed when /etc/os-release names a
 // distribution nobody has heard of. A great many derivatives ship neither a known
-// ID nor an ID_LIKE — PrismLinux reports ID=prismlinux and nothing else — but the
+// ID nor an ID_LIKE - PrismLinux reports ID=prismlinux and nothing else - but the
 // presence of pacman and its database says "arch" unambiguously.
 var managerFamily = map[string]string{
 	"pacman":   "arch",

--- a/internal/system/download_integrity_test.go
+++ b/internal/system/download_integrity_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 )
 
-// Everything rwr downloads is installed with the operator's privileges —
-// package-signing keys included — so plain http from a real host is refused.
+// Everything rwr downloads is installed with the operator's privileges -
+// package-signing keys included - so plain http from a real host is refused.
 // Loopback stays allowed for local mirrors and these tests.
 func TestValidateDownloadURL(t *testing.T) {
 	for _, tt := range []struct {
@@ -55,7 +55,7 @@ func TestDownloadFile_RefusesPlainHTTP(t *testing.T) {
 // Validating only the initial URL is worthless if a redirect can hop to plain
 // http: the default client follows it silently and the content is once again
 // substitutable in transit. Every hop is re-validated by DownloadClient's
-// CheckRedirect. The redirect target here is a non-loopback http URL — the
+// CheckRedirect. The redirect target here is a non-loopback http URL - the
 // refusal happens in CheckRedirect before any request is made to it.
 func TestDownloadFile_RefusesRedirectToPlainHTTP(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/system/embedded.go
+++ b/internal/system/embedded.go
@@ -17,8 +17,8 @@ import (
 //go:embed definitions/*.cue
 var embeddedProviderCUE embed.FS
 
-// LoadEmbeddedProviders evaluates the embedded CUE provider definitions —
-// schema, family templates, one file per provider — and returns them keyed
+// LoadEmbeddedProviders evaluates the embedded CUE provider definitions -
+// schema, family templates, one file per provider - and returns them keyed
 // by provider name. Each call returns fresh values: callers own what they
 // get, exactly as they did with the per-call decode this replaced.
 func LoadEmbeddedProviders() (map[string]*types.Provider, error) {

--- a/internal/system/files.go
+++ b/internal/system/files.go
@@ -114,8 +114,8 @@ func copyFileContentMode(source, target string, mode os.FileMode) error {
 //
 // Only a file the invoking user owns donates its mode. In a shared directory
 // like /tmp anyone can plant the target ahead of time, and inheriting a
-// planted 0666 turns the freshly written file — root-owned, about to be
-// executed by an install step — into one every local user can rewrite.
+// planted 0666 turns the freshly written file - root-owned, about to be
+// executed by an install step - into one every local user can rewrite.
 func targetMode(filePath string) os.FileMode {
 	if info, err := os.Stat(filePath); err == nil {
 		if !fileOwnedByEUID(info) {
@@ -130,7 +130,7 @@ func targetMode(filePath string) os.FileMode {
 // cleanupStaged removes a staging file on an error path.
 // cleanupStaged removes a staging file on an error path. It is best-effort by
 // design: the caller is already returning an error, and a failure to tidy up must
-// not replace it — but it is logged rather than discarded, because a staging file
+// not replace it - but it is logged rather than discarded, because a staging file
 // left behind is the kind of thing that only shows up as a full disk much later.
 func cleanupStaged(f *os.File) {
 	if err := f.Close(); err != nil {
@@ -178,7 +178,7 @@ func ValidateDownloadURL(raw string) error {
 //
 //   - every redirect hop is re-validated with ValidateDownloadURL. Validating
 //     only the initial URL is worthless the moment the server answers with a
-//     302 to plain http — the default client follows it silently and the
+//     302 to plain http - the default client follows it silently and the
 //     content is once again substitutable in transit.
 //   - a timeout, so a stalled mirror fails the step instead of hanging the
 //     whole run forever. Generous, because font archives run to hundreds of MB

--- a/internal/system/files_owner_unix.go
+++ b/internal/system/files_owner_unix.go
@@ -20,7 +20,7 @@ func fileOwnedByEUID(info os.FileInfo) bool {
 
 // ownedByRootOrEUID reports whether the file or directory belongs to root or
 // to the effective user. A provider directory owned by any other account is
-// rewritable by that account regardless of its mode bits — a directory's owner
+// rewritable by that account regardless of its mode bits - a directory's owner
 // can always chmod it open.
 func ownedByRootOrEUID(info os.FileInfo) bool {
 	st, ok := info.Sys().(*syscall.Stat_t)

--- a/internal/system/files_owner_windows.go
+++ b/internal/system/files_owner_windows.go
@@ -11,7 +11,7 @@ func fileOwnedByEUID(os.FileInfo) bool {
 	return true
 }
 
-// ownedByRootOrEUID: see fileOwnedByEUID — Windows security is ACLs, which
+// ownedByRootOrEUID: see fileOwnedByEUID - Windows security is ACLs, which
 // os.FileInfo cannot express, so the unix ownership check always passes.
 func ownedByRootOrEUID(os.FileInfo) bool {
 	return true

--- a/internal/system/files_test.go
+++ b/internal/system/files_test.go
@@ -120,7 +120,7 @@ func TestWriteToFile_NewFileUsesDefaultMode(t *testing.T) {
 }
 
 // A repository add appends its section to a shared configuration file. What is
-// already in that file — every other repository, every option — has to survive,
+// already in that file - every other repository, every option - has to survive,
 // and a second `rwr all` must not add the section again.
 func TestAppendToFile_KeepsExistingContentAndIsIdempotent(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/system/interactive_handoff_test.go
+++ b/internal/system/interactive_handoff_test.go
@@ -21,7 +21,7 @@ func (r *recordingReporter) Emit(e reporting.Event) {
 }
 
 // Interactive commands are handed to the display layer via TerminalReq; the
-// run blocks on Done. This is the seam a TUI suspends around — and it must
+// run blocks on Done. This is the seam a TUI suspends around - and it must
 // fire regardless of the global interactive flag, because a single blueprint
 // item can set interactive: true inside a non-interactive run.
 func TestRunCommand_InteractiveGoesThroughTerminalReq(t *testing.T) {

--- a/internal/system/linux.go
+++ b/internal/system/linux.go
@@ -30,7 +30,7 @@ func SetLinuxDetails(osInfo *types.OSInfo) error {
 //
 // Deriving the default from /etc/os-release directly does not work. That lookup
 // returned the first provider matching the distro, and flatpak, snap, nix and
-// cargo all declare the "linux" wildcard, so they match every distribution — on
+// cargo all declare the "linux" wildcard, so they match every distribution - on
 // this machine it selected flatpak as the default package manager for an
 // Arch-based system. Families map to their native managers explicitly instead.
 func linuxPreferredManagers(osInfo *types.OSInfo) []string {

--- a/internal/system/managers.go
+++ b/internal/system/managers.go
@@ -12,7 +12,7 @@ import (
 //
 // GetAvailableProviders has already applied supportsSystem (exact distro, distro
 // family, or the "linux" wildcard), confirmed the binary exists, and stored its
-// path in BinPath — so no further filtering belongs here. The per-OS callers used
+// path in BinPath - so no further filtering belongs here. The per-OS callers used
 // to re-filter with a literal string match against the provider's distribution
 // list, which excluded every provider that names concrete distros: on Linux that
 // meant apt, dnf, pacman, zypper and the AUR helpers never made it into the map,

--- a/internal/system/managers_test.go
+++ b/internal/system/managers_test.go
@@ -59,7 +59,7 @@ func TestSupportsSystem_RejectsWrongDistro(t *testing.T) {
 	loaded := mustLoadEmbedded(t)
 
 	// Simulate running on a Debian-derived host. Its ID_LIKE must not leak into
-	// answers about other distributions — that is what made apt look available on
+	// answers about other distributions - that is what made apt look available on
 	// Arch when these ran on the Ubuntu CI runner.
 	restore := stubHost(t, "ubuntu", "debian")
 	defer restore()
@@ -134,7 +134,7 @@ func TestSetDefaultManager_FallsThroughMissingPreferences(t *testing.T) {
 }
 
 // Go randomizes map iteration, so an unsorted fallback could resolve a different
-// default on every run — and with it, a different package manager for any package
+// default on every run - and with it, a different package manager for any package
 // that did not name one.
 func TestSetDefaultManager_FallbackIsDeterministic(t *testing.T) {
 	managers := map[string]types.PackageManagerInfo{
@@ -226,7 +226,7 @@ func TestProviderFilter_LiteralLinuxMatchWouldDropRealPackageManagers(t *testing
 // End-to-end proof on a real machine: after OS detection, the distribution's own
 // package manager must appear in osInfo.PackageManager.Managers. That map is what
 // CleanPackageManagers and the core-package installers consume, and under the old
-// literal "linux" filter it never contained apt/dnf/pacman/zypper/apk — so a
+// literal "linux" filter it never contained apt/dnf/pacman/zypper/apk - so a
 // system running `rwr all` reported "Cleaning up package managers" while never
 // cleaning the one package manager it actually uses.
 //
@@ -462,7 +462,7 @@ func stubHost(t *testing.T, host, idLike string) func() {
 // ID_LIKE must only ever answer for the machine it describes. Asking whether
 // some unrelated distribution belongs to a family used to be answered from the
 // host's ID_LIKE, so on a Debian derivative every unknown distro looked like
-// debian — and apt looked available on Arch.
+// debian - and apt looked available on Arch.
 func TestIsDistroInFamily_IgnoresHostIDLikeForOtherDistros(t *testing.T) {
 	restore := stubHost(t, "ubuntu", "debian")
 	defer restore()

--- a/internal/system/paths.go
+++ b/internal/system/paths.go
@@ -86,7 +86,7 @@ func AddCommonPaths() string {
 //
 // The variables have to be expanded here: Go does not interpret cmd-style
 // "%USERPROFILE%\..." strings, so the literal paths never resolved and every
-// Windows entry was silently skipped — including scoop's shims directory, which
+// Windows entry was silently skipped - including scoop's shims directory, which
 // an elevated shell often does not inherit in PATH, so scoop went undetected.
 //
 // getenv is a parameter so the expansion can be tested off Windows.

--- a/internal/system/paths_test.go
+++ b/internal/system/paths_test.go
@@ -296,7 +296,7 @@ func BenchmarkSetPaths(b *testing.B) {
 }
 
 // Windows entries used to be literal "%USERPROFILE%\..." strings that Go never
-// expands, so every one of them failed EvalSymlinks and was dropped — scoop
+// expands, so every one of them failed EvalSymlinks and was dropped - scoop
 // included. The expansion is tested through the injected lookup so it runs on
 // any platform.
 func TestWindowsCommonPaths_ExpandsVariables(t *testing.T) {

--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -130,7 +130,7 @@ func getSystemInfo() (string, string) {
 // Availability is decided by evidence on the machine rather than by what the
 // distribution calls itself. A named distro match is accepted, but so is the
 // combination of "the binary is installed" plus "every file the provider declares
-// as proof of itself exists" — for pacman that is /etc/pacman.conf and
+// as proof of itself exists" - for pacman that is /etc/pacman.conf and
 // /var/lib/pacman. There are far more Arch and Debian derivatives than any list
 // can track (this was found on PrismLinux, which no provider names and which sets
 // no ID_LIKE), and a machine that has pacman's binary and pacman's database is
@@ -160,7 +160,7 @@ func isProviderAvailable(provider *types.Provider, currentOS, currentDistro stri
 	}
 
 	// Unrecognised distribution. Accept it when the provider declares files that
-	// prove it is genuinely in use, and say so — a provider with no such files has
+	// prove it is genuinely in use, and say so - a provider with no such files has
 	// only its distro list to go on, so it stays unavailable.
 	if len(provider.Detection.Files) > 0 {
 		log.Debugf("GetAvailableProviders: Provider %s not listed for %s/%s but its binary and required files are present; treating as available",
@@ -184,7 +184,7 @@ var osTokens = map[string]bool{
 //
 // A provider that names any OS token must name this one. A provider that lists
 // only distributions (pacman, apt, dnf) is not OS-specific in its declaration, so
-// the file and binary checks decide — those paths simply do not exist on the wrong
+// the file and binary checks decide - those paths simply do not exist on the wrong
 // OS.
 func targetsOS(provider *types.Provider, currentOS string) bool {
 	namedAnOS := false
@@ -248,7 +248,7 @@ func GetProvider(name string) (*types.Provider, bool) {
 
 	// Under providersMu like every other reader: this was the one lookup that
 	// read the map unlocked, a data race against SetProvidersForTest and any
-	// future reload. The lock is not held across FindTool below — only the map
+	// future reload. The lock is not held across FindTool below - only the map
 	// access needs it.
 	providersMu.Lock()
 	provider, exists := providers[name]
@@ -284,7 +284,7 @@ func GetProvider(name string) (*types.Provider, bool) {
 
 // GetProviderDefinition returns a provider by name without requiring its
 // binary to exist. GetProvider treats a missing binary as "not available",
-// which is right everywhere except the install flow — whose entire purpose is
+// which is right everywhere except the install flow - whose entire purpose is
 // that the binary is not there yet.
 func GetProviderDefinition(name string) (*types.Provider, bool) {
 	if err := InitProviders(); err != nil {
@@ -304,7 +304,7 @@ func GetProviderDefinition(name string) (*types.Provider, bool) {
 // The current working directory is deliberately not searched. A provider file
 // declares exec, args and elevated=true and those are run verbatim, so honouring
 // ./providers would hand root-level execution to any directory rwr happens to be
-// run from — a cloned blueprint repo, /tmp, a shared downloads folder. Provider
+// run from - a cloned blueprint repo, /tmp, a shared downloads folder. Provider
 // overrides belong in the user's config directory, which only the user can write.
 func GetProvidersPath() (string, error) {
 	// Get the executable's directory
@@ -322,7 +322,7 @@ func GetProvidersPath() (string, error) {
 
 	// $HOME via Getenv would be empty under systemd/cron/sudo env -i (and always
 	// on Windows), and joining "" yields a relative path that os.Stat resolves
-	// against the CWD — exactly the directory this search must never honour.
+	// against the CWD - exactly the directory this search must never honour.
 	if home, err := os.UserHomeDir(); err == nil {
 		locations = append(locations, filepath.Join(home, ".config/rwr/providers")) // RWR Config Path
 	} else {
@@ -403,7 +403,7 @@ func isProviderFileTrustedOn(goos, path string) bool {
 
 	// Windows has no unix permission bits: Go synthesizes 0666 for any file
 	// that is not read-only, so the writability check below would reject every
-	// normal provider file — and its chmod advice is not runnable there. File
+	// normal provider file - and its chmod advice is not runnable there. File
 	// security on Windows is ACLs, which os.FileMode cannot express.
 	if goos == "windows" {
 		return true
@@ -450,7 +450,7 @@ func LoadProviderDefinition(path string) (*types.Provider, error) {
 	}
 
 	// Overrides come in two shapes: the historical TOML with a [provider]
-	// section, and bare-provider JSON — the same document the embedded
+	// section, and bare-provider JSON - the same document the embedded
 	// definitions use, so an exported provider can be dropped in verbatim.
 	var provider types.Provider
 	if filepath.Ext(path) == ".json" {

--- a/internal/system/providers_path_test.go
+++ b/internal/system/providers_path_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // With HOME unset, the user-config candidate must be dropped, not degrade to
-// the relative path ".config/rwr/providers" — which os.Stat would resolve
+// the relative path ".config/rwr/providers" - which os.Stat would resolve
 // against the CWD, honouring a providers directory planted in whatever
 // directory rwr is run from (a cloned repo, /tmp). GetProvidersPath's own doc
 // comment rules the CWD out of the search.
@@ -44,7 +44,7 @@ func TestGetProvidersPath_UnsetHomeNeverSearchesCWD(t *testing.T) {
 		return
 	}
 	if !filepath.IsAbs(got) {
-		t.Fatalf("GetProvidersPath returned a relative path %q — resolved against the CWD", got)
+		t.Fatalf("GetProvidersPath returned a relative path %q - resolved against the CWD", got)
 	}
 	if got == planted || got == ".config/rwr/providers" {
 		t.Fatalf("GetProvidersPath honoured a providers directory under the CWD: %q", got)

--- a/internal/system/providers_trust_test.go
+++ b/internal/system/providers_trust_test.go
@@ -8,7 +8,7 @@ import (
 
 // On unix, group/world-writable definitions are skipped; a 0644 one loads.
 // On Windows, Go synthesizes mode 0666 for every writable file, so the same
-// check rejected every provider definition a Windows user could ever write —
+// check rejected every provider definition a Windows user could ever write -
 // the platform gets no mode check at all rather than one that always fails.
 func TestIsProviderFileTrustedOn(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/tui/activate.go
+++ b/internal/tui/activate.go
@@ -11,7 +11,7 @@ import (
 
 // Active reports whether the TUI should run. Anything short of a real,
 // capable, non-CI terminal falls back to the LogReporter, whose output is
-// byte-identical to the pre-TUI stream — `rwr all > install.log` already
+// byte-identical to the pre-TUI stream - `rwr all > install.log` already
 // fails the TTY check and behaves as today.
 func Active(noTUI bool) bool {
 	if noTUI {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -72,7 +72,7 @@ func (l *Lane) target() float64 {
 	return float64(l.Done) / float64(l.Total)
 }
 
-// state derives a processor's display state from the worst lane state —
+// state derives a processor's display state from the worst lane state -
 // never set directly, per the design.
 func (p *Proc) derive() ProcState {
 	if p.State == ProcFailed || p.State == ProcSkipped || p.State == ProcPending {
@@ -282,7 +282,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tick:
 		m.spinnerFrame++
 		// Advance the bar springs; when every spring has settled and nothing
-		// is running, the animation has nothing left to do — kill the tick
+		// is running, the animation has nothing left to do - kill the tick
 		// (the next event restarts it).
 		animating := false
 		for _, proc := range m.procs {
@@ -303,7 +303,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		// Either threshold trips compact mode; resize promotes/demotes live
-		// with no state lost — both layouts render from this one model.
+		// with no state lost - both layouts render from this one model.
 		m.compact = msg.Width < 60 || msg.Height < 14
 		return m, nil
 	case tea.FocusMsg:

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -34,7 +34,7 @@ func testModel(t *testing.T) *Model {
 }
 
 // Every frame renders from one model: running (with a failure row), summary,
-// dry-run vocabulary, compact — and the ASCII theme — without panicking and
+// dry-run vocabulary, compact - and the ASCII theme - without panicking and
 // with the load-bearing content present.
 func TestModel_FramesRender(t *testing.T) {
 	m := testModel(t)

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -35,7 +35,7 @@ var asciiGlyphs = Glyphs{
 }
 
 // Theme is the eleven color roles plus glyphs. Color is by state, not by
-// processor — thirteen distinguishable accents is more than most palettes
+// processor - thirteen distinguishable accents is more than most palettes
 // carry. No background is ever painted: the terminal's own is inherited, so
 // light-theme and transparent-terminal users keep a working frame.
 type Theme struct {
@@ -72,7 +72,7 @@ func catppuccinTheme(name string, flavour catppuccin.Flavor) Theme {
 
 // builtinThemes ships embedded; user themes are TOML files in the config dir
 // with the same schema (LoadUserTheme), so copying a built-in and editing it
-// just works — the providers pattern.
+// just works - the providers pattern.
 func builtinThemes() map[string]Theme {
 	themes := map[string]Theme{
 		"rwr":       rwrTheme,
@@ -131,7 +131,7 @@ func unicodeSafe() bool {
 // ResolveTheme picks the theme: --theme flag, config key, $RWR_THEME, then
 // the default. NO_COLOR overrides all of it (colors drop; glyphs stay per
 // capability). forceASCII/forceUnicode come from --ascii/--unicode.
-// A TOML theme in <configDir>/themes/ overrides a built-in of the same name —
+// A TOML theme in <configDir>/themes/ overrides a built-in of the same name -
 // the providers pattern. unknown names the requested theme when nothing
 // matched and the default was substituted, so the caller can warn.
 func ResolveTheme(configDir, flagTheme, configTheme string, forceASCII, forceUnicode bool) (resolved Theme, unknown string) {

--- a/internal/tui/theme_user.go
+++ b/internal/tui/theme_user.go
@@ -15,7 +15,7 @@ func LoadUserTheme(configDir, name string) (Theme, bool) {
 		return Theme{}, false
 	}
 	// The name reaches us from a flag or environment variable; a theme name
-	// is a bare filename, never a path — anything else stays out of ReadFile.
+	// is a bare filename, never a path - anything else stays out of ReadFile.
 	if name != filepath.Base(name) || strings.ContainsAny(name, `/\`) || name == ".." {
 		return Theme{}, false
 	}

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -226,7 +226,7 @@ func (m *Model) viewResolving() string {
 	var b strings.Builder
 	b.WriteString(m.viewHeader() + "\n\n")
 	b.WriteString(" " + style(m.theme.Accent).Render(spin) + " resolving blueprints…\n\n")
-	b.WriteString(style(m.theme.Muted).Render(" nothing has been modified yet — q cancels") + "\n")
+	b.WriteString(style(m.theme.Muted).Render(" nothing has been modified yet - q cancels") + "\n")
 	return b.String()
 }
 
@@ -355,7 +355,7 @@ func (m *Model) statusGlyph(status types.Status) string {
 	}
 }
 
-// viewCompact: one pinned status line, the log stream, one help line — stays
+// viewCompact: one pinned status line, the log stream, one help line - stays
 // inside the TUI so filters and search survive a tiny pane.
 func (m *Model) viewCompact() string {
 	failures := 0

--- a/internal/types/command.go
+++ b/internal/types/command.go
@@ -24,7 +24,7 @@ type Command struct {
 	// Secrets lists values that must be scrubbed from any log line describing this
 	// command. Some tools accept a credential only as an argument (chocolatey's
 	// --password, cargo's login token), so the value cannot always be moved to
-	// Stdin — but it should still never be written to a log file. Callers that put
+	// Stdin - but it should still never be written to a log file. Callers that put
 	// a credential in Args are expected to list it here.
 	Secrets []string `mapstructure:"-" yaml:"-" json:"-" toml:"-"`
 }
@@ -39,7 +39,7 @@ func (c Command) LogArgs() []string {
 	for i, arg := range c.Args {
 		for _, secret := range c.Secrets {
 			// Substring replacement on a very short secret would corrupt unrelated
-			// arguments — a password of "1" would rewrite every digit in the argv.
+			// arguments - a password of "1" would rewrite every digit in the argv.
 			// Below this length the log damage outweighs the disclosure, and a
 			// secret that short is not protecting anything anyway.
 			if len(secret) < minRedactableSecret {

--- a/internal/types/command_test.go
+++ b/internal/types/command_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Some tools take a credential only as an argument, so it cannot always be moved
-// to Stdin — but it must still never reach a log file. buildCommand logs argv at
+// to Stdin - but it must still never reach a log file. buildCommand logs argv at
 // debug level and the dry-run path logs it at info.
 func TestCommandLogArgs_RedactsSecrets(t *testing.T) {
 	cmd := Command{

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -46,8 +46,8 @@ const (
 	// and the processor never implemented it, so `action: update` passed
 	// `rwr validate` and then failed the run. It cannot be implemented on top of
 	// the providers' `update` commands either: they disagree about what update
-	// means — apt's refreshes the package lists, while pacman's is a full system
-	// upgrade — so appending a package name would do something different, and in
+	// means - apt's refreshes the package lists, while pacman's is a full system
+	// upgrade - so appending a package name would do something different, and in
 	// pacman's case drastic, on each distribution.
 )
 
@@ -74,7 +74,7 @@ const (
 //
 // This is the set the files processor actually dispatches on. It previously
 // listed append and template, which no branch handles, and omitted copy, move,
-// chmod, chown, chgrp and symlink, which every one of them does — so validation
+// chmod, chown, chgrp and symlink, which every one of them does - so validation
 // rejected the actions the examples use and accepted two that do nothing.
 const (
 	FileActionCreate  = "create"

--- a/internal/types/credentials.go
+++ b/internal/types/credentials.go
@@ -12,8 +12,8 @@ import (
 // CredentialSpec is one entry of the init file's `credentials:` section: a named
 // credential the tree's blueprints need, and the ordered places to look for it.
 //
-// Declarations live only in the init file the operator points rwr at — a
-// blueprint can reference a declared credential but never declare one — and
+// Declarations live only in the init file the operator points rwr at - a
+// blueprint can reference a declared credential but never declare one - and
 // exposure to blueprints still requires the operator's exposeCredentials opt-in.
 type CredentialSpec struct {
 	// Name is the credential's identity everywhere: in exposeCredentials, in
@@ -45,7 +45,7 @@ var credentialNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 // DecodeCredentialSpecs strictly decodes the raw `credentials:` section as read
 // by viper. Viper's own Unmarshal ignores unknown keys, so a typo like
-// `soruces:` would silently become the default source order — an error naming
+// `soruces:` would silently become the default source order - an error naming
 // the key is the only honest answer.
 func DecodeCredentialSpecs(raw interface{}) ([]CredentialSpec, error) {
 	if raw == nil {
@@ -137,8 +137,8 @@ func isBuiltinCredential(name string) bool {
 }
 
 // The credential registry: the declared set (scopes) and the values resolved
-// for this run. Values live only here — never in viper, never in a struct a
-// debug dump can reach — and leave only through the exposure-gated accessors
+// for this run. Values live only here - never in viper, never in a struct a
+// debug dump can reach - and leave only through the exposure-gated accessors
 // below.
 var (
 	credentialScopes = map[string][]string{}
@@ -220,7 +220,7 @@ func TemplateCredentials() map[string]interface{} {
 
 // ExportedCredentialEnv returns the RWR_CRED_<NAME> environment entries for
 // spawned commands: resolved, opted into via exposeCredentials, and in a scope
-// that admits scripts. Env is the only export surface — a value must never be
+// that admits scripts. Env is the only export surface - a value must never be
 // placed in argv, where ps can read it.
 func ExportedCredentialEnv() map[string]string {
 	out := map[string]string{}

--- a/internal/types/file.go
+++ b/internal/types/file.go
@@ -17,7 +17,7 @@ const MaxFileMode = 0o7777
 // FileMode is a Unix permission mode declared by a blueprint.
 //
 // A plain int could not carry one safely. `mode: 644` is decimal 644 in YAML and
-// in JSON — 0o1204, a setuid mode nobody asked for — and JSON has no octal
+// in JSON - 0o1204, a setuid mode nobody asked for - and JSON has no octal
 // literal at all, so a JSON blueprint could only say 0o644 by writing its decimal
 // value 420. Every one of those decoded without complaint, so a wrong mode
 // reached the file and nothing reported it.
@@ -30,7 +30,7 @@ const MaxFileMode = 0o7777
 //   - A number, read as the mode's own value. That is what every parser already
 //     produces for an octal literal, so YAML `0644`, TOML `0o644` and JSON `420`
 //     are one and the same mode. A number that instead reads like octal digits
-//     typed without quotes — `644`, `755` — is refused rather than guessed at,
+//     typed without quotes - `644`, `755` - is refused rather than guessed at,
 //     because as a value it is a mode the blueprint cannot have meant.
 //
 // Zero means "no mode declared". A mode of 0000 leaves a file nobody can read,
@@ -90,7 +90,7 @@ func fileModeFromInt(v int64, literal string) (FileMode, error) {
 	return FileMode(v), nil
 }
 
-// isExplicitlyBased reports whether a numeric literal carried its own base —
+// isExplicitlyBased reports whether a numeric literal carried its own base -
 // 0644, 0o644, 0x1a4. Such a literal has already been converted by the parser
 // and cannot be a decimal mistaken for octal.
 func isExplicitlyBased(literal string) bool {
@@ -185,7 +185,7 @@ func (m *FileMode) UnmarshalJSON(data []byte) error {
 }
 
 // UnmarshalTOML reads a mode from TOML. BurntSushi hands over the decoded value
-// only, so `0o644` and `420` arrive identically — as the number 420, the mode
+// only, so `0o644` and `420` arrive identically - as the number 420, the mode
 // both of them name. The ambiguity check therefore works from the value alone,
 // which is why a setuid mode has to be written as a string in TOML.
 func (m *FileMode) UnmarshalTOML(data any) error {

--- a/internal/types/file_mode_test.go
+++ b/internal/types/file_mode_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 // modeCase is one way of writing a mode, in each of the three formats. A blank
-// literal means the format cannot express that form at all — JSON has no octal
-// literal — and is skipped rather than asserted.
+// literal means the format cannot express that form at all - JSON has no octal
+// literal - and is skipped rather than asserted.
 type modeCase struct {
 	name string
 	yaml string

--- a/internal/types/initialize.go
+++ b/internal/types/initialize.go
@@ -58,14 +58,14 @@ type InitConfig struct {
 	PackageManagers []PackageManagerInfo `mapstructure:"packageManagers,omitempty" yaml:"packageManagers,omitempty" json:"packageManagers,omitempty" toml:"packageManagers,omitempty"`
 	// The inline resource sections (repositories, packages, services, files,
 	// templates, directories, configuration) are gone: they were decoded,
-	// validated, profile-counted — and never applied at runtime. Blueprints
+	// validated, profile-counted - and never applied at runtime. Blueprints
 	// are the single declaration path; under strict decode a leftover key is
 	// an error naming it instead of a silent no-op.
 	// Squashing this made the `variables:` block in the init file decode into
 	// nothing at all, so every {{ .UserDefined.x }} in a blueprint rendered empty.
 	Variables Variables `mapstructure:"variables,omitempty" yaml:"variables,omitempty" json:"variables,omitempty" toml:"variables,omitempty"`
 	// ExposeCredentials names the credentials this tree's blueprints are allowed
-	// to read, e.g. ["gh_api_token"]. Empty — the default — means blueprints get
+	// to read, e.g. ["gh_api_token"]. Empty - the default - means blueprints get
 	// none of them. See docs/credentials.md.
 	ExposeCredentials []string `mapstructure:"exposeCredentials,omitempty" yaml:"exposeCredentials,omitempty" json:"exposeCredentials,omitempty" toml:"exposeCredentials,omitempty"`
 	// Credentials declares the named credentials this tree's blueprints need and
@@ -93,7 +93,7 @@ func (u UserInfo) ToMap() map[string]interface{} {
 // Templates render from blueprint files cloned out of git repositories, and the
 // result is written to a path the same blueprint chooses, so exposing a
 // credential by default let any blueprint copy it anywhere. A blueprint that
-// genuinely needs one — writing a .netrc, configuring gh — opts in by name; see
+// genuinely needs one - writing a .netrc, configuring gh - opts in by name; see
 // exposeCredentials in the init file.
 func (f Flags) ToMap() map[string]interface{} {
 	out := map[string]interface{}{

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -3,7 +3,7 @@ package types
 import "time"
 
 // The Plan data model is shared by the resolver (internal/processors), the
-// reporters (internal/reporting), and validate — it lives here so none of
+// reporters (internal/reporting), and validate - it lives here so none of
 // them import each other.
 
 // ResolvedFile is one blueprint file after stage 1: routed, read, and
@@ -25,7 +25,7 @@ type ProviderState struct {
 }
 
 // Status is a resource's outcome. `unknown` is required: rwr shells out and
-// several providers do not report per-package results reliably — forcing
+// several providers do not report per-package results reliably - forcing
 // those into ok or failed would be a lie in either direction.
 type Status string
 
@@ -77,7 +77,7 @@ type StepError struct {
 // only SetPaths and DetectOS, so `rwr validate` consumes it pre-init; stage 2
 // (provider states, resource enumeration) runs after init and bootstrap,
 // because bootstrap can install the package manager later blueprints depend
-// on — detecting providers earlier produces wrong lanes.
+// on - detecting providers earlier produces wrong lanes.
 type Plan struct {
 	Init      *InitConfig
 	Order     []string

--- a/internal/types/providers.go
+++ b/internal/types/providers.go
@@ -83,7 +83,7 @@ type ActionStep struct {
 	Source  string `toml:"source,omitempty"`
 	Dest    string `toml:"dest,omitempty"`
 	// Sha256, when set on a "download" step, is the hex digest the fetched
-	// content must match — the download is discarded on a mismatch. It is a
+	// content must match - the download is discarded on a mismatch. It is a
 	// template like every other step field, so a provider can take it from the
 	// blueprint with `sha256 = "{{ .SHA256 }}"`.
 	Sha256  string   `toml:"sha256,omitempty"`
@@ -93,7 +93,7 @@ type ActionStep struct {
 	// Condition gates the step: it is a template rendered against the same data
 	// as the rest of the step, and the step runs only when it renders to a
 	// truthy value. Without a field to decode into, every shipped `condition`
-	// was dropped and mutually exclusive steps all ran — flatpak added a remote
+	// was dropped and mutually exclusive steps all ran - flatpak added a remote
 	// both --user and --system, chocolatey added a source twice.
 	Condition string `toml:"condition,omitempty"`
 }

--- a/internal/types/repository.go
+++ b/internal/types/repository.go
@@ -29,7 +29,7 @@ type Repository struct {
 	// Credentials a provider needs to authenticate against a private repository:
 	// chocolatey signs a source in with Username/Password, cargo with Token.
 	//
-	// They are treated like the credentials in secrets.go — never printed. Anything
+	// They are treated like the credentials in secrets.go - never printed. Anything
 	// rwr logs about a repository goes through Redact for these fields, because a
 	// registry token in a debug log is as reusable as one in a blueprint, and rwr's
 	// logs get pasted into issues.
@@ -71,7 +71,7 @@ func (r Repository) GetProfiles() []string {
 // (chocolatey's --password, cargo's login token), so it cannot be moved to stdin
 // the way a user password can. Listing the values here at least keeps them out of
 // the debug and dry-run log lines, which print the whole argv. It does not hide
-// them from `ps` — nothing can, short of the tool growing a stdin option.
+// them from `ps` - nothing can, short of the tool growing a stdin option.
 //
 // The username is not included: it is not a credential, and redacting it would
 // only make the log harder to read.

--- a/internal/types/schema.go
+++ b/internal/types/schema.go
@@ -7,7 +7,7 @@ import (
 )
 
 // DefaultSchemaVersion is the version assumed for a blueprint type that has only
-// ever had one. It is not the fallback for an undeclared blueprint — see
+// ever had one. It is not the fallback for an undeclared blueprint - see
 // ResolveSchemaVersion, which falls back to the latest version instead.
 const DefaultSchemaVersion = 1
 
@@ -32,7 +32,7 @@ var supportedSchemaVersions = map[string][]int{
 	BlueprintTypeBootstrap:     {1},
 	// BlueprintTypePackageManagers is deliberately absent: package managers are
 	// declared in the init file's packageManagers section, not in a blueprint
-	// file — there is no decoder, no processor dispatch, and no schema variant
+	// file - there is no decoder, no processor dispatch, and no schema variant
 	// for one. Listing it here claimed a file type that NewSchemaVariant could
 	// only ever error on.
 }
@@ -66,7 +66,7 @@ func (s SchemaVersion) DeclaredVersion() int { return s.SchemaVersion }
 // without boilerplate, and the version field is what you add when you want to be
 // pinned rather than something you must add to get started. The consequence is
 // that an undeclared blueprint follows the schema forward across upgrades, so a
-// tree that needs to stay on a particular version has to say so — which is what
+// tree that needs to stay on a particular version has to say so - which is what
 // the declaration is for.
 func ResolveSchemaVersion(fileDeclared, treeDeclared int, blueprintType string) int {
 	if fileDeclared > 0 {
@@ -112,7 +112,7 @@ func ValidateSchemaVersion(blueprintType string, version int) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("%s: schema version %d is not supported by this build (supports %s) — "+
+	return fmt.Errorf("%s: schema version %d is not supported by this build (supports %s) - "+
 		"upgrade rwr, or write this blueprint in a supported version",
 		blueprintType, version, versionList(blueprintType))
 }
@@ -138,7 +138,7 @@ func ValidateTreeSchemaVersion(version int) error {
 	if len(unsupported) == 0 {
 		return nil
 	}
-	return fmt.Errorf("schema version %d is not supported for %s — "+
+	return fmt.Errorf("schema version %d is not supported for %s - "+
 		"declare it per blueprint file instead, or upgrade rwr",
 		version, strings.Join(unsupported, ", "))
 }

--- a/internal/types/schema_registry.go
+++ b/internal/types/schema_registry.go
@@ -8,7 +8,7 @@ import "fmt"
 // Each supported version of a blueprint type is its own struct describing exactly
 // what that version accepts on disk. Decoding picks the struct by resolved
 // version and then converts it to the canonical type the processors use. So a v2
-// of packages is a new struct plus a conversion — nothing downstream of the
+// of packages is a new struct plus a conversion - nothing downstream of the
 // decoder learns that more than one version exists, and no other blueprint type
 // is touched.
 //
@@ -70,7 +70,7 @@ func HasSchemaVariant(blueprintType string, version int) bool {
 }
 
 // v1 variants. Each wraps the canonical struct, because v1 *is* the current
-// shape — the indirection only starts paying off at v2, where the wire struct
+// shape - the indirection only starts paying off at v2, where the wire struct
 // and the canonical struct diverge and Canonical() does real mapping work.
 
 type packagesV1 struct{ PackagesData }

--- a/internal/types/schema_test.go
+++ b/internal/types/schema_test.go
@@ -50,7 +50,7 @@ func TestResolveSchemaVersion(t *testing.T) {
 // blueprint written today gets today's format without boilerplate.
 //
 // This asserts against LatestSchemaVersion rather than a literal, so it keeps
-// testing the intent once a type gains a v2 — a hardcoded 1 here would silently
+// testing the intent once a type gains a v2 - a hardcoded 1 here would silently
 // keep passing while the behaviour it describes had changed.
 func TestResolveSchemaVersion_UndeclaredIsLatest(t *testing.T) {
 	for _, blueprintType := range []string{
@@ -131,7 +131,7 @@ func TestValidateTreeSchemaVersion(t *testing.T) {
 		t.Fatal("a tree-wide v2 must be rejected while no type implements v2")
 	}
 	// A tree-wide version applies to every type, so when only some types have a
-	// v2 the fix is to declare it per file — the error should say so.
+	// v2 the fix is to declare it per file - the error should say so.
 	if !strings.Contains(err.Error(), "per blueprint file") {
 		t.Errorf("error should suggest declaring per file, got: %v", err)
 	}
@@ -172,7 +172,7 @@ func withExtraVersion(t *testing.T, blueprintType string, version int) {
 }
 
 // The real point of "undeclared means latest": when packages gains a v2, a
-// packages blueprint that declares nothing is read as v2 — while files, which did
+// packages blueprint that declares nothing is read as v2 - while files, which did
 // not change, stays where it is. Today latest is 1 everywhere, so this simulates
 // the v2 to test the rule rather than the current numbers.
 func TestResolveSchemaVersion_UndeclaredFollowsANewVersion(t *testing.T) {
@@ -181,10 +181,10 @@ func TestResolveSchemaVersion_UndeclaredFollowsANewVersion(t *testing.T) {
 	if got := ResolveSchemaVersion(0, 0, BlueprintTypePackages); got != 2 {
 		t.Errorf("undeclared packages resolved to %d, want the new latest 2", got)
 	}
-	// A type that did not gain a version is unaffected — this is what keeps a
+	// A type that did not gain a version is unaffected - this is what keeps a
 	// breaking change contained to one resource.
 	if got := ResolveSchemaVersion(0, 0, BlueprintTypeFiles); got != 1 {
-		t.Errorf("undeclared files resolved to %d, want 1 — files did not change", got)
+		t.Errorf("undeclared files resolved to %d, want 1 - files did not change", got)
 	}
 	// Declaring a version still pins, which is how a tree stays on v1 after v2
 	// ships.
@@ -198,13 +198,13 @@ func TestResolveSchemaVersion_UndeclaredFollowsANewVersion(t *testing.T) {
 
 // Every type-and-version pair the supported map advertises must resolve to a
 // registered variant. packageManagers was listed as supported with no variant
-// registered, so NewSchemaVariant could only ever error on it — the two tables
+// registered, so NewSchemaVariant could only ever error on it - the two tables
 // are one contract and must not drift.
 func TestSupportedSchemaVersions_AllHaveRegisteredVariants(t *testing.T) {
 	for blueprintType, versions := range supportedSchemaVersions {
 		for _, version := range versions {
 			if _, err := NewSchemaVariant(blueprintType, version); err != nil {
-				t.Errorf("NewSchemaVariant(%q, %d): %v — supported but not registered", blueprintType, version, err)
+				t.Errorf("NewSchemaVariant(%q, %d): %v - supported but not registered", blueprintType, version, err)
 			}
 		}
 	}

--- a/internal/types/secrets.go
+++ b/internal/types/secrets.go
@@ -36,8 +36,8 @@ func IsSecretConfigKey(key string) bool {
 // Credentials are withheld by default because blueprints are cloned from git
 // repositories and scripts inherit rwr's environment, so anything reachable from
 // either is readable by whoever wrote the blueprint. But some blueprints
-// legitimately need a token — writing a .netrc, configuring gh, calling the
-// GitHub API from a script — so this is opt-in rather than unavailable.
+// legitimately need a token - writing a .netrc, configuring gh, calling the
+// GitHub API from a script - so this is opt-in rather than unavailable.
 var exposedCredentials = map[string]bool{}
 
 // SetExposedCredentials records which credential keys the operator opted into.
@@ -87,7 +87,7 @@ func SetShowSecrets(enabled bool) {
 // Redact returns value unless the operator asked to see secrets.
 //
 // The escape hatch exists because "is rwr even reading my token?" is a real
-// question with no other answer — but it has to be asked for deliberately rather
+// question with no other answer - but it has to be asked for deliberately rather
 // than being the default any time debug logging is on.
 func Redact(value string) string {
 	if value == "" {

--- a/internal/types/secrets_test.go
+++ b/internal/types/secrets_test.go
@@ -149,7 +149,7 @@ func TestNestedStructsDoNotLeakCredentials(t *testing.T) {
 }
 
 // Credentials are withheld from templates by default, but a blueprint that
-// genuinely needs one — writing a .netrc, configuring gh — can opt in by name.
+// genuinely needs one - writing a .netrc, configuring gh - can opt in by name.
 func TestFlagsToMap_ExposesOnlyOptedInCredentials(t *testing.T) {
 	defer SetExposedCredentials(nil)
 

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -1,4 +1,4 @@
-// Package uninstall reverses what the run journal shows was applied — and
+// Package uninstall reverses what the run journal shows was applied - and
 // only that. Input is the record, never the blueprint tree: uninstall after
 // editing or deleting the tree still works, and nothing without a record
 // entry is ever touched.
@@ -51,7 +51,7 @@ type Item struct {
 // removals from a tree that may have changed is how the wrong file dies.
 func Plan(records []*state.RecordFile) (items []Item, skipped []string, err error) {
 	if len(records) == 0 {
-		return nil, nil, fmt.Errorf("no run records under the state directory — nothing recorded, nothing to reverse")
+		return nil, nil, fmt.Errorf("no run records under the state directory - nothing recorded, nothing to reverse")
 	}
 	refs := state.UnreversedApplies(records)
 
@@ -108,7 +108,7 @@ func Execute(out io.Writer, items []Item, querier *status.Querier) (failed int) 
 			log.Errorf("uninstall: %s: %v", item.Action, err)
 			continue
 		case outcome != "":
-			helpers.Say(out, "skipped: %s — %s\n", item.Action, outcome)
+			helpers.Say(out, "skipped: %s - %s\n", item.Action, outcome)
 			continue
 		}
 		helpers.Say(out, "done: %s\n", item.Action)
@@ -139,7 +139,7 @@ func reverse(entry *state.Entry, querier *status.Querier) (skipReason string, er
 }
 
 // reverseFont deletes the font faces the recorded name installed into the
-// recorded directory — the same glob the fonts processor's own remove action
+// recorded directory - the same glob the fonts processor's own remove action
 // uses.
 func reverseFont(entry *state.Entry) (string, error) {
 	dir, name := entry.Identity["dir"], entry.Identity["name"]
@@ -195,7 +195,7 @@ func reverseFile(entry *state.Entry) (string, error) {
 			return "already absent", nil
 		}
 		if err := os.Remove(dest); err != nil {
-			return "not empty or not removable — left in place", nil //nolint:nilerr // deliberate skip, not a failure
+			return "not empty or not removable - left in place", nil //nolint:nilerr // deliberate skip, not a failure
 		}
 		return "", nil
 	}
@@ -203,9 +203,9 @@ func reverseFile(entry *state.Entry) (string, error) {
 	case status.Absent:
 		return "already absent", nil
 	case status.Modified:
-		return "modified since the recorded apply — not deleting", nil
+		return "modified since the recorded apply - not deleting", nil
 	case status.Unknown:
-		return "content unreadable — not deleting", nil
+		return "content unreadable - not deleting", nil
 	}
 	return "", os.Remove(dest)
 }
@@ -220,10 +220,10 @@ func reverseGit(entry *state.Entry) (string, error) {
 	}
 	dirty, err := exec.Command("git", "-C", target, "status", "--porcelain").Output() // #nosec G204 -- target comes from rwr's own journal
 	if err != nil {
-		return "not a readable git worktree — not deleting", nil //nolint:nilerr // deliberate skip
+		return "not a readable git worktree - not deleting", nil //nolint:nilerr // deliberate skip
 	}
 	if strings.TrimSpace(string(dirty)) != "" {
-		return "worktree has local changes — not deleting", nil
+		return "worktree has local changes - not deleting", nil
 	}
 	return "", os.RemoveAll(target)
 }

--- a/internal/uninstall/uninstall_test.go
+++ b/internal/uninstall/uninstall_test.go
@@ -114,7 +114,7 @@ func TestExecute_HashGuardAndAbsentSkip(t *testing.T) {
 		t.Error("deleted entry not marked reversed")
 	}
 	if marks["modified"] {
-		t.Error("skipped entry marked reversed — a re-run would never retry it")
+		t.Error("skipped entry marked reversed - a re-run would never retry it")
 	}
 }
 

--- a/internal/validate/blueprints.go
+++ b/internal/validate/blueprints.go
@@ -23,7 +23,7 @@ func ValidateBlueprints(path string, verbose bool, results *types.ValidationResu
 	// Find init file in the specified directory only
 	initFile := findInitFile(path)
 	if initFile == "" {
-		// A multi-configuration repo has a manifest instead: validate it —
+		// A multi-configuration repo has a manifest instead: validate it -
 		// decode, escape checks, and each entry's init file existing.
 		if manifestPath := helpers.FindManifest(path); manifestPath != "" {
 			validateManifest(manifestPath, results)
@@ -143,7 +143,7 @@ func validateInitFile(initFile string, results *types.ValidationResults) (*types
 	}
 
 	// Blueprints are rendered as templates before they are read, so validation
-	// has to render them against the same variables a run would — including
+	// has to render them against the same variables a run would - including
 	// the userDefined block the init file declares. Assigning the whole
 	// struct used to throw that block away, which blanked every
 	// {{ .UserDefined.x }} and turned the values behind them into false
@@ -208,8 +208,8 @@ func validateBlueprintFile(blueprintFile string, initConfig *types.InitConfig, r
 	//
 	// This used to apply to bootstrap.yaml alone, which was survivable only because
 	// validation never looked past the top directory. A blueprint using
-	// {{ .User.home }} is not valid YAML until it is rendered — the braces read as a
-	// flow mapping — so validating the raw bytes reports a parse error against a
+	// {{ .User.home }} is not valid YAML until it is rendered - the braces read as a
+	// flow mapping - so validating the raw bytes reports a parse error against a
 	// blueprint that works.
 	// Strict for the fixed namespaces, lenient only for UserDefined: validate
 	// used to render everything with missingkey=zero, so a typo like
@@ -263,8 +263,8 @@ type blueprintValidator func(data []byte, format string, file string, results *t
 // blueprintValidators maps blueprint types to their decode+validate functions.
 //
 // Each one decodes into the same Data struct the matching processor uses. They
-// used to decode into a bare slice — []types.Repository for a file whose content
-// is `repositories:` followed by a list — which cannot succeed against any real
+// used to decode into a bare slice - []types.Repository for a file whose content
+// is `repositories:` followed by a list - which cannot succeed against any real
 // blueprint. Nothing caught it because validation never looked inside a
 // subdirectory, and blueprints live in subdirectories.
 var blueprintValidators = map[string]blueprintValidator{

--- a/internal/validate/components.go
+++ b/internal/validate/components.go
@@ -115,7 +115,7 @@ func ValidateFiles(files []types.File, file string, results *types.ValidationRes
 
 // ValidateDirectories checks directory entries the same way ValidateFiles
 // checks files: they share the action vocabulary and the mode rules, and the
-// files processor dispatches both — validating only two of the three kinds a
+// files processor dispatches both - validating only two of the three kinds a
 // files blueprint carries let a bad directory mode through to run time.
 func ValidateDirectories(directories []types.Directory, file string, results *types.ValidationResults) {
 	blueprintDir := filepath.Dir(file)
@@ -145,7 +145,7 @@ var modeCarryingActions = map[string]bool{
 
 // validateFileMode reports the mode problems that survive decoding.
 //
-// A mode written ambiguously — `mode: 644`, which as a number is 0o1204 — is
+// A mode written ambiguously - `mode: 644`, which as a number is 0o1204 - is
 // already refused by types.FileMode while the blueprint is being read, so it
 // arrives here as a parse error naming the file. What is left is a mode that
 // parses but cannot do what the entry asks: a chmod with nothing to chmod to,

--- a/internal/validate/examples_schema_test.go
+++ b/internal/validate/examples_schema_test.go
@@ -73,7 +73,7 @@ type multiTypeBlueprint struct {
 //
 // This deliberately mirrors production: getProcessorType (processors/blueprints.go)
 // scans *every* path segment for a blueprint type name, it does not look only at
-// the immediate parent directory. Using the parent alone — as this test used to —
+// the immediate parent directory. Using the parent alone - as this test used to -
 // gave a nil target to every init and bootstrap file (their parent is the format
 // name, "yaml"/"json"/"toml"), to everything under alternative_layouts/, and to
 // examples/imports/Common/packages/arch/base-aur.yaml, all of which were then
@@ -116,8 +116,8 @@ func blueprintTargetForPath(rel string) interface{} {
 //
 // It is currently empty, and that is the goal state. Widening the type derivation
 // above brought init, bootstrap, alternative_layouts/ and imports/ under the strict
-// check for the first time and uncovered two real bugs — `asUser` on script entries
-// and `variables.userDefined` in init files — both of which are now implemented
+// check for the first time and uncovered two real bugs - `asUser` on script entries
+// and `variables.userDefined` in init files - both of which are now implemented
 // rather than tolerated.
 //
 // This is a shrinking list, never a growing one: an entry whose file starts
@@ -132,7 +132,7 @@ var knownSchemaViolations = map[string]struct{ key string }{}
 // here means such a change fails the build with the field named, instead of
 // shipping and quietly doing nothing on users' machines.
 //
-// It also catches the reverse — an example inventing a field that never existed,
+// It also catches the reverse - an example inventing a field that never existed,
 // which is how `src`/`dest`, `username` and script `mode` survived in the tree.
 func TestExamples_DecodeStrictlyIntoBlueprintStructs(t *testing.T) {
 	root := examplesDir(t)
@@ -181,7 +181,7 @@ func TestExamples_DecodeStrictlyIntoBlueprintStructs(t *testing.T) {
 			t.Errorf("%s: expected only the known %q violation, got: %s",
 				path, known.key, strings.Join(unknown, ", "))
 		case len(unknown) == 0 && isKnown:
-			t.Errorf("%s: now decodes cleanly — delete its knownSchemaViolations entry "+
+			t.Errorf("%s: now decodes cleanly - delete its knownSchemaViolations entry "+
 				"so the file cannot regress", path)
 		}
 		return nil
@@ -249,7 +249,7 @@ func unknownFieldsFromError(msg string) []string {
 //
 // This replaces a blanket "skip everything under alternative_layouts/" exclusion.
 // That exclusion was written when the whole subtree had drifted; it no longer
-// holds — every other pair under alternative_layouts/ agrees exactly, so the
+// holds - every other pair under alternative_layouts/ agrees exactly, so the
 // exclusion was hiding nothing but suppressing a real check on eleven files.
 //
 // What remains is narrow and real: YAML's `|` block scalar keeps the trailing
@@ -290,7 +290,7 @@ func trimStringNewlines(v interface{}) interface{} {
 
 // The yaml, json and toml copies of a blueprint must express the same thing.
 //
-// They had drifted badly — the Arch files example was 194 lines of YAML against
+// They had drifted badly - the Arch files example was 194 lines of YAML against
 // 31 of JSON, and the macOS scripts example worked in YAML while the JSON and
 // TOML copies were missing the `action` every entry needs. Someone reading the
 // TOML tree was being shown something that would not run.
@@ -361,7 +361,7 @@ func TestExamples_FormatsAgreeWithEachOther(t *testing.T) {
 		compare := func(other map[string]interface{}, format string) {
 			if reflect.DeepEqual(fromYAML, other) {
 				if _, listed := knownTrailingNewlineDrift[key]; listed && format == "toml" {
-					t.Errorf("%s and its .toml copy now agree exactly — delete its "+
+					t.Errorf("%s and its .toml copy now agree exactly - delete its "+
 						"knownTrailingNewlineDrift entry", rel)
 				}
 				return
@@ -401,8 +401,8 @@ func decodeInto(t *testing.T, path, format string, out *map[string]interface{}) 
 		return false // reported by the parse test
 	}
 
-	// Decoders disagree on Go representation for identical content — yaml yields
-	// []interface{} of maps where toml yields []map[string]interface{} — so
+	// Decoders disagree on Go representation for identical content - yaml yields
+	// []interface{} of maps where toml yields []map[string]interface{} - so
 	// canonicalise through JSON before comparing, or every file looks different.
 	canonical, err := json.Marshal(*out)
 	if err != nil {

--- a/internal/validate/examples_test.go
+++ b/internal/validate/examples_test.go
@@ -74,7 +74,7 @@ func TestExamples_ParseInTheirDeclaredFormat(t *testing.T) {
 
 // The examples may only use template variables that actually exist. A missing key
 // renders as the literal "<no value>" rather than erroring, so a typo silently
-// produces paths like "<no value>/.bashrc" — which is how 214 uses of
+// produces paths like "<no value>/.bashrc" - which is how 214 uses of
 // {{ .User.Home }} (capital H, where the map key is "home") went unnoticed.
 func TestExamples_UseOnlyRealTemplateVariables(t *testing.T) {
 	walkExamples(t, func(path, ext string, data []byte) {
@@ -83,7 +83,7 @@ func TestExamples_UseOnlyRealTemplateVariables(t *testing.T) {
 			return // reported by the parse test
 		}
 		if strings.Contains(string(resolved), "<no value>") {
-			t.Errorf("%s: renders \"<no value>\" — it references a template variable "+
+			t.Errorf("%s: renders \"<no value>\" - it references a template variable "+
 				"that does not exist (check casing: the keys are lowercase-first)", path)
 		}
 	})
@@ -121,7 +121,7 @@ func exampleVariables() types.Variables {
 }
 
 // A CUE blueprint that violates its own constraints is a validate diagnostic
-// with the file attached, on the same surface as schema errors — and the tree
+// with the file attached, on the same surface as schema errors - and the tree
 // still gets its init file discovered in .cue.
 func TestValidate_CueConstraintViolationIsDiagnostic(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/validate/helpers.go
+++ b/internal/validate/helpers.go
@@ -168,7 +168,7 @@ func validatePackagesWithVisited(packages []types.Package, file string, results 
 			validateImportWithVisited(pkg.Import, fmt.Sprintf("packages[%d]", i), blueprintDir, file, results, &types.PackagesData{}, visited)
 			continue
 		}
-		// name or names, the same contract ValidatePackages applies — this
+		// name or names, the same contract ValidatePackages applies - this
 		// copy still required `name` alone, so a names-list entry that
 		// validated fine as a file errored the moment it was imported.
 		if pkg.Name == "" && len(pkg.Names) == 0 {

--- a/internal/validate/recursion_test.go
+++ b/internal/validate/recursion_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fynxlabs/rwr/internal/types"
 )
 
-// Blueprints live in subdirectories — packages/, files/, services/ — which is the
+// Blueprints live in subdirectories - packages/, files/, services/ - which is the
 // layout the documentation recommends and every shipped example uses. Validation
 // read only the top directory, so `rwr validate` on a real tree checked the init
 // file and reported success. These tests use that layout.

--- a/mise.toml
+++ b/mise.toml
@@ -89,7 +89,7 @@ description = "Validate the CUE provider sources against their schema"
 run = "cue vet ./internal/system/definitions/"
 
 [tasks.security]
-description = "Scan for known vulnerabilities (govulncheck — staged by postinstall)"
+description = "Scan for known vulnerabilities (govulncheck - staged by postinstall)"
 run = "govulncheck ./..."
 
 [tasks.install]

--- a/openspec/changes/add-capture-command/proposal.md
+++ b/openspec/changes/add-capture-command/proposal.md
@@ -1,12 +1,12 @@
-# Change: rwr capture — turn a handcrafted machine into a blueprint tree
+# Change: rwr capture - turn a handcrafted machine into a blueprint tree
 
 Depends on: add-system-scan (the harvest layer).
 
 ## Why
 
 The first blueprint tree is the expensive one. An operator with a machine
-they have shaped over years — packages across pacman *and* cargo *and* npm,
-a decade of dotfiles, hand-enabled services — has no path into rwr except
+they have shaped over years - packages across pacman *and* cargo *and* npm,
+a decade of dotfiles, hand-enabled services - has no path into rwr except
 transcribing it all by hand. That is exactly the work a tool that already
 knows every provider's package list, the blueprint schema, and four output
 formats should do.
@@ -19,11 +19,11 @@ human with a checklist, so the human gets a checklist.
 ## What Changes
 
 - `rwr capture [dir]`: scans the machine (add-system-scan) and walks the
-  operator through a multi-page huh form — one page per category:
+  operator through a multi-page huh form - one page per category:
   - packages (per provider, explicit-only, pre-selected);
   - configs (dotfiles + `~/.config` survivors of the noise list,
     pre-selected only for the known-dotfile set);
-  - services (enabled units, unselected by default — most are distro
+  - services (enabled units, unselected by default - most are distro
     plumbing);
   - git checkouts (discovered clones, pre-selected).
 - Generates into `dir` (default `./rwr-blueprints`):
@@ -33,7 +33,7 @@ human with a checklist, so the human gets a checklist.
   - `--manifest` also writes a root manifest with the current machine's
     OS/distro matchers, ready to grow more machines.
 - The generated tree SHALL pass `rwr validate` before capture reports
-  success — a capture that emits an invalid tree has failed, loudly.
+  success - a capture that emits an invalid tree has failed, loudly.
 - Non-interactive mode (`--all`, CI/scripting) takes every pre-selected
   default without the form.
 

--- a/openspec/changes/add-capture-command/specs/cli/spec.md
+++ b/openspec/changes/add-capture-command/specs/cli/spec.md
@@ -1,4 +1,4 @@
-# CLI — Deltas
+# CLI - Deltas
 
 ## ADDED Requirements
 
@@ -8,7 +8,7 @@
 selection form (packages per provider explicit-only and pre-selected;
 configs pre-selected only for known dotfiles; services unselected by
 default; git checkouts pre-selected), and generate a blueprint tree in the
-chosen registry format from the selection — init file, per-category
+chosen registry format from the selection - init file, per-category
 blueprints, and selected config files copied under `files/src/` with
 matching entries. `--all` SHALL take the defaults without the form;
 `--manifest` SHALL add a root manifest carrying the machine's detected

--- a/openspec/changes/add-diff-command/proposal.md
+++ b/openspec/changes/add-diff-command/proposal.md
@@ -1,4 +1,4 @@
-# Change: rwr diff — machine drift as blueprint updates
+# Change: rwr diff - machine drift as blueprint updates
 
 Depends on: add-system-scan (the harvest layer).
 
@@ -6,7 +6,7 @@ Depends on: add-system-scan (the harvest layer).
 
 A provisioned machine drifts: packages installed by hand, configs adjusted,
 services enabled. `rwr status` (state-tracking spec) answers "does the
-machine match the tree" — but its unit of report is drift, and its consumer
+machine match the tree" - but its unit of report is drift, and its consumer
 is an exit code. The operator's actual next step is "fold the drift I want
 to keep back into the blueprints", and today that is a manual diff of
 `pacman -Qe` against yaml by eyeball.
@@ -26,9 +26,9 @@ instead of guessed at.
     additions/removals, rendered by the scan emission layer;
   - `--packages` (and siblings) to scope to one category.
 - `--into <tree>`: interactive routing. For each change group a huh form
-  offers the destination candidates discovered from the tree itself — the
+  offers the destination candidates discovered from the tree itself - the
   matching machine tree's blueprint file, any Common file the tree imports
-  for that category, or skip — then writes the edit in the target file's
+  for that category, or skip - then writes the edit in the target file's
   own format. rwr cannot know whether a new package is an Archcraft thing
   or a Common thing; that is the operator's call, made once per group
   instead of once per hand-edit.

--- a/openspec/changes/add-diff-command/specs/cli/spec.md
+++ b/openspec/changes/add-diff-command/specs/cli/spec.md
@@ -1,4 +1,4 @@
-# CLI — Deltas
+# CLI - Deltas
 
 ## ADDED Requirements
 
@@ -32,8 +32,8 @@ named registry format. Diff never mutates the system.
 ### Requirement: rwr diff --into routes changes into the tree interactively
 
 `rwr diff --into <tree>` SHALL offer each change group a destination chosen
-by the operator — the matching machine tree's file for that category, a
-Common file the tree imports, or skip — and SHALL write accepted edits in
+by the operator - the matching machine tree's file for that category, a
+Common file the tree imports, or skip - and SHALL write accepted edits in
 the destination file's own format, leaving a tree that passes validation.
 Whether a change is machine-specific or Common is the operator's decision;
 rwr's job is to make it once per group instead of once per hand-edit.

--- a/openspec/changes/add-diff-command/tasks.md
+++ b/openspec/changes/add-diff-command/tasks.md
@@ -1,12 +1,12 @@
 # Tasks
 
-- [x] 1. `internal/diff`: scan-vs-tree comparison per category — additions
+- [x] 1. `internal/diff`: scan-vs-tree comparison per category - additions
       (on machine, not in tree) and removals (in tree, gone from machine),
       package identity matched provider-aware. Test: synthetic tree +
       fixture scan → expected delta; blueprint-installed packages (journal
       entries) never report as hand-added.
 - [x] 2. `rwr diff` list output grouped by category/provider; exit 0 always
-      (reporting, not gating — `rwr status` owns the exit code). Test:
+      (reporting, not gating - `rwr status` owns the exit code). Test:
       golden output.
 - [x] 3. `--format cue|yaml|json|toml` paste-ready blocks via the scan
       emission layer; `--packages`/`--configs`/`--services`/`--git` scoping.

--- a/openspec/changes/add-system-scan/proposal.md
+++ b/openspec/changes/add-system-scan/proposal.md
@@ -1,7 +1,7 @@
-# Change: System scan — the shared harvest layer for diff and capture
+# Change: System scan - the shared harvest layer for diff and capture
 
-Scope: the scanning foundation only. The two consumers — `rwr diff`
-(add-diff-command) and `rwr capture` (add-capture-command) — are separate
+Scope: the scanning foundation only. The two consumers - `rwr diff`
+(add-diff-command) and `rwr capture` (add-capture-command) - are separate
 changes that depend on this one.
 
 ## Why
@@ -17,7 +17,7 @@ actually on this machine, filtered to what a human chose to put there?"
 Today rwr can only see what a blueprint declared (`internal/processors/plan.go`)
 or what a run recorded (`internal/state`). The status querier
 (`internal/status/query.go`) reads provider `list` output, but that is the
-full installed set — on Arch that is every dependency ever pulled in, ~1200
+full installed set - on Arch that is every dependency ever pulled in, ~1200
 packages of noise around the ~200 the operator actually asked for. There is
 no notion of "explicitly installed", no config scanner, and no service
 scanner beyond the single-unit `is-enabled` probe.
@@ -29,7 +29,7 @@ scanner beyond the single-unit `is-enabled` probe.
   showmanual`, `brew leaves`, `dnf repoquery --userinstalled`,
   `cargo install --list`, `npm ls -g --depth=0`, …). Providers without one
   fall back to `list` and are marked unfiltered in scan results.
-- `internal/scan`: read-only scanners returning typed results —
+- `internal/scan`: read-only scanners returning typed results -
   - packages: per detected provider, explicit set preferred;
   - configs: the known-dotfile set (`.bashrc`, `.gitconfig`, …) plus
     top-level `~/.config` entries, minus a shipped known-noise exclusion
@@ -38,7 +38,7 @@ scanner beyond the single-unit `is-enabled` probe.
     list-unit-files --state=enabled`, minus vendor presets where
     determinable), per-platform, honest `unknown` elsewhere;
   - git checkouts: clones under configured roots (default `~/git`).
-- Scanners never mutate and never elevate — same contract as the status
+- Scanners never mutate and never elevate - same contract as the status
   querier, enforced the same way.
 - Blueprint emission helpers: a scan result renders as a blueprint block in
   any registry format (cue/yaml/json/toml), reusing the format-registry

--- a/openspec/changes/add-system-scan/specs/provider-detection/spec.md
+++ b/openspec/changes/add-system-scan/specs/provider-detection/spec.md
@@ -1,12 +1,12 @@
-# Provider Detection — Deltas
+# Provider Detection - Deltas
 
 ## ADDED Requirements
 
 ### Requirement: Providers may declare an explicit-install list command
 
-The provider schema SHALL accept an optional `list_explicit` command — the
+The provider schema SHALL accept an optional `list_explicit` command - the
 package manager's query for explicitly-installed packages (`pacman -Qe`,
-`apt-mark showmanual`, `brew leaves`) — and scan consumers SHALL prefer it
+`apt-mark showmanual`, `brew leaves`) - and scan consumers SHALL prefer it
 over `list`. Absence is not an error: consumers fall back to
 `list` and say so.
 

--- a/openspec/changes/add-system-scan/specs/system-scan/spec.md
+++ b/openspec/changes/add-system-scan/specs/system-scan/spec.md
@@ -1,11 +1,11 @@
-# System Scan — Deltas
+# System Scan - Deltas
 
 ## ADDED Requirements
 
 ### Requirement: Scans report what the operator put on the machine
 
-A scan SHALL report the machine's operator-chosen state per category —
-packages, configs, services, git checkouts — preferring each package
+A scan SHALL report the machine's operator-chosen state per category -
+packages, configs, services, git checkouts - preferring each package
 manager's explicitly-installed query (`list_explicit`) over its full list,
 and marking results unfiltered when only the full list exists. Dependency
 noise is the difference between a usable answer and 1200 rows.

--- a/openspec/changes/add-tui/proposal.md
+++ b/openspec/changes/add-tui/proposal.md
@@ -19,7 +19,7 @@ Full design in `design.md`. Summary:
   Exit nonzero if any collected.
 - `Reporter` event bus; `TUIReporter` and `LogReporter` (byte-identical to
   today's output). Log capture via a `slog.Handler` stamping a package-level
-  `currentProcessor` — zero edits to the ten processor files.
+  `currentProcessor` - zero edits to the ten processor files.
 - Interactive command handoff via `TerminalReq` + `tea.ExecProcess`; stderr of
   interactive commands is never piped (sudo prompt). Works for per-item
   `interactive: true` inside non-interactive runs.
@@ -33,7 +33,7 @@ Full design in `design.md`. Summary:
   `LogReporter`.
 
 Also folds `internal/system/prompt.go` `PromptUserChoice` (raw stdin) into the
-reporter/handoff path — a second stdin consumer would fight the TUI.
+reporter/handoff path - a second stdin consumer would fight the TUI.
 
 ## Breakage
 

--- a/openspec/changes/add-tui/specs/blueprint-processing/spec.md
+++ b/openspec/changes/add-tui/specs/blueprint-processing/spec.md
@@ -1,4 +1,4 @@
-# Blueprint Processing — Deltas
+# Blueprint Processing - Deltas
 
 ## ADDED Requirements
 

--- a/openspec/changes/add-tui/specs/cli/spec.md
+++ b/openspec/changes/add-tui/specs/cli/spec.md
@@ -1,4 +1,4 @@
-# CLI — Deltas
+# CLI - Deltas
 
 ## ADDED Requirements
 
@@ -29,7 +29,7 @@ A TUI run SHALL record every log line to a run log file (mode 0600, path
 printed on exit, `--log-file` overrides) and SHALL end with a summary of
 resources by status: applied, skipped, failed, unknown.
 
-Why: `unknown` is required — several providers do not report per-package
+Why: `unknown` is required - several providers do not report per-package
 results reliably; forcing them into ok/failed fabricates data.
 
 #### Scenario: Failure visible at end

--- a/openspec/changes/add-tui/specs/command-execution/spec.md
+++ b/openspec/changes/add-tui/specs/command-execution/spec.md
@@ -1,4 +1,4 @@
-# Command Execution — Deltas
+# Command Execution - Deltas
 
 ## MODIFIED Requirements
 

--- a/openspec/changes/add-tui/tasks.md
+++ b/openspec/changes/add-tui/tasks.md
@@ -9,7 +9,7 @@ Steps 1–5 are prerequisites and carry the risk; 6+ are additive.
 - [x] 3. Store, views, slog handler; test processor attribution of records.
 - [x] 4. Stage 2 resolve: provider grouping, lane counts.
 - [x] 5. Error accumulation in `All()`; test: non-interactive run with one
-      failing processor continues, exits nonzero (fails today — first error
+      failing processor continues, exits nonzero (fails today - first error
       aborts).
 - [x] 6. Static TUI: header, strip, collapsed list, panel, help bar.
 - [x] 7. Terminal handoff (`tea.ExecProcess`); test sudo prompt and per-item
@@ -27,5 +27,5 @@ Steps 1–5 are prerequisites and carry the risk; 6+ are additive.
 - [x] 14. OSC 9 notification (unfocused, >30s, recognized terminal only).
 - [ ] 15. Full test checklist from design.md §18. Per-item
       ResourceDone/LaneUpdate emission from all ten Process* functions is DONE.
-      REMAINING: manual terminal checks only — sudo-prompt handoff on a real
+      REMAINING: manual terminal checks only - sudo-prompt handoff on a real
       TTY; NO_COLOR/TERM=xterm/conhost visual passes.

--- a/openspec/changes/archive/2026-08-03-add-blueprint-manifest/proposal.md
+++ b/openspec/changes/archive/2026-08-03-add-blueprint-manifest/proposal.md
@@ -4,7 +4,7 @@ Depends on: `add-format-registry`, `add-tui` (selection renders as a TUI frame).
 
 ## Why
 
-A single blueprint repo commonly carries several machines' worth of config —
+A single blueprint repo commonly carries several machines' worth of config -
 e.g. TheFynx/rwr-blueprints has Arch/, Archcraft/, Common/, macOS/,
 OpenMandriva/, PopOS/, Windows/ at root. Today rwr has no notion of this: the
 operator must point `--init-file` at the right subdirectory by hand, and there
@@ -14,14 +14,14 @@ is no way to publish one repo URL that works on any of your machines.
 
 - A `manifest.{yaml,yml,json,toml}` file at blueprint-repo root (`.cue` once
   `add-cue-blueprints` lands), listing named configurations. Each entry:
-  - `name` — e.g. `arch-desktop`
-  - `init` — path to that configuration's init file, relative to repo root
+  - `name` - e.g. `arch-desktop`
+  - `init` - path to that configuration's init file, relative to repo root
   - matchers: `os` (linux/darwin/windows), `distro`, `family` (arch/debian/…),
     optional `arch`
   - optional `default: true`
 - Init resolution learns to accept a repo root (local dir or git URL): clone via
   the existing `GetBlueprints` machinery, find `manifest.*` at root, filter
-  entries against `system.DetectOS()` (runs before init — ordering already works).
+  entries against `system.DetectOS()` (runs before init - ordering already works).
 - Selection:
   - zero matches → error listing every entry and its matchers
   - exactly one match → use it, log which

--- a/openspec/changes/archive/2026-08-03-add-blueprint-manifest/specs/cli/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-blueprint-manifest/specs/cli/spec.md
@@ -1,4 +1,4 @@
-# CLI — Deltas
+# CLI - Deltas
 
 ## ADDED Requirements
 

--- a/openspec/changes/archive/2026-08-03-add-blueprint-manifest/specs/initialization/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-blueprint-manifest/specs/initialization/spec.md
@@ -1,11 +1,11 @@
-# Initialization — Deltas
+# Initialization - Deltas
 
 ## ADDED Requirements
 
 ### Requirement: A repo-root manifest declares multiple configurations
 
 The system SHALL read a root `manifest.*` when the init location (local dir
-or cloned git repo) contains no init file — the manifest is a list of
+or cloned git repo) contains no init file - the manifest is a list of
 named configurations, each with an `init` path relative to the repo root and
 optional matchers `os`, `distro`, `family`, `arch`, plus optional `default`.
 The manifest SHALL decode strictly through the format registry.

--- a/openspec/changes/archive/2026-08-03-add-bootstrap-command/proposal.md
+++ b/openspec/changes/archive/2026-08-03-add-bootstrap-command/proposal.md
@@ -12,18 +12,18 @@ deliberately absent from the `runProcessors` table (`cmd/run.go:112-123`), so
 neither `rwr run bootstrap` nor the root shorthand `rwr bootstrap` exists.
 
 The result: re-running just the bootstrap after editing `bootstrap.yaml`
-requires `rwr all --force-bootstrap` — which also re-runs every other
+requires `rwr all --force-bootstrap` - which also re-runs every other
 processor. That is both slow and surprising ("I asked to redo bootstrap, why
 is it reinstalling packages?").
 
 ## What Changes
 
 - `rwr run bootstrap` joins the processor table, and therefore the root
-  shorthand `rwr bootstrap` works too — same mechanism as every other
+  shorthand `rwr bootstrap` works too - same mechanism as every other
   processor, no special-casing in `cmd/`.
 - Semantics of an explicit invocation: asking for bootstrap by name implies
   wanting it to run, so the standalone command ignores the run-once marker
-  (equivalent to `--force-bootstrap`) — the marker exists to keep `all`
+  (equivalent to `--force-bootstrap`) - the marker exists to keep `all`
   idempotent, not to refuse an explicit request. It still writes/refreshes the
   marker on success and still honors `--dry-run`.
 - No bootstrap file in the tree → clear error naming the candidate filenames

--- a/openspec/changes/archive/2026-08-03-add-bootstrap-command/specs/cli/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-bootstrap-command/specs/cli/spec.md
@@ -1,4 +1,4 @@
-# CLI — Deltas
+# CLI - Deltas
 
 ## ADDED Requirements
 
@@ -8,8 +8,8 @@ RWR SHALL provide `rwr run bootstrap` (and the root shorthand `rwr bootstrap`)
 to run the bootstrap processor by itself. An explicit invocation SHALL run the
 bootstrap even when the run-once marker exists, SHALL refresh the marker on
 success, and SHALL fail with an error naming the candidate filenames when the
-tree has no bootstrap file. The gating of bootstrap inside `rwr all` — skipped
-when the marker exists unless `--force-bootstrap` is given — is unchanged.
+tree has no bootstrap file. The gating of bootstrap inside `rwr all` - skipped
+when the marker exists unless `--force-bootstrap` is given - is unchanged.
 
 #### Scenario: Re-running bootstrap after editing it
 

--- a/openspec/changes/archive/2026-08-03-add-convert-command/proposal.md
+++ b/openspec/changes/archive/2026-08-03-add-convert-command/proposal.md
@@ -1,4 +1,4 @@
-# Change: `rwr convert` — format conversion and tree migration
+# Change: `rwr convert` - format conversion and tree migration
 
 Depends on: `add-format-registry` (decode/encode dispatch),
 `unify-blueprint-semantics` (defines the "current state" trees migrate to).
@@ -12,7 +12,7 @@ Status: fleshed out (task 1). Decisions:
   a quoted scalar decodes and re-encodes byte-preserved. A file whose
   templates make it unparseable raw (unquoted `{{` at value start in YAML)
   cannot be converted and is reported per file, not silently mangled.
-- **CUE export style is JSON-form CUE** — valid CUE, lossless, and
+- **CUE export style is JSON-form CUE** - valid CUE, lossless, and
   mechanical. Idiomatic CUE (constraints, unification) is authoring work a
   converter should not guess at.
 - **Migration rules are a registry** (`migrateRules`), one entry per
@@ -37,13 +37,13 @@ Two recurring needs with no tool today:
   bootstrap file in a tree to the target format, preserving comments where the
   target supports them and template placeholders byte-identical.
 - `rwr convert --migrate [path]`: rewrite deprecated constructs to their
-  current equivalents — starting with init-file inline resource sections moved
+  current equivalents - starting with init-file inline resource sections moved
   into blueprint files under the tree.
 - Dry-run by default with a diff; `--write` applies.
 
 ## Breakage
 
-None — a new command; it only writes with `--write`.
+None - a new command; it only writes with `--write`.
 
 ## Impact
 

--- a/openspec/changes/archive/2026-08-03-add-convert-command/specs/cli/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-convert-command/specs/cli/spec.md
@@ -1,4 +1,4 @@
-# CLI — Deltas
+# CLI - Deltas
 
 ## ADDED Requirements
 
@@ -17,7 +17,7 @@ valid and lossless; idiomatic CUE remains authoring work.
 
 The first migration rule SHALL move init-file inline resource sections
 (`repositories`, `packages`, `services`, `files`, `templates`, `directories`,
-`configuration`) out of the init file into blueprint files under the tree —
+`configuration`) out of the init file into blueprint files under the tree -
 the construct strict decode now rejects.
 
 #### Scenario: Dry run by default

--- a/openspec/changes/archive/2026-08-03-add-coverage-reporting/baseline.md
+++ b/openspec/changes/archive/2026-08-03-add-coverage-reporting/baseline.md
@@ -16,6 +16,6 @@ Measured with `go test -coverprofile` across `./...`:
 (`main` and `internal/exectest` carry no tests: the former is a thin
 entrypoint, the latter is itself test tooling.)
 
-Gate threshold: **50%** — at-or-below the measured total so CI does not go
+Gate threshold: **50%** - at-or-below the measured total so CI does not go
 red on day one; ratchet deliberately as coverage grows (prompts at 8.1% is
 the obvious first target).

--- a/openspec/changes/archive/2026-08-03-add-cue-blueprints/proposal.md
+++ b/openspec/changes/archive/2026-08-03-add-cue-blueprints/proposal.md
@@ -1,11 +1,11 @@
 # Change: CUE as a supported blueprint format
 
-Depends on: `add-format-registry`. Related: `add-cue-providers` (independent —
+Depends on: `add-format-registry`. Related: `add-cue-providers` (independent -
 that change is build-time only; this one is runtime).
 
 ## Why
 
-Blueprints today are YAML, JSON, or TOML — all shape-unchecked at authoring
+Blueprints today are YAML, JSON, or TOML - all shape-unchecked at authoring
 time; errors surface at run time on the target machine. CUE gives blueprint
 authors types, constraints, and composition (shared fragments unified across
 machines), and rwr already publishes strict schemas per blueprint type that

--- a/openspec/changes/archive/2026-08-03-add-cue-blueprints/specs/blueprint-processing/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-cue-blueprints/specs/blueprint-processing/spec.md
@@ -1,4 +1,4 @@
-# Blueprint Processing — Deltas
+# Blueprint Processing - Deltas
 
 ## ADDED Requirements
 
@@ -7,7 +7,7 @@
 `.cue` SHALL be a registered blueprint format alongside YAML, JSON, and TOML,
 valid for blueprints, imports, init files, bootstrap files, and the manifest.
 A `.cue` file SHALL be evaluated in-process (`cuelang.org/go`), exported to
-concrete values, and decoded through the existing strict path — semantics
+concrete values, and decoded through the existing strict path - semantics
 identical to the equivalent YAML.
 
 Why: CUE gives authors types, constraints, and composition at authoring time;

--- a/openspec/changes/archive/2026-08-03-add-cue-blueprints/specs/blueprint-validation/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-cue-blueprints/specs/blueprint-validation/spec.md
@@ -1,4 +1,4 @@
-# Blueprint Validation — Deltas
+# Blueprint Validation - Deltas
 
 ## ADDED Requirements
 

--- a/openspec/changes/archive/2026-08-03-add-cue-providers/design.md
+++ b/openspec/changes/archive/2026-08-03-add-cue-providers/design.md
@@ -37,12 +37,12 @@ plain values a definition unifies with (`yay: #ArchAURHelper & {name: "yay"}`).
    The exported JSON decodes into the existing `types.Provider` structs; the
    loading code changes from a TOML decoder to a JSON decoder and nothing
    downstream notices. Filesystem provider *overrides* stay TOML (or gain
-   JSON) — operators should not need CUE installed to override a provider.
+   JSON) - operators should not need CUE installed to override a provider.
 
 2. **Schema mirrors `types.Provider` exactly, and a test enforces it.** A Go
    test round-trips every exported provider through strict decoding into
    `types.Provider` with no unknown keys, so the CUE schema and the Go structs
-   cannot drift apart silently — the same guarantee `embedded_test.go` gives
+   cannot drift apart silently - the same guarantee `embedded_test.go` gives
    today, but at the schema level.
 
 3. **Family templates for the proven clusters only.**
@@ -52,7 +52,7 @@ plain values a definition unifies with (`yay: #ArchAURHelper & {name: "yay"}`).
      parameterized by AUR package name (collapses 5 files to ~5 lines each).
    - `#DebianFamily`: apt/apt-get share detection and repository shape.
 
-   Everything else stays a standalone definition — inventing hierarchies for
+   Everything else stays a standalone definition - inventing hierarchies for
    single members obscures more than it saves.
 
 4. **Contracts move into the schema.** What `validate/providers.go` checks by
@@ -62,14 +62,14 @@ plain values a definition unifies with (`yay: #ArchAURHelper & {name: "yay"}`).
    - step actions constrained to the enum the processors implement
    - a `condition` may reference only the predicate names rwr derives
      (kept as a CUE `or` list that a Go test asserts equals the keys of
-     `repositoryPredicates` — one source of truth, checked both ways)
+     `repositoryPredicates` - one source of truth, checked both ways)
    - install/remove steps may not contain literal `/tmp/` paths
      (the `{{ .TempDir }}` rule, today a Go test, becomes a schema regexp)
 
 5. **CI validates and checks freshness; the export is committed.** A
    `cue-providers` job runs `cue vet` + `cue export` and fails if the
    committed JSON differs from the fresh export (same pattern as gofmt).
-   Committed output keeps `go build` working with no CUE toolchain installed —
+   Committed output keeps `go build` working with no CUE toolchain installed -
    contributors touching providers need CUE (via mise), everyone else doesn't.
 
 ## What gets deleted
@@ -88,13 +88,13 @@ of export-freshness tooling.
 ## Sequencing (3 PRs)
 
 1. **Schema + pipeline**: `providers/cue/schema.cue`, export tooling
-   (`mise run providers:export`), CI job, loader reads committed JSON —
+   (`mise run providers:export`), CI job, loader reads committed JSON -
    with the TOMLs still the source, converted mechanically 1:1 (no family
    templates yet). Proves the pipeline with zero semantic change; the
    round-trip test is the gate.
 2. **Families**: introduce `#PacmanFamily` / `#ArchAURHelper` /
    `#DebianFamily`, collapse the members onto them. Exported JSON must be
-   byte-identical to PR 1's — the diff *is* the review.
+   byte-identical to PR 1's - the diff *is* the review.
 3. **Contracts**: move the validate/providers.go checks into the schema,
    delete the superseded Go, add the predicate-name cross-check test.
 

--- a/openspec/changes/archive/2026-08-03-add-cue-providers/proposal.md
+++ b/openspec/changes/archive/2026-08-03-add-cue-providers/proposal.md
@@ -37,7 +37,7 @@ Full design in `design.md`. Key decisions:
    working without a CUE toolchain.
 
 Resolved open questions: overrides accept TOML **and** JSON; `cue` pinned in
-mise from PR 1; source lives at `providers/cue/` (repo root — it is source,
+mise from PR 1; source lives at `providers/cue/` (repo root - it is source,
 not an embedded asset).
 
 ## What Changes

--- a/openspec/changes/archive/2026-08-03-add-cue-providers/specs/blueprint-validation/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-cue-providers/specs/blueprint-validation/spec.md
@@ -1,10 +1,10 @@
-# Blueprint Validation — Deltas
+# Blueprint Validation - Deltas
 
 ## ADDED Requirements
 
 ### Requirement: Embedded provider contracts live in the CUE schema
 
-Embedded provider contracts SHALL be expressed in the CUE schema — the checks
+Embedded provider contracts SHALL be expressed in the CUE schema - the checks
 currently hand-rolled in `internal/validate/providers.go`: required `name`,
 `detection.binary`, `commands.install`; step `action` constrained to the enum
 the processors implement; `condition` restricted to derivable predicate names;

--- a/openspec/changes/archive/2026-08-03-add-cue-providers/specs/provider-detection/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-cue-providers/specs/provider-detection/spec.md
@@ -1,4 +1,4 @@
-# Provider Detection — Deltas
+# Provider Detection - Deltas
 
 ## ADDED Requirements
 

--- a/openspec/changes/archive/2026-08-03-add-cue-providers/tasks.md
+++ b/openspec/changes/archive/2026-08-03-add-cue-providers/tasks.md
@@ -5,13 +5,13 @@ Three PRs, each independently green.
 - [x] 1. **Schema + pipeline**: `providers/cue/schema.cue`, mechanical 1:1
       conversion of the 25 TOMLs, `mise run providers:export`, pinned `cue` in
       mise, CI job (`cue vet` + freshness diff), loader reads committed JSON.
-      Gate: strict round-trip test — every exported provider decodes into
+      Gate: strict round-trip test - every exported provider decodes into
       `types.Provider` with no unknown keys and equals the TOML-derived value
       (fails on any semantic drift).
 - [x] 2. **Families**: `#PacmanFamily`, `#ArchAURHelper`, `#DebianFamily`;
       collapse members. Gate: exported JSON byte-identical to PR 1's.
 - [x] 3. **Contracts**: move `validate/providers.go` checks into the schema;
       delete superseded Go; predicate-name cross-check test (CUE `or` list ==
-      keys of `repositoryPredicates`, asserted from Go — fails if either side
+      keys of `repositoryPredicates`, asserted from Go - fails if either side
       drifts). Filesystem overrides accept `.toml` and `.json`; override
       validation stays in Go.

--- a/openspec/changes/archive/2026-08-03-add-format-registry/proposal.md
+++ b/openspec/changes/archive/2026-08-03-add-format-registry/proposal.md
@@ -3,7 +3,7 @@
 ## Why
 
 Format *decoding* is centralized (`internal/helpers/blueprints.go` `unmarshalBlueprint`),
-but format *derivation* — which extensions exist and which decoder a file gets — is
+but format *derivation* - which extensions exist and which decoder a file gets - is
 hardcoded in ~15 places. Worse, the codebase holds two contradictory models:
 
 - `internal/processors/blueprints.go:187,221` and `internal/processors/profiles.go:53`
@@ -43,8 +43,8 @@ the config-file form of the setting and the flag disagree.
 
 ## Breakage
 
-Nothing breaks for existing blueprints. A tree that mixes formats — previously
-undefined behavior (half the code honored it, half didn't) — becomes supported.
+Nothing breaks for existing blueprints. A tree that mixes formats - previously
+undefined behavior (half the code honored it, half didn't) - becomes supported.
 `examples/` must still pass unchanged.
 
 ## Impact

--- a/openspec/changes/archive/2026-08-03-add-format-registry/specs/blueprint-processing/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-format-registry/specs/blueprint-processing/spec.md
@@ -1,4 +1,4 @@
-# Blueprint Processing — Deltas
+# Blueprint Processing - Deltas
 
 ## ADDED Requirements
 

--- a/openspec/changes/archive/2026-08-03-add-format-registry/specs/initialization/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-format-registry/specs/initialization/spec.md
@@ -1,4 +1,4 @@
-# Initialization — Deltas
+# Initialization - Deltas
 
 ## ADDED Requirements
 

--- a/openspec/changes/archive/2026-08-03-add-managed-auth/design.md
+++ b/openspec/changes/archive/2026-08-03-add-managed-auth/design.md
@@ -5,7 +5,7 @@
 Today's secret handling is a fixed two-key list (`internal/types/secrets.go`)
 with three behaviors attached: template-scope withholding, `RWR_VAR_*` export
 gating, and log redaction. The design generalizes the *list* while keeping the
-three behaviors exactly as specified in `credential-handling` — they are
+three behaviors exactly as specified in `credential-handling` - they are
 already right, they just apply to too few things.
 
 ## Goals
@@ -20,7 +20,7 @@ already right, they just apply to too few things.
 
 - Secret *management* (rotation, expiry, vault backends). Sources are local:
   env, OS keyring, prompt. A future `exec:` source could shell out to
-  `pass`/`op`/`vault` — out of scope here, but the sources list is ordered and
+  `pass`/`op`/`vault` - out of scope here, but the sources list is ordered and
   extensible precisely so that can land without schema change.
 - Per-blueprint scoping. Scope is per-processor at most; anything finer needs
   provenance tracking rwr does not have.
@@ -65,8 +65,8 @@ before prompt so an interactive answer given once (and saved) is not re-asked.
 A single resolution phase in `ProcessInitialization` after `SetExposedCredentials`
 (`internal/processors/initialize.go:156`) and before
 `setUserDefinedAndEnvVariables`, so the export gate sees the full credential
-set. All declared credentials resolve up front — failing at minute 20 inside a
-script is worse than failing at second 1 — except credentials scoped to
+set. All declared credentials resolve up front - failing at minute 20 inside a
+script is worse than failing at second 1 - except credentials scoped to
 processors not selected for this run, which are skipped.
 
 ### Storage
@@ -75,10 +75,10 @@ processors not selected for this run, which are skipped.
   name). Candidate library: `zalando/go-keyring` (no cgo, covers Secret
   Service, macOS Keychain, Windows Credential Manager). Headless Linux without
   a Secret Service provider: `keyring` source resolves to "unavailable" and
-  precedence moves on — never an error on read, loud error on an explicit save.
+  precedence moves on - never an error on read, loud error on an explicit save.
 - Hard rule: rwr never writes a managed credential to a plaintext file. The
-  one existing violation — the GitHub token in the viper config file
-  (`SaveGitHubTokenToConfig`) — is grandfathered for reads; the device flow's
+  one existing violation - the GitHub token in the viper config file
+  (`SaveGitHubTokenToConfig`) - is grandfathered for reads; the device flow's
   save path prefers the keyring when available and only falls back to the
   config file with a warning naming the file.
 
@@ -95,7 +95,7 @@ export surface is env (opt-in via `exposeCredentials`) and template scope
 
 `scope` limits which processors see the credential even after exposure:
 `scripts`, `templates` (files/templates rendering), or a processor name.
-Enforcement point is the same gate that today checks `IsCredentialExposed` —
+Enforcement point is the same gate that today checks `IsCredentialExposed` -
 the check becomes (exposed AND in scope for the consuming processor). Default
 scope is everything `exposeCredentials` reaches today, so omitting `scope`
 reproduces current semantics.

--- a/openspec/changes/archive/2026-08-03-add-managed-auth/proposal.md
+++ b/openspec/changes/archive/2026-08-03-add-managed-auth/proposal.md
@@ -1,23 +1,23 @@
-# Change: Managed auth — declared credentials, sourced and redacted
+# Change: Managed auth - declared credentials, sourced and redacted
 
 ## Why
 
 rwr's credential story is two hardcoded secrets and ad-hoc plumbing around one
 of them. `types.SecretConfigKeys` (`internal/types/secrets.go:15-18`) names
 exactly `repository.gh_api_token` and `repository.ssh_private_key`; everything
-downstream — withholding from template scope, the `RWR_VAR_*` export gate
-(`internal/processors/initialize.go:239-244`), log redaction — keys off that
+downstream - withholding from template scope, the `RWR_VAR_*` export gate
+(`internal/processors/initialize.go:239-244`), log redaction - keys off that
 fixed list. A blueprint that needs any *other* secret (a registry token, an API
 key a script writes into a `.netrc`, a license key) has no declared path at
 all: the operator smuggles it in as an `RWR_*` environment variable, which
 lands in `Variables.UserDefined` (`initialize.go:227-233`) with none of the
-secret handling — unredacted in debug logs, exported to every spawned command.
+secret handling - unredacted in debug logs, exported to every spawned command.
 
 The GitHub token shows what the pieces look like when hand-built: `--gh-auth`
 runs an OAuth device flow (`internal/processors/ssh_key.go:278`,
 `AuthenticateWithGitHub`), `--gh-api-key` takes it on the command line
 (`cmd/root.go:145`), and the result persists via `viper.WriteConfig` into the
-config file — plaintext at rest, guarded only by 0600 permissions
+config file - plaintext at rest, guarded only by 0600 permissions
 (`internal/prompts/github.go`, `SaveGitHubTokenToConfig`). None of that
 machinery is reusable for a second credential; the ssh_keys processor is the
 only one that gets device-flow pre-work (`cmd/run.go:110-123`).
@@ -25,17 +25,17 @@ only one that gets device-flow pre-work (`cmd/run.go:110-123`).
 `exposeCredentials` (`internal/types/initialize.go:67-70`) already gives trees
 an opt-in vocabulary for *sharing* credentials with blueprints. What is missing
 is the other half: a way for a tree to *declare* the credentials it needs, and
-for rwr to *source* them — so the declared path is also the safe path.
+for rwr to *source* them - so the declared path is also the safe path.
 
 ## What Changes
 
 - A `credentials:` section in the init file. Each entry declares a named
   credential the tree's blueprints need:
-  - `name` — the identifier blueprints reference (e.g. `cachix_token`)
-  - `sources` — ordered list of places to look: `env:<VAR>`, `keyring`,
+  - `name` - the identifier blueprints reference (e.g. `cachix_token`)
+  - `sources` - ordered list of places to look: `env:<VAR>`, `keyring`,
     `prompt` (interactive input, masked), with a documented default order
-  - `description` — shown when prompting
-  - optional `scope` — which processors may read it (default: templates and
+  - `description` - shown when prompting
+  - optional `scope` - which processors may read it (default: templates and
     scripts, same surface `exposeCredentials` governs today)
 - Resolution at init time, after config load and before any processor runs:
   first source that yields a value wins; a declared credential that resolves
@@ -73,6 +73,6 @@ an existing config-file token keeps being read.
   `internal/prompts/github.go` / `internal/processors/ssh_key.go` (device flow
   re-pointed at the credential store), new keyring package.
 - Security posture: blueprints remain untrusted; a blueprint can *reference* a
-  declared credential but never *declare* one — declarations live only in the
+  declared credential but never *declare* one - declarations live only in the
   init file the operator points rwr at, and exposure still requires the
   operator's `exposeCredentials` opt-in.

--- a/openspec/changes/archive/2026-08-03-add-managed-auth/specs/credential-handling/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-managed-auth/specs/credential-handling/spec.md
@@ -1,4 +1,4 @@
-# Credential Handling — Deltas
+# Credential Handling - Deltas
 
 ## ADDED Requirements
 
@@ -35,7 +35,7 @@ unless named in `exposeCredentials`, and redacted in logs.
 RWR SHALL NOT write a managed credential's value to a plaintext file at rest.
 Persistence SHALL use the operating system keyring, and only with the
 operator's consent. When no keyring backend is available, RWR SHALL decline to
-persist and say so, rather than fall back to a plaintext file — except the
+persist and say so, rather than fall back to a plaintext file - except the
 pre-existing GitHub-token config-file path, which SHALL warn with the file
 path when used.
 

--- a/openspec/changes/archive/2026-08-03-add-managed-auth/tasks.md
+++ b/openspec/changes/archive/2026-08-03-add-managed-auth/tasks.md
@@ -27,7 +27,7 @@
       `gh_api_token` credential; device-flow save prefers keyring, config-file
       fallback warns with the path. Tests: existing config-file token still
       read; keyring-available path writes no plaintext.
-      *Deviation:* the built-ins' implicit sources omit `prompt` at init time —
+      *Deviation:* the built-ins' implicit sources omit `prompt` at init time -
       prompting for the GitHub token stays at its point of use (`ssh_keys`),
       preserving the existing behavior of never prompting a run that does not
       need the token. Built-ins are optional: unresolved is not an error.

--- a/openspec/changes/archive/2026-08-03-add-uninstall-status/design.md
+++ b/openspec/changes/archive/2026-08-03-add-uninstall-status/design.md
@@ -5,7 +5,7 @@
 rwr is convergence-oriented (`openspec/config.yaml`: running `rwr all` twice
 is the normal case) but write-only: nothing records what a run did. This
 design adds an observation journal and two consumers of it. It deliberately
-does NOT turn rwr into a state-enforcing system like Terraform — blueprints
+does NOT turn rwr into a state-enforcing system like Terraform - blueprints
 remain the source of desired state; the record is evidence of past applies,
 never an input to `all`.
 
@@ -36,7 +36,7 @@ never an input to `all`.
   services, `{name}` for repositories/fonts, `{target}` for git.
 - Only *applies* are recorded (dry-run writes nothing). Removal runs append
   removal entries; `uninstall` finalizes by marking entries reversed rather
-  than deleting records — the journal is append-only history.
+  than deleting records - the journal is append-only history.
 - Emission point: the processors already funnel failures through the ledger
   (`internal/processors/failures.go`); record emission rides the same
   per-item points, so coverage is per-item, not per-processor-exit.
@@ -44,7 +44,7 @@ never an input to `all`.
 ### `rwr status`
 
 - Desired side: reuse blueprint resolution (the `ResolveStage1` /
-  `plan_stage2` machinery, `internal/processors/plan.go`) — no new parser.
+  `plan_stage2` machinery, `internal/processors/plan.go`) - no new parser.
 - Actual side: a new optional per-processor `Query` capability:
   - packages: provider `list` command output (already defined per provider,
     e.g. apt's `dpkg --get-selections`) parsed for presence
@@ -53,17 +53,17 @@ never an input to `all`.
     sc.exe)
   - repositories: source-file presence at the provider's `paths`
   - fonts/git: recorded-path existence
-  - scripts, configuration, users, ssh_keys: report `unknown` — a query that
+  - scripts, configuration, users, ssh_keys: report `unknown` - a query that
     cannot be honest is worse than none
 - Output rows: `in-sync | missing | modified | unknown`; with a record
   available, an extra class `stale` (recorded but no longer in the tree).
-  Exit code 0 when everything in-sync/unknown, 1 on drift — scriptable.
+  Exit code 0 when everything in-sync/unknown, 1 on drift - scriptable.
 - Never elevates and never mutates: queries run unelevated, read-only.
 
 ### `rwr uninstall`
 
 - Input is the record (union of unreversed entries across runs), not the
-  blueprint tree — uninstall after editing or deleting the tree still works.
+  blueprint tree - uninstall after editing or deleting the tree still works.
   No record → refuse with an explanation (guessing at removals from a tree
   that may have changed is how you delete the wrong file).
 - Reverse application order (the inverse of the `all` processor order,

--- a/openspec/changes/archive/2026-08-03-add-uninstall-status/proposal.md
+++ b/openspec/changes/archive/2026-08-03-add-uninstall-status/proposal.md
@@ -14,29 +14,29 @@ logs. Concretely, today:
   packages honor `action: remove` (`internal/processors/packages.go:118`) and
   every provider defines a `remove` command (e.g.
   `internal/system/definitions/providers/apt.json` `"remove": "remove -y"`)
-  plus `repository.remove` step lists — but the operator must hand-edit
+  plus `repository.remove` step lists - but the operator must hand-edit
   blueprints to `remove` and re-run, which also loses the declaration.
 - Desired state is already resolvable without applying (the TUI's
   `ResolveStage1`, `internal/processors/plan.go:17`, and dry-run centralized
   in `system.RunCommand`), but nothing compares it to the actual machine.
 
 Without a record, "what did rwr do to this machine" and "take it back off"
-are both unanswerable — a real cost for the trying-it-out user and for anyone
+are both unanswerable - a real cost for the trying-it-out user and for anyone
 provisioning short-lived machines.
 
 ## What Changes
 
 - **Run record**: every non-dry-run applies get journaled to a state file
   (`<configdir>/state/`, one record per run): timestamp, blueprint tree
-  identity (URL/path + commit when git), and per-resource entries — what was
+  identity (URL/path + commit when git), and per-resource entries - what was
   applied, by which processor, with enough identity to check or reverse it
   (package name + provider, file dest + content hash, service name + action,
   repo name, font name, git target). Recording is best-effort observation:
   a failed run still records what it did apply.
 - **`rwr status`**: desired-vs-actual. Resolves the tree (reusing the plan
-  machinery), queries actuals per processor — package present via the
+  machinery), queries actuals per processor - package present via the
   provider's `list`/`search`, file dest exists and hash matches, service
-  enabled/running, repo file present — and prints a drift table: in-sync,
+  enabled/running, repo file present - and prints a drift table: in-sync,
   missing, modified, unmanaged-but-recorded. Requires new read-only query
   support per processor; processors that cannot be queried (scripts,
   configuration) report `unknown` honestly rather than guessing.

--- a/openspec/changes/archive/2026-08-03-add-uninstall-status/specs/state-tracking/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-uninstall-status/specs/state-tracking/spec.md
@@ -1,4 +1,4 @@
-# State Tracking — Deltas
+# State Tracking - Deltas
 
 ## ADDED Requirements
 

--- a/openspec/changes/archive/2026-08-03-add-uninstall-status/tasks.md
+++ b/openspec/changes/archive/2026-08-03-add-uninstall-status/tasks.md
@@ -22,7 +22,7 @@
       drift table (`in-sync/missing/modified/unknown/stale`), exit 1 on
       drift. Tests: golden output for a synthetic tree; no-record fallback
       omits the recorded column; command never elevates.
-- [x] 5. `rwr uninstall`: record-driven reverse-order removal — provider
+- [x] 5. `rwr uninstall`: record-driven reverse-order removal - provider
       `remove` for packages, provider `remove` steps for repositories,
       hash-guarded deletes for files/dirs/git/fonts, disable/stop for
       services. Tests: modified file skipped and listed; already-absent
@@ -35,5 +35,5 @@
       exit; failed entries stay unreversed and a re-run retries them (test
       fails without re-run coverage).
 - [x] 8. Docs: new commands page, state-file format doc; examples unaffected
-      (no blueprint schema change) — verify `examples/` validation still
+      (no blueprint schema change) - verify `examples/` validation still
       green.

--- a/openspec/changes/archive/2026-08-03-refactor-cmd-config/proposal.md
+++ b/openspec/changes/archive/2026-08-03-refactor-cmd-config/proposal.md
@@ -25,5 +25,5 @@ internal restructuring.
 
 ## Impact
 
-- Affected specs: `cli` (no requirement changes — internal only).
+- Affected specs: `cli` (no requirement changes - internal only).
 - Makes cmd-level tests with isolated config instances possible.

--- a/openspec/changes/archive/2026-08-03-refactor-cmd-config/tasks.md
+++ b/openspec/changes/archive/2026-08-03-refactor-cmd-config/tasks.md
@@ -6,6 +6,6 @@
       `cmd/root.go` into it; thread through `initializeSystemInfo` and
       subcommands.
 - [x] 3. Test constructing two isolated `AppConfig` instances and running
-      command setup against each without cross-talk (impossible today —
+      command setup against each without cross-talk (impossible today -
       fails without the refactor).
 - [x] 4. `mise run ci` green; behavior of every flag unchanged.

--- a/openspec/changes/archive/2026-08-03-refine-cli-shorthands/proposal.md
+++ b/openspec/changes/archive/2026-08-03-refine-cli-shorthands/proposal.md
@@ -1,4 +1,4 @@
-# Change: CLI polish — config view/edit, shorthand rationalization
+# Change: CLI polish - config view/edit, shorthand rationalization
 
 ## Why
 
@@ -7,7 +7,7 @@ Two leftover roughnesses after the fossil-kill batch (#209 landed the rest):
 **`rwr config` is create-only.** The command's own help admits it: "there is
 no config view or edit mode yet" (`cmd/config.go:16-18`). `--create`/`-c` is
 the single flag (`cmd/config.go:34`); anything else prints help. There is no
-way to see the effective config (which matters — it merges file, env, and
+way to see the effective config (which matters - it merges file, env, and
 flags via viper) or to open it in an editor, and the config file can contain
 the GitHub token, so "just cat it" is the wrong answer to teach.
 
@@ -24,15 +24,15 @@ defaulting to *true*, so `-I` alone is a no-op and the useful spelling is
 ## What Changes
 
 - **`rwr config` grows subcommands** (bare `rwr config` keeps printing help):
-  - `rwr config view` — the effective merged config, secret values shown as
+  - `rwr config view` - the effective merged config, secret values shown as
     `[redacted]` (reusing `types.RedactedPlaceholder`; `--show-secrets`
     reveals, matching the existing log convention at `cmd/root.go:178`), each
     key annotated with its source (default/file/env/flag) where viper can say.
-  - `rwr config edit` — open the config file in `$EDITOR` (fallback
+  - `rwr config edit` - open the config file in `$EDITOR` (fallback
     `$VISUAL`, then a platform default), creating it via the existing
     `CreateDefaultConfig` path if absent; re-validate after the editor exits
     and warn on parse errors rather than leaving them to the next run.
-  - `rwr config create` — subcommand form of today's `--create`. The
+  - `rwr config create` - subcommand form of today's `--create`. The
     `--create`/`-c` flag stays as a deprecated alias (cobra
     `MarkDeprecated`, the `--gh-key` pattern at `cmd/root.go:150-154`).
 - **New shorthands, additive only**:
@@ -60,5 +60,5 @@ or re-meaninged.
 - Affected code: `cmd/config.go` (subcommands), `cmd/root.go` (two
   `BoolVarP`/`StringVarP` swaps), docs `commands/config.md` and the flag
   tables.
-- `config view` must go through the redaction path — it is a new place a
+- `config view` must go through the redaction path - it is a new place a
   secret could leak; the test for that is the load-bearing one.

--- a/openspec/changes/archive/2026-08-03-refine-cli-shorthands/specs/cli/spec.md
+++ b/openspec/changes/archive/2026-08-03-refine-cli-shorthands/specs/cli/spec.md
@@ -1,4 +1,4 @@
-# CLI — Deltas
+# CLI - Deltas
 
 ## ADDED Requirements
 

--- a/openspec/changes/archive/2026-08-03-unify-blueprint-semantics/proposal.md
+++ b/openspec/changes/archive/2026-08-03-unify-blueprint-semantics/proposal.md
@@ -6,9 +6,9 @@ HIGH finding and every cross-processor inconsistency it catalogued.
 
 ## Why
 
-Six semantics questions have two answers each in today's code — import base
+Six semantics questions have two answers each in today's code - import base
 directories, name/names precedence, template strictness at validate, dead
-init-file sections, path-only type dispatch — and the blueprint schema cannot
+init-file sections, path-only type dispatch - and the blueprint schema cannot
 express a content digest for the two most security-sensitive downloads it
 causes: repository signing keys and `files:` sources. Each inconsistency is a
 blueprint that behaves differently depending on which processor reads it.
@@ -30,28 +30,28 @@ blueprint that behaves differently depending on which processor reads it.
 - Import resolution is file-relative everywhere. Six processors (packages,
   git, ssh_keys, services, users, repositories) resolve top-level imports
   against the tree root while files/scripts/fonts/configuration are
-  file-relative — the blueprint-processing spec already mandates
+  file-relative - the blueprint-processing spec already mandates
   file-relative, so this also closes the open code-violates-spec item.
 - `names` wins over `name` when both are set, everywhere. files/fonts already
   do this; packages had it backwards. Declaring both is a validate warning.
 - Init-file inline resource sections (`repositories`, `packages`, `services`,
   `files`, `templates`, `directories`, `configuration`) are REMOVED from the
   schema. They were decoded, validated, profile-counted, and never applied at
-  runtime — a declaration that silently does nothing. (Decision: drop rather
+  runtime - a declaration that silently does nothing. (Decision: drop rather
   than apply; blueprints stay the single declaration path. A `rwr convert`
   /migration tool is a planned follow-up change for moving old trees forward.)
 - Content-based blueprint-type detection: a file whose path names no processor
   directory is decoded shallowly and typed by its top-level keys
   (`packages:` → packages, …). This makes the shipped
-  `examples/alternative_layouts/` (flattened, minimal_files) actually execute —
-  today they exit 0 having run nothing — and honors the README's promise.
+  `examples/alternative_layouts/` (flattened, minimal_files) actually execute -
+  today they exit 0 having run nothing - and honors the README's promise.
   Ambiguous or unrecognized content keeps the loud unrouted-file warning.
 - Validate template strictness matches the spec: `missingkey=zero` only for
   the `UserDefined` namespace; `User`/`System`/`Flags` references that do not
   exist are validate errors.
 
 **Riders:** tautological tests deleted as encountered (roadmap item); bare
-`rwr run` now runs the whole tree (the landing command, mise-run style — the
+`rwr run` now runs the whole tree (the landing command, mise-run style - the
 READMEs always said `rwr run`; the code printed help and errored), with
 `rwr all` delegating to the same path.
 
@@ -64,7 +64,7 @@ READMEs always said `rwr run`; the code printed help and errored), with
 - A packages entry declaring BOTH `name` and `names` now installs the `names`
   list (was: only `name`). Declaring both also warns at validate.
 - Validate becomes stricter about unknown `.User/.System/.Flags` template
-  references — previously silently zero-valued. Runs were already strict;
+  references - previously silently zero-valued. Runs were already strict;
   this only moves the failure earlier.
 - Everything else is additive (`key_sha256`, `files[].sha256`, content
   detection for previously dead layouts).

--- a/openspec/changes/archive/2026-08-03-unify-blueprint-semantics/specs/blueprint-processing/spec.md
+++ b/openspec/changes/archive/2026-08-03-unify-blueprint-semantics/specs/blueprint-processing/spec.md
@@ -1,4 +1,4 @@
-# Blueprint Processing — Deltas
+# Blueprint Processing - Deltas
 
 ## ADDED Requirements
 
@@ -17,10 +17,10 @@ backwards relative to files/fonts.)
 
 A blueprint file whose path names no processor directory SHALL be typed by its
 top-level keys (`packages:` → packages, `repositories:` → repositories, …).
-A file whose content matches no type — or more than one — SHALL produce the
+A file whose content matches no type - or more than one - SHALL produce the
 loud unrouted-file warning and SHALL NOT execute.
 
-Why: the flattened and minimal_files layouts the examples ship were dead ends —
+Why: the flattened and minimal_files layouts the examples ship were dead ends -
 path-only dispatch sent every file to a bucket the run loop never reads, and
 the run exited 0 having executed nothing.
 
@@ -41,8 +41,8 @@ the run exited 0 having executed nothing.
 ### Requirement: Downloads are validated on every hop, bounded, and pinnable
 
 A download URL SHALL be refused unless it is https (plain http is allowed only
-for loopback hosts) — everything RWR downloads (package-signing keys, fonts,
-file sources, the init file) is installed with the operator's privileges — and
+for loopback hosts) - everything RWR downloads (package-signing keys, fonts,
+file sources, the init file) is installed with the operator's privileges - and
 that check SHALL be re-applied to **every redirect hop**, not only the initial
 URL. Validating only the first URL is worthless the moment a server answers
 with a 302 to plain http.
@@ -96,7 +96,7 @@ file whose definitions are merged in.
 
 Import paths SHALL resolve relative to the file that declares them, in every
 processor. (Previously six processors resolved top-level imports against the
-tree root while four resolved file-relative — the same `import:` string meant
+tree root while four resolved file-relative - the same `import:` string meant
 two different files depending on the blueprint type.) An imported file MAY be
 in any supported format, and its format SHALL be derived from its own
 extension, not the importing file's. Imported entries SHALL be subject to

--- a/openspec/changes/archive/2026-08-03-unify-blueprint-semantics/specs/blueprint-validation/spec.md
+++ b/openspec/changes/archive/2026-08-03-unify-blueprint-semantics/specs/blueprint-validation/spec.md
@@ -1,16 +1,16 @@
-# Blueprint Validation — Deltas
+# Blueprint Validation - Deltas
 
 ## ADDED Requirements
 
 ### Requirement: Template strictness at validate matches the run
 
 `rwr validate` SHALL resolve template references strictly for the `User`,
-`System`, and `Flags` namespaces — a reference that does not exist is a
-validation error — and leniently (`missingkey=zero`) only for `UserDefined`,
+`System`, and `Flags` namespaces - a reference that does not exist is a
+validation error - and leniently (`missingkey=zero`) only for `UserDefined`,
 whose values legitimately vary per machine.
 
 Why: validate resolved every namespace leniently, so a typo like
-`{{ .User.hoem }}` validated clean and failed at run time — the exact class of
+`{{ .User.hoem }}` validated clean and failed at run time - the exact class of
 error validate exists to catch early.
 
 #### Scenario: Misspelled built-in reference

--- a/openspec/changes/archive/2026-08-03-unify-blueprint-semantics/specs/initialization/spec.md
+++ b/openspec/changes/archive/2026-08-03-unify-blueprint-semantics/specs/initialization/spec.md
@@ -1,4 +1,4 @@
-# Initialization — Deltas
+# Initialization - Deltas
 
 ## ADDED Requirements
 
@@ -10,7 +10,7 @@ Under strict decode, an init file carrying any of these keys SHALL fail with
 an error naming the key and pointing at blueprint files.
 
 Why: these sections were decoded, validated, and profile-counted but never
-applied at runtime — a declaration that silently did nothing. Blueprints are
+applied at runtime - a declaration that silently did nothing. Blueprints are
 the single declaration path.
 
 Migration: move the entries into blueprint files under the tree; `rwr convert

--- a/openspec/specs/blueprint-processing/spec.md
+++ b/openspec/specs/blueprint-processing/spec.md
@@ -58,7 +58,7 @@ When the init file declares no order, RWR SHALL run blueprint types in this orde
 10. `configuration`
 
 `users` SHALL be present. Its previous absence meant `rwr all` never created users
-unless the init file hand-wrote its own order, while `rwr run users` worked — which
+unless the init file hand-wrote its own order, while `rwr run users` worked - which
 made the omission easy to miss.
 
 An init file that declares `blueprints.order` SHALL override this order.
@@ -70,7 +70,7 @@ When an `order` entry is a mapping rather than a plain name, RWR SHALL run the n
 processors in sorted order, and when the mapping names more than one processor RWR
 SHALL warn that it did so, naming them. A mapping cannot preserve the order it was
 written in, and Go randomizes map iteration, so such an entry previously produced a
-different sequence on every run — the one thing an explicit order is written to
+different sequence on every run - the one thing an explicit order is written to
 control. A mapping naming a single processor has only one possible order, so it
 produces no warning.
 
@@ -100,7 +100,7 @@ produces no warning.
 When the blueprint tree contains a bootstrap file, RWR SHALL process it before the
 ordered blueprint types.
 
-RWR SHALL look for the bootstrap file in every supported format — `bootstrap.yaml`,
+RWR SHALL look for the bootstrap file in every supported format - `bootstrap.yaml`,
 `bootstrap.yml`, `bootstrap.json`, `bootstrap.toml`. Looking only for
 `bootstrap.yaml` meant a tree written in TOML or JSON silently never bootstrapped,
 with no message saying so.
@@ -131,7 +131,7 @@ and every processor SHALL read its blueprint through `DecodeBlueprintInto`.
 
 A silently ignored key is a blueprint that looks applied and is not: `pacakges:`
 yields an empty section, every processor finds nothing to do, and the run reports
-success having changed nothing. A misspelled `profiles` is worse — the entry loses
+success having changed nothing. A misspelled `profiles` is worse - the entry loses
 its scoping and runs on every machine. Both are invisible at any log level, so they
 surface as "rwr didn't do anything" long after the typo was written.
 
@@ -182,9 +182,9 @@ time on an unchanged machine is the normal case, not an error path. Specifically
 
 ### Requirement: Non-fatal item failures reach the exit code
 
-A processor that SHALL continue past a failed item — a package that is not in the
+A processor that SHALL continue past a failed item - a package that is not in the
 repositories, a git remote that is temporarily unreachable, an SSH key that could
-not be registered — SHALL record that failure in a run ledger rather than only
+not be registered - SHALL record that failure in a run ledger rather than only
 logging it.
 
 At the end of the run RWR SHALL report every recorded failure and SHALL return an
@@ -212,13 +212,13 @@ the first failed entry instead (see Known Gaps).
 
 ### Requirement: A file mode is declared unambiguously
 
-A blueprint SHALL declare a file or directory mode as a quoted octal string —
-`"0644"`, `"644"`, `"0o644"` — which is the recommended form because it means the
+A blueprint SHALL declare a file or directory mode as a quoted octal string -
+`"0644"`, `"644"`, `"0o644"` - which is the recommended form because it means the
 same thing in YAML, JSON, and TOML.
 
 A number SHALL be read as the mode's own value, which is what every parser already
 produces for an octal literal: YAML `0644`, TOML `0o644`, and JSON `420` are one
-mode. A bare decimal that instead reads like unquoted octal digits — `644`, `755` —
+mode. A bare decimal that instead reads like unquoted octal digits - `644`, `755` -
 SHALL be refused with an error showing both readings, rather than guessed at.
 
 A mode SHALL NOT exceed `0o7777`. Zero SHALL mean "no mode declared", so a
@@ -247,14 +247,14 @@ file `0644`. A template's output is the place a credential is most likely to lan
 
 RWR SHALL render every templated field of a repository action step against the
 repository's values before acting on it, with `missingkey=error`. A provider's
-`add` and `remove` steps are Go templates — apt writes
+`add` and `remove` steps are Go templates - apt writes
 `deb [arch={{ .Arch }} signed-by={{ .KeyPath }}] {{ .URL }} ...`.
 
 Previously the placeholders were written to disk literally, producing source files
 containing `{{ .URL }}`.
 
 A step MAY declare a `condition`, which SHALL be evaluated before the rest of the
-step is rendered — a skipped step is allowed to reference data this repository does
+step is rendered - a skipped step is allowed to reference data this repository does
 not carry, which is the reason it is conditional. Only an explicitly truthy
 rendering SHALL run the step.
 
@@ -265,15 +265,15 @@ SHALL stop the run.
 `action: remove` on a repository blueprint SHALL run the provider's remove steps.
 Every embedded provider defines them.
 
-The steps that edit or delete an existing file — `append`, `remove_line`,
-`remove_section`, and `remove` — SHALL resolve their path against the provider's
+The steps that edit or delete an existing file - `append`, `remove_line`,
+`remove_section`, and `remove` - SHALL resolve their path against the provider's
 declared repository directories and SHALL refuse a path that resolves outside them,
 including through a symlink.
 
-The steps that create a file — `download`, `write`, and `copy` — SHALL resolve
+The steps that create a file - `download`, `write`, and `copy` - SHALL resolve
 their destination the same way, accepting only a destination inside the provider's
 declared repository paths or the run's private staging directory. These steps run
-with the provider's privileges — root, for every system package manager — and the
+with the provider's privileges - root, for every system package manager - and the
 destination is a template rendered against blueprint values, so an unchecked
 destination would be a root-privileged write to an arbitrary path.
 
@@ -291,7 +291,7 @@ destination would be a root-privileged write to an arbitrary path.
 #### Scenario: Removing a repository
 
 - **WHEN** a repositories blueprint declares `action: remove`
-- **THEN** the provider's remove steps run — deleting the source file and keyring,
+- **THEN** the provider's remove steps run - deleting the source file and keyring,
   or removing the named section from the provider's config file
 
 #### Scenario: A step path outside the provider's directories
@@ -327,7 +327,7 @@ file whose definitions are merged in.
 
 Import paths SHALL resolve relative to the file that declares them, in every
 processor. (Previously six processors resolved top-level imports against the
-tree root while four resolved file-relative — the same `import:` string meant
+tree root while four resolved file-relative - the same `import:` string meant
 two different files depending on the blueprint type.) An imported file MAY be
 in any supported format, and its format SHALL be derived from its own
 extension, not the importing file's. Imported entries SHALL be subject to
@@ -395,7 +395,7 @@ blueprint tree declares, before processing begins. A name no blueprint declares
 SHALL stop the run with an error listing the available profiles.
 
 When the tree declares no profiles at all, RWR SHALL warn that every
-profile-scoped entry will be skipped and continue — an empty discovery is as
+profile-scoped entry will be skipped and continue - an empty discovery is as
 likely to mean the walk missed something as that the operator mistyped. When
 profile discovery itself fails, RWR SHALL continue without validating; the
 processors will report why with better context.
@@ -449,8 +449,8 @@ than through the command executor where dry-run is otherwise enforced.
 ### Requirement: A managed clone's origin follows the declared URL
 
 RWR SHALL compare a managed clone's `origin` remote URL against the URL the
-blueprint declares — for a `git` blueprint entry that already exists on disk,
-and for the blueprint repository itself — and SHALL re-point `origin` to the
+blueprint declares - for a `git` blueprint entry that already exists on disk,
+and for the blueprint repository itself - and SHALL re-point `origin` to the
 declared URL when they differ, before any pull.
 
 The blueprint is the source of truth for where a repository comes from; without
@@ -546,8 +546,8 @@ RWR SHALL enforce the schema version of every file in the chain.
 ### Requirement: Downloads are validated on every hop, bounded, and pinnable
 
 A download URL SHALL be refused unless it is https (plain http is allowed only
-for loopback hosts) — everything RWR downloads (package-signing keys, fonts,
-file sources, the init file) is installed with the operator's privileges — and
+for loopback hosts) - everything RWR downloads (package-signing keys, fonts,
+file sources, the init file) is installed with the operator's privileges - and
 that check SHALL be re-applied to **every redirect hop**, not only the initial
 URL. Validating only the first URL is worthless the moment a server answers
 with a 302 to plain http.
@@ -609,10 +609,10 @@ backwards relative to files/fonts.)
 
 A blueprint file whose path names no processor directory SHALL be typed by its
 top-level keys (`packages:` → packages, `repositories:` → repositories, …).
-A file whose content matches no type — or more than one — SHALL produce the
+A file whose content matches no type - or more than one - SHALL produce the
 loud unrouted-file warning and SHALL NOT execute.
 
-Why: the flattened and minimal_files layouts the examples ship were dead ends —
+Why: the flattened and minimal_files layouts the examples ship were dead ends -
 path-only dispatch sent every file to a bucket the run loop never reads, and
 the run exited 0 having executed nothing.
 
@@ -666,7 +666,7 @@ touches it.
 `.cue` SHALL be a registered blueprint format alongside YAML, JSON, and TOML,
 valid for blueprints, imports, init files, bootstrap files, and the manifest.
 A `.cue` file SHALL be evaluated in-process (`cuelang.org/go`), exported to
-concrete values, and decoded through the existing strict path — semantics
+concrete values, and decoded through the existing strict path - semantics
 identical to the equivalent YAML.
 
 Why: CUE gives authors types, constraints, and composition at authoring time;
@@ -700,8 +700,8 @@ arbitrary files or phone home.
 - **THEN** evaluation fails with a containment error
 ### Requirement: Configuration entries apply desktop settings through named tools
 
-RWR SHALL apply a `configuration` entry with the tool it names — `dconf`,
-`gsettings`, `macos_defaults`, or `windows_registry` — and SHALL stop the run
+RWR SHALL apply a `configuration` entry with the tool it names - `dconf`,
+`gsettings`, `macos_defaults`, or `windows_registry` - and SHALL stop the run
 with an error naming any other tool. A failure applying a `dconf`,
 `macos_defaults`, or `windows_registry` entry SHALL also stop the run.
 
@@ -710,14 +710,14 @@ action as a ledger failure and skip the entry. The field used to be decoded and
 never read, so `action: banana` applied the setting anyway.
 
 For `dconf`, RWR SHALL resolve the entry's `file` relative to the blueprint
-directory and feed its content to `dconf load /` on standard input — commands
+directory and feed its content to `dconf load /` on standard input - commands
 run without a shell, so a `<` in argv is data, not a redirection. An entry with
 `run_once: true` SHALL be skipped when its bootstrap marker file exists, and
 the marker SHALL be written only after a successful apply.
 
 For `gsettings`, RWR SHALL check that each key is writable before setting it,
-and SHALL record a per-key ledger failure — and continue with the remaining
-keys — when the check or the set fails. Every failure here used to be
+and SHALL record a per-key ledger failure - and continue with the remaining
+keys - when the check or the set fails. Every failure here used to be
 discarded, so a run in which no setting applied still reported success.
 
 For `macos_defaults`, RWR SHALL write through `defaults write`, defaulting the
@@ -749,7 +749,7 @@ RWR SHALL write a `windows_registry` entry through PowerShell script bodies
 that are compile-time constants, and SHALL pass the blueprint-supplied path,
 name, and value in forms PowerShell never re-tokenizes: environment variables
 for an unelevated write, and a JSON payload file read with `ConvertFrom-Json`
-for an elevated one — a UAC-elevated child does not reliably inherit the
+for an elevated one - a UAC-elevated child does not reliably inherit the
 parent's environment. The elevated command itself is a constant plus a
 base64-encoded script, whose alphabet contains no quote, space, or
 metacharacter.
@@ -761,7 +761,7 @@ instead of reaching the registry as formatted garbage.
 
 Values used to be interpolated into the `-Command` string, so a value such as
 `a'; Remove-Item C:\ -Recurse; #` closed the surrounding quote and ran as a
-second statement — as administrator, for an elevated entry.
+second statement - as administrator, for an elevated entry.
 
 #### Scenario: A value carrying PowerShell metacharacters
 
@@ -779,7 +779,7 @@ second statement — as administrator, for an elevated entry.
 
 RWR SHALL resolve the latest `ryanoasis/nerd-fonts` release once per run and
 download each font as `<name>.tar.xz` from that release. The lookup SHALL
-happen only after the dry-run and empty-blueprint exits — it is a network call,
+happen only after the dry-run and empty-blueprint exits - it is a network call,
 and `--dry-run` is expected to work offline.
 
 A failed release lookup SHALL be recorded as a ledger failure and SHALL NOT
@@ -788,7 +788,7 @@ through the ledger. One font failing SHALL NOT stop the rest: each failure is
 ledgered and processing continues.
 
 A font name SHALL be refused when it is empty or contains a path separator or
-`..` — the name is concatenated into the download URL and the local font path,
+`..` - the name is concatenated into the download URL and the local font path,
 so `../../owner/repo/x` would both redirect the download to another release and,
 on removal, glob outside the font directory.
 
@@ -812,21 +812,21 @@ decompression error.
 RWR SHALL extract only regular-file entries whose name ends in `.ttf` or `.otf`
 (case-insensitive) from a font archive, into the system font directory for
 `location: system` and the user font directory otherwise. The filter used to be
-`.ttf` alone, so an OTF-only archive — several Nerd Fonts ship only `.otf` —
+`.ttf` alone, so an OTF-only archive - several Nerd Fonts ship only `.otf` -
 "installed successfully" with zero files written.
 
 Symlink and hardlink entries SHALL be skipped with a warning: links are never
 needed to install a font and are the cheapest way to make a later write land
 outside the destination. An entry whose path resolves outside the destination
 directory SHALL fail the extraction. A single entry decompressing past 64 MB
-SHALL fail as a suspected decompression bomb — archives arrive xz-compressed
+SHALL fail as a suspected decompression bomb - archives arrive xz-compressed
 from the network, and real font faces are single-digit MB.
 
 An archive that produced zero font faces SHALL be a failure, not a success.
 After an install or removal RWR SHALL refresh the font cache, elevated only for
 a system-scoped install.
 
-Removal SHALL glob both `<name>*.ttf` and `<name>*.otf` in the font directory —
+Removal SHALL glob both `<name>*.ttf` and `<name>*.otf` in the font directory -
 removal was `.ttf`-blind too, so an installed OTF face survived its own
 removal.
 
@@ -879,7 +879,7 @@ RWR SHALL show a diff and ask before overwriting when a directory copy runs
 interactively and a file already exists at the target. Declining SHALL skip
 that file and continue with the rest of the copy.
 
-A failed read of the confirmation — for example EOF on a piped stdin — SHALL
+A failed read of the confirmation - for example EOF on a piped stdin - SHALL
 fail the operation with an error naming `--interactive=false` as the way to
 skip prompts, and SHALL NOT terminate the process. It used to be a
 `log.Fatalf`, which bypassed the failure ledger and every deferred cleanup;
@@ -900,14 +900,14 @@ interactive defaults to on, so a piped stdin killed the whole run mid-flight.
 ## Known Gaps
 
 - **The users and scripts processors do not use the failure ledger.** The other
-  eight processors — packages, repositories, services, files (with its templates
-  and directories sections), configuration, git, `ssh_keys`, and fonts — record a
+  eight processors - packages, repositories, services, files (with its templates
+  and directories sections), configuration, git, `ssh_keys`, and fonts - record a
   failed item and keep going. The users and scripts processors return an error on
   the first failed entry, which aborts the rest of the run: the failure does reach
   the exit code, but the remaining work is given up rather than attempted and
   reported at the end.
 - **The files processor's `target` is not contained.** Repository steps resolve
-  their paths against the provider's declared repository directories — the editing
+  their paths against the provider's declared repository directories - the editing
   and removing steps and, since the write-path containment landed, the `download`,
   `write` and `copy` steps too. The files processor still writes to whatever
   `target` a blueprint names, with no boundary check.

--- a/openspec/specs/blueprint-schema-versioning/spec.md
+++ b/openspec/specs/blueprint-schema-versioning/spec.md
@@ -136,7 +136,7 @@ it wanted rather than failing as malformed.
 ## Known Gaps
 
 - **`packageManagers` has a supported-version entry but no wire struct.** It is
-  listed in the per-type version table — so a tree-wide declaration is checked
-  against it — but has no entry in the variant registry, because package managers
+  listed in the per-type version table - so a tree-wide declaration is checked
+  against it - but has no entry in the variant registry, because package managers
   are read from the init file rather than decoded as a blueprint. Nothing decodes
   that type today, so the mismatch is latent rather than reachable.

--- a/openspec/specs/blueprint-validation/spec.md
+++ b/openspec/specs/blueprint-validation/spec.md
@@ -85,7 +85,7 @@ wild, and CI is where that must surface.
 `rwr validate` SHALL walk the blueprint tree and check every blueprint file, not
 only the files in the top directory.
 
-Blueprints are organised by type — `packages/`, `files/`, `services/` — which is the
+Blueprints are organised by type - `packages/`, `files/`, `services/` - which is the
 layout the documentation recommends and every example uses. Reading only the top
 directory means checking the init file and reporting success.
 
@@ -132,10 +132,10 @@ what a processor rejects is a missed one. Specifically:
 - A package entry SHALL be valid with `name` or with `names`.
 - `package_manager` SHALL be optional; without one the default manager applies.
 - A file entry's action SHALL be one of `create`, `delete`, `copy`, `move`,
-  `chmod`, `chown`, `chgrp`, `symlink` — the set the files processor dispatches on.
+  `chmod`, `chown`, `chgrp`, `symlink` - the set the files processor dispatches on.
 - A script SHALL be valid with `exec`, `content`, or `source`.
 - A user or group action SHALL be valid as `create`, `modify`, `remove`, or
-  `delete` — the last being the accepted alias for `remove`.
+  `delete` - the last being the accepted alias for `remove`.
 - Every blueprint type SHALL have a validator, including `fonts` and
   `configuration`.
 
@@ -166,8 +166,8 @@ what a processor rejects is a missed one. Specifically:
 - A `chmod` action with no mode SHALL be an error, because applying it would strip
   every permission off the target at run time.
 - A mode larger than `0o7777` SHALL be an error: it is not a permission mode.
-- A mode on an action that ignores it — `move`, `delete`, `chown`, `chgrp`,
-  `symlink` — SHALL be a warning, so an operator who expected it to be applied
+- A mode on an action that ignores it - `move`, `delete`, `chown`, `chgrp`,
+  `symlink` - SHALL be a warning, so an operator who expected it to be applied
   finds out here. The mode-carrying actions are `create`, `chmod`, and `copy`:
   the files processor applies a declared mode to a copied target, so a mode on
   `copy` is meaningful, not ignored.
@@ -200,7 +200,7 @@ define, across YAML, JSON, and TOML. It SHALL be what a run uses as well as what
 validation uses, so `rwr validate` and `rwr all` agree on which keys exist; see the
 blueprint-processing specification.
 
-A silently ignored key is a blueprint that looks applied and is not — a misspelled
+A silently ignored key is a blueprint that looks applied and is not - a misspelled
 `profiles` key means an entry runs on every machine instead of the one it was
 scoped to.
 
@@ -226,12 +226,12 @@ its concern.
 ### Requirement: Template strictness at validate matches the run
 
 `rwr validate` SHALL resolve template references strictly for the `User`,
-`System`, and `Flags` namespaces — a reference that does not exist is a
-validation error — and leniently (`missingkey=zero`) only for `UserDefined`,
+`System`, and `Flags` namespaces - a reference that does not exist is a
+validation error - and leniently (`missingkey=zero`) only for `UserDefined`,
 whose values legitimately vary per machine.
 
 Why: validate resolved every namespace leniently, so a typo like
-`{{ .User.hoem }}` validated clean and failed at run time — the exact class of
+`{{ .User.hoem }}` validated clean and failed at run time - the exact class of
 error validate exists to catch early.
 
 #### Scenario: Misspelled built-in reference
@@ -252,7 +252,7 @@ naming the entry, since only the `names` list will be processed.
 
 ### Requirement: Embedded provider contracts live in the CUE schema
 
-Embedded provider contracts SHALL be expressed in the CUE schema — the checks
+Embedded provider contracts SHALL be expressed in the CUE schema - the checks
 currently hand-rolled in `internal/validate/providers.go`: required `name`,
 `detection.binary`, `commands.install`; step `action` constrained to the enum
 the processors implement; `condition` restricted to derivable predicate names;
@@ -303,12 +303,12 @@ validated in CI, per the compatibility contract.
 ### Requirement: Template strictness at validate matches the run
 
 `rwr validate` SHALL resolve template references strictly for the `User`,
-`System`, and `Flags` namespaces — a reference that does not exist is a
-validation error — and leniently (`missingkey=zero`) only for `UserDefined`,
+`System`, and `Flags` namespaces - a reference that does not exist is a
+validation error - and leniently (`missingkey=zero`) only for `UserDefined`,
 whose values legitimately vary per machine.
 
 Why: validate resolved every namespace leniently, so a typo like
-`{{ .User.hoem }}` validated clean and failed at run time — the exact class of
+`{{ .User.hoem }}` validated clean and failed at run time - the exact class of
 error validate exists to catch early.
 
 #### Scenario: Misspelled built-in reference
@@ -329,7 +329,7 @@ naming the entry, since only the `names` list will be processed.
 
 ### Requirement: Embedded provider contracts live in the CUE schema
 
-Embedded provider contracts SHALL be expressed in the CUE schema — the checks
+Embedded provider contracts SHALL be expressed in the CUE schema - the checks
 currently hand-rolled in `internal/validate/providers.go`: required `name`,
 `detection.binary`, `commands.install`; step `action` constrained to the enum
 the processors implement; `condition` restricted to derivable predicate names;

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -17,9 +17,9 @@ new-machine command.
 
 ### Requirement: `rwr run <processor>` applies one blueprint type
 
-`rwr run` SHALL provide a subcommand for each blueprint type — `packages`,
+`rwr run` SHALL provide a subcommand for each blueprint type - `packages`,
 `repository`, `services`, `files`, `configuration`, `users`, `git`, `scripts`,
-`ssh_keys`, and `fonts` — plus `all`, which runs everything exactly as `rwr all`
+`ssh_keys`, and `fonts` - plus `all`, which runs everything exactly as `rwr all`
 does. The subcommands are generated from one processor table, so a new processor
 is one table entry, not a new hand-written command.
 
@@ -29,8 +29,8 @@ path as `rwr all`.
 A bare `rwr run` SHALL list the processors and exit zero, like a task runner
 listing its tasks; naming an unknown processor SHALL print the list and fail.
 
-Each processor name SHALL also work directly off the root — `rwr packages` is
-`rwr run packages` — without the processor names entering the primary command
+Each processor name SHALL also work directly off the root - `rwr packages` is
+`rwr run packages` - without the processor names entering the primary command
 namespace, so they cannot collide with real subcommands.
 
 #### Scenario: Reapplying packages only
@@ -126,8 +126,8 @@ RWR SHALL provide a `version` subcommand and a `--version` flag on the root comm
 both reporting the version injected at link time by goreleaser, along with the
 commit, build date, builder, tree state, and the Go toolchain and platform.
 
-When a field was not injected — which is the case for `go build` and `go install`
-binaries — RWR SHALL fall back to the module and VCS information the Go toolchain
+When a field was not injected - which is the case for `go build` and `go install`
+binaries - RWR SHALL fall back to the module and VCS information the Go toolchain
 embeds, and SHALL report `dev` rather than nothing.
 
 A binary on disk that cannot say which commit produced it cannot be matched to a
@@ -148,7 +148,7 @@ bug report.
 At the start of any command that initializes the system, RWR SHALL ask GitHub for
 the latest release and SHALL print a one-line notice to stderr when a newer version
 exists. `--skip-version-check` SHALL suppress it, as SHALL the `rwr.skipVersionCheck`
-configuration key and its environment form — the flag binding into viper is one-way,
+configuration key and its environment form - the flag binding into viper is one-way,
 so reading only the flag variable left the key `rwr config --create` writes inert.
 
 The check SHALL be strictly advisory: a timeout, an unreachable network, a rate
@@ -257,7 +257,7 @@ valid and lossless; idiomatic CUE remains authoring work.
 
 The first migration rule SHALL move init-file inline resource sections
 (`repositories`, `packages`, `services`, `files`, `templates`, `directories`,
-`configuration`) out of the init file into blueprint files under the tree —
+`configuration`) out of the init file into blueprint files under the tree -
 the construct strict decode now rejects.
 
 #### Scenario: Dry run by default
@@ -291,8 +291,8 @@ RWR SHALL provide `rwr run bootstrap` (and the root shorthand `rwr bootstrap`)
 to run the bootstrap processor by itself. An explicit invocation SHALL run the
 bootstrap even when the run-once marker exists, SHALL refresh the marker on
 success, and SHALL fail with an error naming the candidate filenames when the
-tree has no bootstrap file. The gating of bootstrap inside `rwr all` — skipped
-when the marker exists unless `--force-bootstrap` is given — is unchanged.
+tree has no bootstrap file. The gating of bootstrap inside `rwr all` - skipped
+when the marker exists unless `--force-bootstrap` is given - is unchanged.
 
 #### Scenario: Re-running bootstrap after editing it
 

--- a/openspec/specs/command-execution/spec.md
+++ b/openspec/specs/command-execution/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-RWR configures a machine by running other programs — package managers, `systemctl`,
+RWR configures a machine by running other programs - package managers, `systemctl`,
 `ssh-keygen`, `useradd`, operator scripts. Every one of those invocations carries
 values that came out of a blueprint file, and blueprints are cloned from git
 repositories. This capability defines how a `types.Command` becomes a real process,
@@ -58,7 +58,7 @@ cannot be absorbed as a `sudo` option.
 On Windows, `Elevated` SHALL be a no-op at this layer: there is no `sudo`
 equivalent. A processor that genuinely needs elevation on Windows SHALL raise it
 itself through `Start-Process -Verb RunAs`, and SHALL pass the elevated process
-its inputs as data rather than as command text — the elevated shell tokenizes its
+its inputs as data rather than as command text - the elevated shell tokenizes its
 argument list a second time, so any value interpolated into it becomes code
 running as administrator. The Windows registry processor does this by writing a
 JSON payload and invoking a constant script via `-EncodedCommand`.
@@ -130,8 +130,8 @@ spawned process on standard input. `Stdin` SHALL NOT be a blueprint field: it ex
 so RWR can hand a tool a credential without putting it in argv.
 
 Where a tool accepts a credential on stdin, RWR SHALL use that path. Setting a Linux
-account password SHALL go through `chpasswd` on stdin — `chpasswd -e` when the value
-is already a crypt(3) hash, plain `chpasswd` otherwise — and SHALL NOT use
+account password SHALL go through `chpasswd` on stdin - `chpasswd -e` when the value
+is already a crypt(3) hash, plain `chpasswd` otherwise - and SHALL NOT use
 `useradd`/`usermod --password`.
 
 An argument of a `sudo`'d process is readable in `ps` by every local user for the
@@ -159,7 +159,7 @@ inheriting `os.Stdin` would hang waiting for a human who has nothing to type.
 `types.Command` SHALL carry a `Secrets` field listing values that must not be
 written to a log, and SHALL expose a `LogArgs()` method returning `Args` with every
 such value replaced by the redaction placeholder. Every log line that prints a
-command's arguments — the debug lines in `buildCommand`, and the `[DRY-RUN]` line —
+command's arguments - the debug lines in `buildCommand`, and the `[DRY-RUN]` line -
 SHALL use `LogArgs()` rather than `Args`.
 
 Some tools accept a credential only as an argument (chocolatey's `--password`,
@@ -249,8 +249,8 @@ the init file opted into them by name. See the credential-handling specification
 
 ### Requirement: Installer steps stage in a private per-run directory
 
-RWR SHALL create one private staging directory per run — a `0700` temporary
-directory with an unpredictable name, reachable only by the invoking user — and
+RWR SHALL create one private staging directory per run - a `0700` temporary
+directory with an unpredictable name, reachable only by the invoking user - and
 SHALL render `{{ .TempDir }}` in package-manager install and remove steps to
 it. When the directory cannot be created, the run SHALL stop; there is no
 fallback path.
@@ -258,8 +258,8 @@ fallback path.
 Install steps historically staged at fixed, world-known `/tmp` names
 (`/tmp/brew-install.sh`, a clone into `/tmp/yay`), and the macports installer
 staged its download in the current working directory. Any local user can
-pre-create such a path — or rewrite it between the download and the elevated
-step that executes it — which is root code execution. A failed creation used to
+pre-create such a path - or rewrite it between the download and the elevated
+step that executes it - which is root code execution. A failed creation used to
 fall back to the predictable `<tmp>/rwr-pm-unavailable`, which is exactly the
 class of name `{{ .TempDir }}` exists to eliminate.
 

--- a/openspec/specs/credential-handling/spec.md
+++ b/openspec/specs/credential-handling/spec.md
@@ -4,7 +4,7 @@
 
 RWR holds two credentials: a GitHub API token and an SSH private key. Blueprints are
 cloned from git repositories, and everything a blueprint can read, the author of that
-blueprint can read — a template writes its result to a path the same blueprint
+blueprint can read - a template writes its result to a path the same blueprint
 chooses, and a script inherits the environment RWR hands it. RWR cannot tell a
 blueprint the operator wrote from one they pulled in.
 
@@ -42,7 +42,7 @@ RWR SHALL warn at the start of the run when any credential is exposed, so the ch
 is visible rather than silent.
 
 This is opt-in rather than unavailable because some blueprints legitimately need a
-token — writing a `.netrc`, configuring `gh`, calling the GitHub API from a script.
+token - writing a `.netrc`, configuring `gh`, calling the GitHub API from a script.
 
 #### Scenario: Opting into the token only
 
@@ -147,7 +147,7 @@ the attacker in cleartext.
 
 RWR SHALL refuse an init file given as an `http://` URL.
 
-The init file drives everything RWR then runs — which repository the blueprints
+The init file drives everything RWR then runs - which repository the blueprints
 come from, which package managers are installed, which scripts execute elevated.
 Over `http://` that document can be rewritten by anyone on the path.
 
@@ -190,8 +190,8 @@ entered token SHALL be read without echo and refused unless it carries a
 recognized GitHub prefix (`ghp_`, `gho_`, `ghu_`).
 
 In a non-interactive run needing a token none is configured for, RWR SHALL fail
-with an error listing the ways to supply one — `--gh-api-key`, `--gh-auth`, or
-`GITHUB_TOKEN` — rather than prompting.
+with an error listing the ways to supply one - `--gh-api-key`, `--gh-auth`, or
+`GITHUB_TOKEN` - rather than prompting.
 
 #### Scenario: A device-flow login
 
@@ -260,7 +260,7 @@ unless named in `exposeCredentials`, and redacted in logs.
 RWR SHALL NOT write a managed credential's value to a plaintext file at rest.
 Persistence SHALL use the operating system keyring, and only with the
 operator's consent. When no keyring backend is available, RWR SHALL decline to
-persist and say so, rather than fall back to a plaintext file — except the
+persist and say so, rather than fall back to a plaintext file - except the
 pre-existing GitHub-token config-file path, which SHALL warn with the file
 path when used.
 

--- a/openspec/specs/distribution/spec.md
+++ b/openspec/specs/distribution/spec.md
@@ -40,8 +40,8 @@ when no hashing tool is available to perform the check.
 A script SHALL match a published asset by its whole file name, so
 `rwr_Linux_arm64.tar.gz` can never satisfy a request for `rwr_Linux_arm.tar.gz`.
 
-A script SHALL accept only architectures goreleaser actually builds — `x86_64`,
-`arm64`, and, on Linux only, `armv7` and `riscv64` — and SHALL say so when asked for
+A script SHALL accept only architectures goreleaser actually builds - `x86_64`,
+`arm64`, and, on Linux only, `armv7` and `riscv64` - and SHALL say so when asked for
 anything else. There is deliberately no `i386` case: no 386 target is built, so
 accepting it only produced a misleading "could not find a download URL" later on.
 
@@ -106,7 +106,7 @@ Every pull request SHALL run, as gating checks:
 - `golangci-lint`, reading the repository's own `.golangci.yml` so there is no
   second copy of the configuration to drift;
 - `shellcheck` on `install.sh`, and a PowerShell parse plus a gating
-  PSScriptAnalyzer run on `install.ps1`, without executing either — running them
+  PSScriptAnalyzer run on `install.ps1`, without executing either - running them
   would test the release rather than the script;
 - the example blueprint checks, including `rwr validate` over every example tree;
 - `gosec` and `govulncheck`.
@@ -149,7 +149,7 @@ and macOS.
   `continue-on-error`: much of the suite assumes POSIX behaviour (unix file modes,
   `/bin/bash`, path separators), and gating on it immediately would fail master for
   reasons unrelated to the change under review. The failures need triaging at their
-  source before the escape hatch comes off — until then the platforms RWR
+  source before the escape hatch comes off - until then the platforms RWR
   provisions are built but not really tested.
 - **Neither installer can pass an init file through to a first run.** See the
   initialization specification.

--- a/openspec/specs/initialization/spec.md
+++ b/openspec/specs/initialization/spec.md
@@ -16,8 +16,8 @@ RWR SHALL accept an init file given as:
   `init.json`, then `init.toml` inside it
 - an `https://` URL to a raw file
 - a GitHub blob URL, which RWR SHALL rewrite to its raw form
-- a GitHub shorthand — `owner/repo`, `owner/repo@ref`, or
-  `owner/repo/path/to/file` with an optional `@ref` — resolved against
+- a GitHub shorthand - `owner/repo`, `owner/repo@ref`, or
+  `owner/repo/path/to/file` with an optional `@ref` - resolved against
   `raw.githubusercontent.com`; a bare `owner/repo` probes the repository root
   for the init file names, and `@ref` defaults to the default branch
 
@@ -74,14 +74,14 @@ same `User`, `System`, `Flags`, and `UserDefined` variables available to bluepri
 RWR SHALL decode the init file's `variables.userDefined` block and SHALL make its
 keys available to every blueprint template as `{{ .UserDefined.<key> }}`.
 
-The runtime halves of the variable set — `Flags`, `User`, `System` — are computed
+The runtime halves of the variable set - `Flags`, `User`, `System` - are computed
 rather than declared and SHALL NOT be decodable from the init file, so a blueprint
 cannot claim to be running as a different user or with different flags than it is.
 Filling them in SHALL preserve the declared `userDefined` entries rather than
 replacing the whole structure.
 
 Previously the block decoded into nothing and was then overwritten, so every
-`{{ .UserDefined.x }}` in a tree rendered empty — and because rendering is strict,
+`{{ .UserDefined.x }}` in a tree rendered empty - and because rendering is strict,
 the run stopped on a variable the operator had in fact declared.
 
 `RWR_`-prefixed environment variables SHALL be merged into the same namespace with
@@ -117,10 +117,10 @@ blueprint silently unprocessed, which is not a state anybody wants a machine in.
 
 RWR SHALL resolve the blueprint location as follows:
 
-- empty or `.` — the directory containing the init file
-- beginning with `~` — relative to the user's home directory
-- a relative path — relative to the directory containing the init file
-- an absolute path — used as given
+- empty or `.` - the directory containing the init file
+- beginning with `~` - relative to the user's home directory
+- a relative path - relative to the directory containing the init file
+- an absolute path - used as given
 
 #### Scenario: A relative location
 
@@ -160,7 +160,7 @@ belongs to.
 
 Configuration keys are nested (`log.level`), and a dot is not legal in an
 environment variable name, so RWR SHALL translate dots to underscores when reading
-the environment — `RWR_LOG_LEVEL` sets `log.level`.
+the environment - `RWR_LOG_LEVEL` sets `log.level`.
 
 RWR SHALL create its config directory and its run-once state directory at startup,
 at owner-only permissions.
@@ -199,7 +199,7 @@ Under strict decode, an init file carrying any of these keys SHALL fail with
 an error naming the key and pointing at blueprint files.
 
 Why: these sections were decoded, validated, and profile-counted but never
-applied at runtime — a declaration that silently did nothing. Blueprints are
+applied at runtime - a declaration that silently did nothing. Blueprints are
 the single declaration path.
 
 Migration: move the entries into blueprint files under the tree; `rwr convert
@@ -214,7 +214,7 @@ Migration: move the entries into blueprint files under the tree; `rwr convert
 ### Requirement: A repo-root manifest declares multiple configurations
 
 The system SHALL read a root `manifest.*` when the init location (local dir
-or cloned git repo) contains no init file — the manifest is a list of
+or cloned git repo) contains no init file - the manifest is a list of
 named configurations, each with an `init` path relative to the repo root and
 optional matchers `os`, `distro`, `family`, `arch`, plus optional `default`.
 The manifest SHALL decode strictly through the format registry.

--- a/openspec/specs/provider-detection/spec.md
+++ b/openspec/specs/provider-detection/spec.md
@@ -5,7 +5,7 @@
 A provider is a declarative description of a package manager: the binary that
 identifies it, the files that prove it is in use, the distributions it belongs to,
 and the command templates for install, remove, update, list, search, and clean.
-Providers are what let RWR put "the annoying bits on rails" — a blueprint says
+Providers are what let RWR put "the annoying bits on rails" - a blueprint says
 `action: install`, and the provider decides what that means on this machine.
 
 This capability defines how providers are loaded, how RWR decides which ones are
@@ -35,7 +35,7 @@ RWR SHALL fail only when it has no providers at all.
 
 RWR SHALL search for a filesystem provider directory in the executable's own
 directory, `/usr/local/share/rwr/providers`, `/usr/share/rwr/providers`, and
-`~/.config/rwr/providers` — plus the Homebrew and app-bundle paths on macOS.
+`~/.config/rwr/providers` - plus the Homebrew and app-bundle paths on macOS.
 
 RWR SHALL NOT search the current working directory.
 
@@ -44,8 +44,8 @@ and which mode, and SHALL continue loading the rest of the directory.
 
 A provider file declares `exec`, `args` and `elevated = true`, and those are run
 verbatim. Honouring `./providers` handed root-level execution to any directory RWR
-happened to be run from — a cloned blueprint repo, `/tmp`, a shared downloads
-folder — and a definition anyone on the box can edit is a root shell for anyone on
+happened to be run from - a cloned blueprint repo, `/tmp`, a shared downloads
+folder - and a definition anyone on the box can edit is a root shell for anyone on
 the box. One bad file is skipped rather than failing the load, so it does not cost
 the operator every other provider in the directory.
 
@@ -72,7 +72,7 @@ When those hold and the provider's distribution list also names this distributio
 or its family, the provider SHALL be available.
 
 When those hold but the distribution is not named, RWR SHALL still treat the
-provider as available if it declares detection files — because a machine that has
+provider as available if it declares detection files - because a machine that has
 `pacman` on `PATH`, `/etc/pacman.conf`, and `/var/lib/pacman` is running `pacman`
 whatever `/etc/os-release` calls itself.
 
@@ -81,7 +81,7 @@ go on, and SHALL be unavailable on an unrecognised distribution.
 
 This exists because derivatives outnumber any list that can be maintained. It was
 found on PrismLinux, which reports `ID=prismlinux`, sets no `ID_LIKE`, and is named
-by no provider — yet is plainly an Arch system.
+by no provider - yet is plainly an Arch system.
 
 #### Scenario: An unrecognised Arch derivative
 
@@ -129,7 +129,7 @@ its resolved binary path and its command templates.
 
 RWR SHALL NOT re-filter that map by matching the provider's distribution list
 against a literal OS name. Doing so excluded every provider that names concrete
-distributions — `apt`, `dnf`, `pacman`, `zypper`, and the AUR helpers — leaving
+distributions - `apt`, `dnf`, `pacman`, `zypper`, and the AUR helpers - leaving
 cache cleaning and core-package resolution operating on a map that held only
 wildcard providers.
 
@@ -191,7 +191,7 @@ load; there SHALL be no second committed representation. The schema closes
 fails evaluation naming the field.
 
 Why: the export-and-commit pipeline made every provider change a
-multi-format edit — the disease the CUE migration existed to cure.
+multi-format edit - the disease the CUE migration existed to cure.
 
 #### Scenario: Provider missing a required field fails at load
 


### PR DESCRIPTION
1064 em dashes across 276 files replaced with plain punctuation. Docs, code comments, specs, and runtime strings. Full suite, lint, and openspec validation clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)