### PR TITLE
fix(cmd): bare rwr/rwr run must not initialize a blueprint tree

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,6 +91,17 @@ git checkouts, scripts, and desktop configuration.`,
 				current = current.Parent()
 			}
 
+			// `rwr run` with no processor, and bare `rwr` with no processor
+			// shorthand, only list processors / print help - they must not
+			// initialize a tree, resolve a manifest, or touch git. A named
+			// processor (`rwr run packages`, `rwr packages`, `rwr all`) still
+			// inits.
+			isBareRun := cmd.Name() == "run" && len(args) == 0
+			isBareRoot := cmd.Name() == "rwr" && !hasProcessorArg(args)
+			if isBareRun || isBareRoot {
+				return nil
+			}
+
 			checkForNewVersion(app)
 
 			return initializeSystemInfo(app, selectedProcessorsFor(cmd, args)...)
@@ -110,7 +121,9 @@ git checkouts, scripts, and desktop configuration.`,
 			}
 
 			fmt.Println("Welcome to rwr - The Distrohopper's Friend!")
-			log.Debugf("Variables: %+v", app.InitConfig.Variables)
+			if app.InitConfig != nil {
+				log.Debugf("Variables: %+v", app.InitConfig.Variables)
+			}
 			return cmd.Help()
 		},
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -123,6 +123,20 @@ func processorShorthand(name string) (runProcessorSpec, bool) {
 	return runProcessorSpec{}, false
 }
 
+// hasProcessorArg reports whether the root command's args begin with a
+// recognized processor shorthand or "all". It gates the "skip init for bare
+// `rwr`" check: `rwr packages` inits, `rwr` alone does not.
+func hasProcessorArg(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	if args[0] == "all" {
+		return true
+	}
+	_, ok := processorShorthand(args[0])
+	return ok
+}
+
 // runProcessorSpec maps each subcommand to the blueprint type it dispatches.
 type runProcessorSpec struct {
 	use       string

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -21,3 +21,27 @@ func TestBootstrapInProcessorTable(t *testing.T) {
 	}
 	t.Fatal("`rwr run bootstrap` subcommand missing")
 }
+
+// hasProcessorArg gates the "skip init for bare `rwr`" check in
+// PersistentPreRunE. A bare invocation must not initialize a tree; any
+// recognized processor shorthand - or "all" - must.
+func TestHasProcessorArg(t *testing.T) {
+	cases := []struct {
+		args []string
+		want bool
+	}{
+		{nil, false},
+		{[]string{}, false},
+		{[]string{"packages"}, true},
+		{[]string{"files"}, true},
+		{[]string{"bootstrap"}, true},
+		{[]string{"all"}, true},
+		{[]string{"nonexistent"}, false},
+		{[]string{"packages", "extra"}, true}, // first arg decides
+	}
+	for _, tc := range cases {
+		if got := hasProcessorArg(tc.args); got != tc.want {
+			t.Errorf("hasProcessorArg(%v) = %v, want %v", tc.args, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Bare `rwr run` (no processor) and bare `rwr` (no processor shorthand) only list processors / print help. They were running full system init in `PersistentPreRunE` before `RunE`'s `cmd.Help()` fired — resolving the manifest, calling `DetectOS`, and rewriting the git remote as a side effect of simply asking for help.

## Changes
- Skip init when the invoked command is bare: `run` with no args, or the root with no recognized processor argument. A named processor (`rwr run packages`, `rwr packages`, `rwr all`) still inits.
- Add `hasProcessorArg` helper to gate the root-skip check.
- Guard the root `RunE` debug log against a nil `InitConfig`, which the skip leaves uninitialized and which previously panicked.

## Verified
`rwr run` and bare `rwr` now print help with no INFO logs, no manifest resolution, no git remote rewrite. `rwr run packages` still inits normally. `go test ./cmd/...` passes (new `TestHasProcessorArg`).