### PR TITLE
fix(manifest): recognize prismlinux as an Arch derivative

### DIFF
--- a/internal/helpers/manifest.go
+++ b/internal/helpers/manifest.go
@@ -86,7 +86,7 @@ func distroInFamily(distro, family string) bool {
 		return true
 	}
 	families := map[string][]string{
-		"arch":   {"arch", "manjaro", "endeavouros", "cachyos", "garuda", "archcraft"},
+		"arch":   {"arch", "manjaro", "endeavouros", "cachyos", "garuda", "archcraft", "prismlinux"},
 		"debian": {"debian", "ubuntu", "pop", "linuxmint", "elementary", "raspbian"},
 		"rhel":   {"rhel", "fedora", "centos", "rocky", "almalinux"},
 		"suse":   {"suse", "opensuse", "opensuse-leap", "opensuse-tumbleweed"},

--- a/internal/helpers/manifest_test.go
+++ b/internal/helpers/manifest_test.go
@@ -57,6 +57,11 @@ func TestMatchManifest(t *testing.T) {
 	if got := MatchManifest(manifest, sys("linux", "manjaro", "amd64")); len(got) != 2 {
 		t.Errorf("manjaro matches = %d (%v), want 2 (arch-desktop via family + any-linux)", len(got), got)
 	}
+	// prismlinux is an Arch derivative (pacman + makepkg); a family: arch
+	// matcher must catch it the same way manjaro is caught.
+	if got := MatchManifest(manifest, sys("linux", "prismlinux", "amd64")); len(got) != 2 {
+		t.Errorf("prismlinux matches = %d (%v), want 2 (arch-desktop via family + any-linux)", len(got), got)
+	}
 	if got := MatchManifest(manifest, sys("darwin", "", "arm64")); len(got) != 1 || got[0].Name != "mac" {
 		t.Errorf("darwin matches = %v, want [mac]", got)
 	}


### PR DESCRIPTION
PrismLinux reports `ID=prismlinux` in `/etc/os-release` with no `ID_LIKE`, so it was absent from `distroInFamily`'s arch list and could not match a `family: arch` manifest entry. A PrismLinux box hit `no manifest configuration matches this machine` despite being pacman-based.

## Changes
Add `prismlinux` to the arch family in `internal/helpers/manifest.go` alongside arch, manjaro, endeavourOS, cachyos, garuda, and archcraft.

## Verified
New `TestMatchManifest` case for prismlinux; `go test ./internal/helpers/...` passes. On the PrismLinux dev box, `rwr` now logs `Using manifest configuration "arch" (matched this machine)` (paired with a `family: arch` manifest entry in the blueprints repo).