### PR TITLE
feat(providers): CUE filesystem overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Rinse, Wash, Repeat (RWR) is a powerful and flexible configuration management to
 - **Git Repository Management**: Clone and manage Git repositories
 - **Script Execution**: Execute scripts with multiple interpreter support
 - **SSH Key Management**: Generate and manage SSH keys with GitHub integration
-- **Extensible Architecture**: Package managers are declarative providers - authored in CUE and embedded in the binary, with filesystem overrides in TOML or JSON
+- **Extensible Architecture**: Package managers are declarative providers, authored in CUE and embedded in the binary; filesystem overrides in CUE, TOML, or JSON
 
 ## Table of Contents<!-- omit in toc -->
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -11,11 +11,11 @@ provider (wrong action name, missing `commands.install`, a `/tmp/` staging
 path) naming the field. There is no exported or committed second
 representation.
 
-You do **not** need CUE to override a provider. RWR also loads provider
-definitions from the filesystem, as either **TOML** (the historical
-`[provider]` layout) or **JSON** (one provider document, the same field
-names). A filesystem provider replaces an embedded provider of the same
-name.
+RWR loads provider overrides from the filesystem in three formats: **CUE**
+(one provider document, validated against the same schema the embedded
+definitions use), **JSON** (same shape), or **TOML** (the historical
+`[provider]` layout). A filesystem provider replaces an embedded provider
+of the same name.
 
 ### Search paths
 

--- a/internal/system/embedded.go
+++ b/internal/system/embedded.go
@@ -68,3 +68,35 @@ func LoadEmbeddedProviders() (map[string]*types.Provider, error) {
 	log.Debugf("LoadEmbeddedProviders: evaluated %d providers from embedded CUE", len(providers))
 	return providers, nil
 }
+
+// decodeCUEOverride evaluates one filesystem override written in CUE,
+// unified against the embedded #Provider schema so an override gets exactly
+// the validation a shipped definition gets.
+func decodeCUEOverride(data []byte, path string) (*types.Provider, error) {
+	schema, err := embeddedProviderCUE.ReadFile("definitions/schema.cue")
+	if err != nil {
+		return nil, err
+	}
+	ctx := cuecontext.New()
+	schemaValue := ctx.CompileBytes(schema, cue.Filename("schema.cue"))
+	if schemaValue.Err() != nil {
+		return nil, schemaValue.Err()
+	}
+	providerDef := schemaValue.LookupPath(cue.ParsePath("#Provider"))
+	if providerDef.Err() != nil {
+		return nil, providerDef.Err()
+	}
+	value := ctx.CompileBytes(data, cue.Filename(path), cue.Scope(schemaValue))
+	if value.Err() != nil {
+		return nil, fmt.Errorf("%s does not parse: %w", path, value.Err())
+	}
+	unified := providerDef.Unify(value)
+	if err := unified.Validate(cue.Concrete(true)); err != nil {
+		return nil, fmt.Errorf("%s fails the provider schema: %w", path, err)
+	}
+	var provider types.Provider
+	if err := unified.Decode(&provider); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return &provider, nil
+}

--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -362,7 +362,7 @@ func LoadProviders(definitionsPath string) error {
 	}
 
 	for _, entry := range entries {
-		if !entry.IsDir() && (filepath.Ext(entry.Name()) == ".toml" || filepath.Ext(entry.Name()) == ".json") {
+		if !entry.IsDir() && (filepath.Ext(entry.Name()) == ".toml" || filepath.Ext(entry.Name()) == ".json" || filepath.Ext(entry.Name()) == ".cue") {
 			path := filepath.Join(definitionsPath, entry.Name())
 			if !isProviderFileTrusted(path) {
 				continue
@@ -449,11 +449,18 @@ func LoadProviderDefinition(path string) (*types.Provider, error) {
 		return nil, err
 	}
 
-	// Overrides come in two shapes: the historical TOML with a [provider]
-	// section, and bare-provider JSON - the same document the embedded
-	// definitions use, so an exported provider can be dropped in verbatim.
+	// Overrides come in three shapes: the historical TOML with a [provider]
+	// section, bare-provider JSON, and CUE - one provider document, checked
+	// against the same schema the embedded definitions use.
 	var provider types.Provider
-	if filepath.Ext(path) == ".json" {
+	if filepath.Ext(path) == ".cue" {
+		decoded, cueErr := decodeCUEOverride(data, path)
+		if cueErr != nil {
+			log.Errorf("LoadProviderDefinition: Failed to decode CUE %s: %v", path, cueErr)
+			return nil, cueErr
+		}
+		provider = *decoded
+	} else if filepath.Ext(path) == ".json" {
 		dec := json.NewDecoder(bytes.NewReader(data))
 		dec.DisallowUnknownFields()
 		if err := dec.Decode(&provider); err != nil {

--- a/internal/system/providers_cue_override_test.go
+++ b/internal/system/providers_cue_override_test.go
@@ -1,0 +1,47 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A CUE override is one provider document validated against the embedded
+// schema: a good one loads, a bad field fails naming the problem.
+func TestLoadProviderDefinition_CUE(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "mypm.cue")
+	if err := os.WriteFile(good, []byte(`
+name: "mypm"
+elevated: false
+detection: {
+	binary: "mypm"
+	files: ["/usr/bin/mypm"]
+	distributions: []
+}
+commands: {
+	install: "install"
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	provider, err := LoadProviderDefinition(good)
+	if err != nil {
+		t.Fatalf("good CUE override rejected: %v", err)
+	}
+	if provider.Name != "mypm" || provider.Commands.Install != "install" {
+		t.Fatalf("decoded = %+v", provider)
+	}
+
+	bad := filepath.Join(dir, "bad.cue")
+	if err := os.WriteFile(bad, []byte(`
+name: "bad"
+detection: { binary: "bad", files: [], distributions: [] }
+commands: { instal: "typo" }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadProviderDefinition(bad); err == nil {
+		t.Fatal("schema-violating CUE override accepted")
+	}
+}


### PR DESCRIPTION
Providers are CUE, but overrides only took TOML or JSON. Now a `.cue` override is one provider document unified against the embedded #Provider schema: same validation as a shipped definition, bad fields fail naming the problem. Tested good and bad documents. Stacked on #245; retarget after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)