### PR TITLE
fix(tui): run the dashboard in the alternate screen buffer

### DIFF
--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -17,6 +17,12 @@ func (m *Model) View() tea.View {
 	// escape sequences; all-motion mouse mode is what delivers hover events.
 	view := tea.NewView(m.zones.Scan(m.render()))
 	view.MouseMode = tea.MouseModeAllMotion
+	// Run in the alternate screen buffer so each frame overwrites the last in
+	// place instead of stacking in the scrollback. Without this, child output
+	// (package installs) interleaves with the dashboard and mode-query
+	// responses (^[[?2026;2$y etc.) leak as literal text across the
+	// tea.ExecProcess handoff. bubbletea v2 exits the alt screen on quit.
+	view.AltScreen = true
 	return view
 }
 


### PR DESCRIPTION
## Problem
`View()` built the dashboard view without setting `AltScreen`, so bubbletea rendered every frame inline in the normal scrollback instead of the alternate screen. Observed symptoms (from `rwr run all` in a real terminal):

1. **Frames stack instead of overwriting.** Every redraw paints a new full dashboard box below the previous one, so the screen fills with successive `╭─...─╮` boxes.
2. **Child output interleaves with the dashboard.** Package-build output (yay/makepkg) runs between and through the frames.
3. **Terminal mode-query responses leak as literal text** — `^[[?2026;2$y` `^[[?2027;2$y` appear where the child takes over, because the kitty/bracketed-paste mode queries are left dangling across the `tea.ExecProcess` handoff.

## Root cause
In bubbletea **v2** the alternate screen is a property of the `tea.View` (`view.AltScreen bool`, tea.go:161), not a program option or a command like v1. The renderer (`cursed_renderer.go:320`) only enters/exits alt-screen mode when `view.AltScreen` flips. `View()` never set it.

## Fix
Set `view.AltScreen = true` in `View()` (`internal/tui/views.go`). The renderer enters the alt screen on the first render and exits it automatically when the program quits, so:
- frames overwrite in place (clean single-screen dashboard)
- child output from `tea.ExecProcess` is isolated
- the scrollback is restored on exit

Usage matches bubbletea's own documented example (tea.go:155-159).

## Verified
`go build`, `go vet ./internal/tui/`, `go test ./internal/tui/...` all pass. (Full interactive verification needs a real TTY; the API usage is exactly per the bubbletea v2 example.)

Closes #252.