### PR TITLE
fix(manifest): show selection TUI whenever --no-tui is absent

### DIFF
--- a/cmd/manifest_select.go
+++ b/cmd/manifest_select.go
@@ -52,28 +52,32 @@ func selectFromManifest(app *AppConfig, manifestPath string) (string, error) {
 	osInfo := system.DetectOS()
 	matched := helpers.MatchManifest(manifest, osInfo)
 
-	switch len(matched) {
-	case 0:
+	if len(matched) == 0 {
 		var lines []string
 		for _, entry := range manifest.Configurations {
 			lines = append(lines, fmt.Sprintf("  %s (os=%s distro=%s family=%s arch=%s)", entry.Name, entry.OS, entry.Distro, entry.Family, entry.Arch))
 		}
 		return "", fmt.Errorf("no manifest configuration matches this machine (%s/%s/%s); entries:\n%s\nselect one explicitly with --config-name",
 			osInfo.System.OS, osInfo.System.OSFamily, osInfo.System.OSArch, strings.Join(lines, "\n"))
-	case 1:
-		log.Infof("Using manifest configuration %q (matched this machine)", matched[0].Name)
-		return entryInit(matched[0]), nil
 	}
 
-	// Prefer a declared default among the matches before prompting.
-	for _, entry := range matched {
-		if entry.Default {
-			log.Infof("Using manifest configuration %q (default among %d matches)", entry.Name, len(matched))
-			return entryInit(entry), nil
-		}
-	}
-
+	// The selection frame is the default whenever a real terminal is present
+	// and --no-tui was not passed - even for a single match, so the operator
+	// always confirms which configuration rwr is about to apply. The headless
+	// path (no TTY, CI, or --no-tui) cannot prompt and falls back to a
+	// deterministic pick: a declared Default among the matches, then a single
+	// match, then an error listing the candidates.
 	if !tui.Active(app.NoTUI) {
+		for _, entry := range matched {
+			if entry.Default {
+				log.Infof("Using manifest configuration %q (default among %d matches, headless)", entry.Name, len(matched))
+				return entryInit(entry), nil
+			}
+		}
+		if len(matched) == 1 {
+			log.Infof("Using manifest configuration %q (matched this machine, headless)", matched[0].Name)
+			return entryInit(matched[0]), nil
+		}
 		return "", fmt.Errorf("%d manifest configurations match this machine (%s); scripts and CI must pick one with --config-name",
 			len(matched), entryNames(matched))
 	}

--- a/cmd/manifest_select_test.go
+++ b/cmd/manifest_select_test.go
@@ -47,3 +47,51 @@ func TestSelectFromManifest_HeadlessSelection(t *testing.T) {
 		t.Errorf("selected = %s, want Server/init.yaml under the repo root", selected)
 	}
 }
+
+// In headless mode a single match still resolves without prompting, so CI and
+// pipes keep working when only one configuration fits the machine.
+func TestSelectFromManifest_HeadlessSingleMatch(t *testing.T) {
+	dir := t.TempDir()
+	manifest := "configurations:\n" +
+		"  - name: only\n    init: Only/init.yaml\n    os: " + runtime.GOOS + "\n" +
+		"  - name: other\n    init: Other/init.yaml\n    os: never-matches\n"
+	manifestPath := filepath.Join(dir, "manifest.yaml")
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewAppConfig()
+	app.NoTUI = true // headless: single match should auto-select
+
+	selected, err := selectFromManifest(app, manifestPath)
+	if err != nil {
+		t.Fatalf("headless single match errored: %v", err)
+	}
+	if selected != filepath.Join(dir, "Only", "init.yaml") {
+		t.Errorf("selected = %s, want Only/init.yaml", selected)
+	}
+}
+
+// --no-tui with multiple matches and a declared default picks the default
+// without prompting - the headless fallback is deterministic, not arbitrary.
+func TestSelectFromManifest_HeadlessDefaultWins(t *testing.T) {
+	dir := t.TempDir()
+	manifest := "configurations:\n" +
+		"  - name: desktop\n    init: Desktop/init.yaml\n    os: " + runtime.GOOS + "\n" +
+		"  - name: server\n    init: Server/init.yaml\n    os: " + runtime.GOOS + "\n    default: true\n"
+	manifestPath := filepath.Join(dir, "manifest.yaml")
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewAppConfig()
+	app.NoTUI = true
+
+	selected, err := selectFromManifest(app, manifestPath)
+	if err != nil {
+		t.Fatalf("headless default selection errored: %v", err)
+	}
+	if selected != filepath.Join(dir, "Server", "init.yaml") {
+		t.Errorf("selected = %s, want the default Server/init.yaml", selected)
+	}
+}


### PR DESCRIPTION
The manifest selector auto-selected silently on a single match and only prompted when multiple entries matched. The selection frame is now the **default path whenever a real terminal is present and `--no-tui` was not passed** — even for a single match — so the operator always confirms which configuration rwr is about to apply to the machine.

## Behavior
- **`--config-name`**: always wins, no prompt (explicit choice)
- **Real TTY, no `--no-tui`**: selection frame shown, matched entries first, rest after — even for a single match
- **Headless fallback** (no TTY, `CI`, or `--no-tui`) — cannot prompt, stays deterministic:
  1. declared `Default` among matches wins
  2. single match auto-selects
  3. multiple matches → error listing candidates

## Rationale
The openspec text described single-match auto-select as intended. The operator rule is that the TUI is the default and `--no-tui` is the opt-out; behavior now matches the rule rather than the prose.

## Verified
Three `TestSelectFromManifest_*` cases cover headless multi-match (errors), headless single-match (auto-selects), and headless default-wins. `go test ./cmd/... ./internal/helpers/...` passes.