### PR TITLE
fix(providers): AUR helpers must not run elevated

### DIFF
--- a/internal/system/definitions/aura.cue
+++ b/internal/system/definitions/aura.cue
@@ -3,7 +3,7 @@ package providers
 providers: "aura": #ArchAURHelper & {
 	#aur: "aura-bin"
 	#removePkg: "aura"
-	elevated: true
+	elevated: false
 	commands: {
  "install": "-A --noconfirm",
  "update": "-Au --noconfirm",

--- a/internal/system/definitions/pamac.cue
+++ b/internal/system/definitions/pamac.cue
@@ -2,7 +2,7 @@ package providers
 
 providers: "pamac": #ArchAURHelper & {
 	#aur: "pamac-aur"
-	elevated: true
+	elevated: false
 	commands: {
  "install": "build --no-confirm",
  "update": "upgrade -a --no-confirm",

--- a/internal/system/definitions/trizen.cue
+++ b/internal/system/definitions/trizen.cue
@@ -2,7 +2,7 @@ package providers
 
 providers: "trizen": #ArchAURHelper & {
 	#aur: "trizen"
-	elevated: true
+	elevated: false
 	commands: {
  "install": "-S --noconfirm --noedit",
  "update": "-Syua --noconfirm --noedit",

--- a/internal/system/definitions/yay.cue
+++ b/internal/system/definitions/yay.cue
@@ -2,7 +2,7 @@ package providers
 
 providers: "yay": #ArchAURHelper & {
 	#aur: "yay"
-	elevated: true
+	elevated: false
 	commands: {
  "install": "-S --noconfirm --needed",
  "update": "-Syu --noconfirm",


### PR DESCRIPTION
yay, aura, pamac, and trizen declared `elevated: true`, so rwr wrapped every command in `sudo -- <helper> ...`. Every AUR helper built on the `#ArchAURHelper` shape runs makepkg, which refuses to run as root — yay prints "Avoid running yay as root/sudo" and exits 1, so **every AUR package install failed**.

## Changes
Set `elevated: false` on `yay`, `aura`, `pamac`, `trizen` (paru already had it). These helpers invoke pacman through their own sudo internally when they need root, and must be launched as the unprivileged user.

## Verified
`rwr --dry-run packages` now resolves to `/usr/sbin/yay -S --noconfirm --needed <pkg>` with **no sudo prefix**. Before: `sudo -- yay ...` → exit 1.

Files: `internal/system/definitions/{yay,aura,pamac,trizen}.cue`