### PR TITLE
Field-hardening from a full fresh-macOS bring-up

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -39,7 +39,7 @@ routed interactively into the tree (--into). Diff never touches the system.`,
 			if err != nil {
 				return err
 			}
-			processors.ResolveStage2(plan)
+			processors.ResolveStage2(plan, app.OSInfo)
 			applies, err := state.Applies(viper.GetString("rwr.configdir"))
 			if err != nil {
 				return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -290,6 +290,13 @@ func initializeSystemInfo(app *AppConfig, selectedProcessors ...string) error {
 	}
 
 	app.OSInfo = system.DetectOS()
+
+	// The detected system feeds the blueprint template variables. They were
+	// never wired: every `{{ .System.osArch }}` in a blueprint rendered
+	// against empty strings, so arch-conditional templates always took their
+	// else branch - a users blueprint chose the Intel homebrew path for the
+	// login shell on an Apple Silicon machine and broke every new terminal.
+	app.InitConfig.Variables.System = app.OSInfo.System
 	return nil
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -25,7 +25,7 @@ mutates and never elevates. Exits 1 on drift.`,
 			if err != nil {
 				return err
 			}
-			processors.ResolveStage2(plan)
+			processors.ResolveStage2(plan, app.OSInfo)
 			applies, err := state.Applies(viper.GetString("rwr.configdir"))
 			if err != nil {
 				return err

--- a/cmd/tui_run.go
+++ b/cmd/tui_run.go
@@ -61,7 +61,7 @@ func runWithTUI(app *AppConfig, order []string) error {
 	if err != nil {
 		return err
 	}
-	processors.ResolveStage2(plan)
+	processors.ResolveStage2(plan, app.OSInfo)
 	if order == nil {
 		order = plan.Order
 	} else {
@@ -77,6 +77,12 @@ func runWithTUI(app *AppConfig, order []string) error {
 
 	restore := reporting.Set(tui.NewReporter(program))
 	defer restore()
+
+	// Closed the moment the program exits: blocking events emitted in the
+	// window before the reporter swap select on this and fall back to their
+	// headless behavior instead of waiting forever on a dropped Send.
+	lost := make(chan struct{})
+	defer reporting.SetTerminalLost(lost)()
 
 	runErr := make(chan error, 1)
 	go func() {
@@ -97,11 +103,16 @@ func runWithTUI(app *AppConfig, order []string) error {
 	// The dashboard is gone; if the run is still going (the program exited
 	// early - a stray quit, a crash), events must not vanish into a dead
 	// program: halts would deadlock and prompts would freeze. Restore the
-	// LogReporter NOW, not at function return, so the rest of the run streams
-	// headless and finishes.
+	// FULL headless state NOW, not at function return: reporter, formatter,
+	// output, level, command sink - leaving the sink installed routed later
+	// command output into a store nobody renders, and the "(stderr in the
+	// log above)" error branch pointed at a log nobody can see.
+	close(lost)
 	restore()
 	log.SetFormatter(log.TextFormatter)
 	log.SetOutput(os.Stderr)
+	log.SetLevel(prevLevel)
+	reporting.SetCommandSink(nil)
 	if programErr != nil {
 		return fmt.Errorf("dashboard error: %w", programErr)
 	}

--- a/cmd/tui_run.go
+++ b/cmd/tui_run.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"time"
 
@@ -12,23 +11,13 @@ import (
 	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/tui"
+	"github.com/fynxlabs/rwr/internal/types"
 	"github.com/spf13/viper"
 )
 
 // runWithTUI executes the whole-tree run under the dashboard. The run itself
 // is unchanged - All() emits events; the TUI is one consumer of them.
 func runWithTUI(app *AppConfig, order []string) error {
-	plan, err := processors.ResolveStage1(app.InitConfig)
-	if err != nil {
-		return err
-	}
-	processors.ResolveStage2(plan)
-	if order == nil {
-		order = plan.Order
-	} else {
-		plan.Order = order
-	}
-
 	store := reporting.NewStore(app.TUIBuffer)
 	runLogPath := app.LogFile
 	if runLogPath == "" {
@@ -47,6 +36,38 @@ func runWithTUI(app *AppConfig, order []string) error {
 		}
 	}
 
+	// Capture starts BEFORE the resolve stages: everything a TUI run logs
+	// belongs in the store and the run log, not splattered onto the terminal
+	// above the dashboard. The terminal itself belongs to the TUI.
+	//
+	// JSON formatter, per the design: the viewport renders from LogRecord
+	// fields (time, level glyph, provider, message; caller at debug only),
+	// never from the text formatter's output - `<file:line>` and `rwr: :`
+	// must not reach the screen. Capture level is debug so the display can
+	// filter without losing anything; the run log keeps full fidelity.
+	prevLevel := log.GetLevel()
+	log.SetFormatter(log.JSONFormatter)
+	log.SetOutput(&reporting.JSONCaptureWriter{Store: store})
+	log.SetLevel(log.DebugLevel)
+	reporting.SetCommandSink(store)
+	defer func() {
+		reporting.SetCommandSink(nil)
+		log.SetFormatter(log.TextFormatter)
+		log.SetOutput(os.Stderr)
+		log.SetLevel(prevLevel)
+	}()
+
+	plan, err := processors.ResolveStage1(app.InitConfig)
+	if err != nil {
+		return err
+	}
+	processors.ResolveStage2(plan)
+	if order == nil {
+		order = plan.Order
+	} else {
+		plan.Order = order
+	}
+
 	theme, unknownTheme := tui.ResolveTheme(app.ConfigLocation, app.Theme, viper.GetString("rwr.theme"), app.ASCII, app.Unicode)
 	if unknownTheme != "" {
 		log.Warnf("Unknown theme %q (no built-in and no %s/themes/%s.toml); using %q", unknownTheme, app.ConfigLocation, unknownTheme, theme.Name)
@@ -54,24 +75,35 @@ func runWithTUI(app *AppConfig, order []string) error {
 	model := tui.New(theme, plan, store, system.IsDryRun(), runLogPath)
 	program := tea.NewProgram(model)
 
-	// Every log line the processors write is captured into the store,
-	// attributed by the current-processor stamp; the terminal itself belongs
-	// to the TUI while it runs.
-	log.SetOutput(io.MultiWriter(&reporting.LineWriter{Store: store, Src: reporting.SrcLog}))
-	defer log.SetOutput(os.Stderr)
-
 	restore := reporting.Set(tui.NewReporter(program))
 	defer restore()
 
 	runErr := make(chan error, 1)
 	go func() {
 		err := runEverythingHeadless(app, order)
-		reporting.Emit(reporting.RunFinished{Errs: nil})
+		// The run's own error has to reach the summary: All() only emits
+		// RunFinished when it gets to the end, so a run that dies early
+		// (package managers, bootstrap, an interactive-halt processor error)
+		// otherwise rendered "no failures" over a run that failed.
+		var errs []types.StepError
+		if err != nil {
+			errs = []types.StepError{{Processor: "run", Err: err}}
+		}
+		reporting.Emit(reporting.RunFinished{Errs: errs})
 		runErr <- err
 	}()
 
-	if _, err := program.Run(); err != nil {
-		return fmt.Errorf("dashboard error: %w", err)
+	_, programErr := program.Run()
+	// The dashboard is gone; if the run is still going (the program exited
+	// early - a stray quit, a crash), events must not vanish into a dead
+	// program: halts would deadlock and prompts would freeze. Restore the
+	// LogReporter NOW, not at function return, so the rest of the run streams
+	// headless and finishes.
+	restore()
+	log.SetFormatter(log.TextFormatter)
+	log.SetOutput(os.Stderr)
+	if programErr != nil {
+		return fmt.Errorf("dashboard error: %w", programErr)
 	}
 	if runLogPath != "" {
 		fmt.Fprintf(os.Stderr, "run log: %s\n", runLogPath)

--- a/internal/credentials/prompt.go
+++ b/internal/credentials/prompt.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/huh/v2"
 	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/reporting"
 	"golang.org/x/term"
 )
 
@@ -35,7 +36,7 @@ var promptForCredential = func(name, description string) (string, error) {
 				}),
 		),
 	)
-	if err := form.Run(); err != nil {
+	if err := reporting.WithTerminal(form.Run); err != nil {
 		return "", fmt.Errorf("prompt for credential %q failed: %w", name, err)
 	}
 	return value, nil
@@ -57,7 +58,7 @@ var offerKeyringSave = func(name, value string) {
 				Value(&confirm),
 		),
 	)
-	if err := form.Run(); err != nil || !confirm {
+	if err := reporting.WithTerminal(form.Run); err != nil || !confirm {
 		return
 	}
 	if err := SaveToKeyring(name, value); err != nil {

--- a/internal/helpers/resolve_imports.go
+++ b/internal/helpers/resolve_imports.go
@@ -4,9 +4,42 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/types"
 )
+
+// importVariables are the template variables imported blueprint files resolve
+// against. The run entry points set them once (the executor seam pattern);
+// without this, an imported file's `{{ .User.home }}` stayed literal - the
+// top-level file went through ResolveTemplate in the run loop, but imports
+// were read and decoded raw, and rwr created a directory literally named
+// "{{ .User.home }}" in the working directory.
+var (
+	importVarsMu    sync.RWMutex
+	importVariables *types.Variables
+)
+
+// SetTemplateVariables installs the variables imports resolve against
+// (nil clears). Returns a restore func for tests.
+func SetTemplateVariables(vars *types.Variables) (restore func()) {
+	importVarsMu.Lock()
+	previous := importVariables
+	importVariables = vars
+	importVarsMu.Unlock()
+	return func() {
+		importVarsMu.Lock()
+		importVariables = previous
+		importVarsMu.Unlock()
+	}
+}
+
+func templateVariables() *types.Variables {
+	importVarsMu.RLock()
+	defer importVarsMu.RUnlock()
+	return importVariables
+}
 
 // ResolveImports expands `import:` entries into the items they name, following
 // imports that the imported files declare in turn.
@@ -63,6 +96,17 @@ func resolveImports[T any](
 		data, err := os.ReadFile(fullPath) // #nosec G304 -- path is inside the operator's own blueprint tree; containment added in PR8
 		if err != nil {
 			return nil, fmt.Errorf("error reading import file %s: %w", fullPath, err)
+		}
+
+		// Imported files get the same template resolution the importing file
+		// got in the run loop - `{{ .User.home }}` in an imported blueprint
+		// must not survive to execution as a literal path.
+		if vars := templateVariables(); vars != nil {
+			resolved, resolveErr := ResolveTemplate(data, *vars)
+			if resolveErr != nil {
+				return nil, fmt.Errorf("error resolving variables in import %s: %w", fullPath, resolveErr)
+			}
+			data = resolved
 		}
 
 		// The imported file's own extension decides its format; the importing

--- a/internal/helpers/resolve_imports_test.go
+++ b/internal/helpers/resolve_imports_test.go
@@ -1,0 +1,51 @@
+package helpers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// Imported blueprint files resolve templates against the run's variables:
+// without this, `{{ .User.home }}` in an imported file survived to execution
+// as a literal path and rwr created a directory named "{{ .User.home }}".
+func TestResolveImports_ResolvesTemplatesInImports(t *testing.T) {
+	dir := t.TempDir()
+	imported := filepath.Join(dir, "shared.yaml")
+	if err := os.WriteFile(imported, []byte("git:\n  - name: rwr\n    path: \"{{ .User.home }}/git/rwr\"\n    action: clone\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	vars := types.Variables{}
+	vars.User.Home = "/home/test"
+	defer SetTemplateVariables(&vars)()
+
+	type entry struct {
+		Name   string `yaml:"name"`
+		Path   string `yaml:"path"`
+		Import string `yaml:"import"`
+	}
+	items := []entry{{Import: "shared.yaml"}}
+	resolved, err := ResolveImports(items, dir,
+		func(e entry) string { return e.Import },
+		func(data []byte, format string) ([]entry, error) {
+			var d struct {
+				Git []entry `yaml:"git"`
+			}
+			if err := UnmarshalBlueprint(data, format, &d); err != nil {
+				return nil, err
+			}
+			return d.Git, nil
+		}, "yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resolved) != 1 {
+		t.Fatalf("got %d items, want 1", len(resolved))
+	}
+	if resolved[0].Path != "/home/test/git/rwr" {
+		t.Fatalf("imported path not template-resolved: %q", resolved[0].Path)
+	}
+}

--- a/internal/processors/all.go
+++ b/internal/processors/all.go
@@ -158,6 +158,14 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 			reporting.SetCurrentProcessor(processor)
 			reporting.Emit(reporting.ProcStarted{Processor: processor, Files: len(files)})
 			var procErr error
+			// Every abort between ProcStarted and the loop's end must emit
+			// the matching ProcFinished, or the display counts this
+			// processor as running forever - spinner, clock, taskbar
+			// progress all wrong on the final frame.
+			fatal := func(ferr error) error {
+				reporting.Emit(reporting.ProcFinished{Processor: processor, Err: ferr, Dur: time.Since(procStarted)})
+				return ferr
+			}
 			for _, file := range files {
 				blueprintFile := filepath.Join(initConfig.Init.Location, file)
 				log.Debugf("Processing blueprint file: %s", blueprintFile)
@@ -173,17 +181,17 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 				// outright on an extensionless file.
 				format, err := helpers.FormatForPath(blueprintFile)
 				if err != nil {
-					return err
+					return fatal(err)
 				}
 
 				blueprintData, err := os.ReadFile(blueprintFile) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
 				if err != nil {
-					return fmt.Errorf("error reading blueprint file %s: %w", blueprintFile, err)
+					return fatal(fmt.Errorf("error reading blueprint file %s: %w", blueprintFile, err))
 				}
 
 				resolvedBlueprint, err := helpers.ResolveTemplate(blueprintData, initConfig.Variables)
 				if err != nil {
-					return fmt.Errorf("error resolving variables in %s: %w", processor, err)
+					return fatal(fmt.Errorf("error resolving variables in %s: %w", processor, err))
 				}
 
 				// A multi-type file (content-routed into several buckets) is cut
@@ -191,7 +199,7 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 				// through untouched and keep strict decode's typo protection.
 				resolvedBlueprint, format, err = subsetForProcessor(resolvedBlueprint, format, processor)
 				if err != nil {
-					return fmt.Errorf("error preparing %s for the %s processor: %w", blueprintFile, processor, err)
+					return fatal(fmt.Errorf("error preparing %s for the %s processor: %w", blueprintFile, processor, err))
 				}
 
 				dispatch := func() error {
@@ -252,8 +260,7 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 						}
 						stepErrs = append(stepErrs, types.StepError{Processor: processor, Err: err})
 					default: // abort
-						reporting.Emit(reporting.ProcFinished{Processor: processor, Err: err, Dur: time.Since(procStarted)})
-						return fmt.Errorf("error processing %s: %w", processor, err)
+						return fatal(fmt.Errorf("error processing %s: %w", processor, err))
 					}
 					break
 				}

--- a/internal/processors/all.go
+++ b/internal/processors/all.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/helpers"
@@ -41,6 +42,10 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 	openJournal(initConfig.Init.Location)
 	defer closeJournal()
 
+	// Imported blueprint files resolve templates against the same variables
+	// as the files that import them (see helpers.SetTemplateVariables).
+	defer helpers.SetTemplateVariables(&initConfig.Variables)()
+
 	log.Debugf("ForceBootstrap: %v", initConfig.Variables.Flags.ForceBootstrap)
 
 	if system.IsDryRun() {
@@ -55,8 +60,12 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 		return fmt.Errorf("error initializing blueprints: %w", err)
 	}
 
-	// Check if macOS and no package manager is installed
-	if osInfo.System.OS == types.OSDarwin {
+	// Check if macOS and no package manager is installed. A tree that declares
+	// packageManagers in its init file has already said what to install - the
+	// ProcessPackageManagers call below handles those (installing any that are
+	// missing), so the ask-and-install fallback is only for trees that declare
+	// nothing.
+	if osInfo.System.OS == types.OSDarwin && len(initConfig.PackageManagers) == 0 {
 		// Check if any package manager is installed
 		hasPackageManager := false
 		for _, pm := range osInfo.PackageManager.Managers {
@@ -69,6 +78,9 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 		if !hasPackageManager {
 			log.Info("No package manager detected on macOS. Installing one is required to proceed.")
 
+			// PromptUserChoice runs under the terminal lease, so it is safe
+			// both headless and under the TUI (the dashboard suspends around
+			// it instead of deadlocking the stdin read).
 			var chosenPM string
 			if initConfig.Variables.Flags.Interactive {
 				chosenPM = system.PromptUserChoice("Choose a package manager to install", []string{"brew", "nix"}, "brew")
@@ -138,6 +150,14 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 	// Process each blueprint in order
 	for _, processor := range blueprintRunOrder {
 		if files, ok := fileOrder[processor]; ok {
+			// One ProcStarted per processor, one ProcFinished when its files
+			// are done. Started used to fire once per FILE, and Finished was
+			// never emitted at all - so the dashboard showed every processor
+			// that had ever started as still running, forever.
+			procStarted := time.Now()
+			reporting.SetCurrentProcessor(processor)
+			reporting.Emit(reporting.ProcStarted{Processor: processor, Files: len(files)})
+			var procErr error
 			for _, file := range files {
 				blueprintFile := filepath.Join(initConfig.Init.Location, file)
 				log.Debugf("Processing blueprint file: %s", blueprintFile)
@@ -174,50 +194,71 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 					return fmt.Errorf("error preparing %s for the %s processor: %w", blueprintFile, processor, err)
 				}
 
-				// One event instead of ten near-identical log lines; the
-				// LogReporter renders exactly what those lines printed. The
-				// processor stamp is what attributes every captured log line
-				// without touching the ten processor files.
-				reporting.SetCurrentProcessor(processor)
-				reporting.Emit(reporting.ProcStarted{Processor: processor, Files: len(files)})
-
-				switch processor {
-				case types.BlueprintTypeRepositories:
-					err = ProcessRepositories(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
-				case types.BlueprintTypePackages:
-					err = ProcessPackages(resolvedBlueprint, nil, blueprintDir, format, osInfo, initConfig)
-				case types.BlueprintTypeFiles:
-					err = ProcessFiles(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
-				case types.BlueprintTypeServices:
-					err = ProcessServices(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
-				case types.BlueprintTypeUsers:
-					err = ProcessUsers(resolvedBlueprint, blueprintDir, format, initConfig)
-				case types.BlueprintTypeGit:
-					err = ProcessGitRepositories(resolvedBlueprint, blueprintDir, format, initConfig)
-				case types.BlueprintTypeScripts:
-					err = ProcessScripts(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
-				case types.BlueprintTypeSSHKeys:
-					err = ProcessSSHKeys(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
-				case types.BlueprintTypeFonts:
-					err = ProcessFonts(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
-				case types.BlueprintTypeConfiguration:
-					err = ProcessConfiguration(resolvedBlueprint, blueprintDir, format, initConfig)
-				default:
-					reporting.Emit(reporting.ProcSkipped{Processor: processor, Reason: "unknown processor"})
-					continue
+				dispatch := func() error {
+					switch processor {
+					case types.BlueprintTypeRepositories:
+						return ProcessRepositories(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
+					case types.BlueprintTypePackages:
+						return ProcessPackages(resolvedBlueprint, nil, blueprintDir, format, osInfo, initConfig)
+					case types.BlueprintTypeFiles:
+						return ProcessFiles(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
+					case types.BlueprintTypeServices:
+						return ProcessServices(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
+					case types.BlueprintTypeUsers:
+						return ProcessUsers(resolvedBlueprint, blueprintDir, format, initConfig)
+					case types.BlueprintTypeGit:
+						return ProcessGitRepositories(resolvedBlueprint, blueprintDir, format, initConfig)
+					case types.BlueprintTypeScripts:
+						return ProcessScripts(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
+					case types.BlueprintTypeSSHKeys:
+						return ProcessSSHKeys(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
+					case types.BlueprintTypeFonts:
+						return ProcessFonts(resolvedBlueprint, blueprintDir, format, osInfo, initConfig)
+					case types.BlueprintTypeConfiguration:
+						return ProcessConfiguration(resolvedBlueprint, blueprintDir, format, initConfig)
+					default:
+						reporting.Emit(reporting.ProcSkipped{Processor: processor, Reason: "unknown processor"})
+						return nil
+					}
 				}
 
-				if err != nil {
-					// Interactive runs halt so the operator can react; a
-					// headless run pushes through, collects, and exits
-					// nonzero - the first error aborting used to leave every
-					// later processor silently unrun in CI.
-					if initConfig.Variables.Flags.Interactive {
+				for {
+					err = dispatch()
+					if err == nil {
+						break
+					}
+					if !initConfig.Variables.Flags.Interactive {
+						// Headless pushes through, collects, and exits
+						// nonzero - the first error aborting used to leave
+						// every later processor silently unrun in CI.
+						if procErr == nil {
+							procErr = err
+						}
+						stepErrs = append(stepErrs, types.StepError{Processor: processor, Err: err})
+						break
+					}
+					// Interactive halts and asks: retry re-runs this file
+					// (providers are idempotent, so completed items skip fast
+					// and only the failures re-attempt), skip records the
+					// error and moves on, abort ends the run.
+					switch reporting.RequestHalt(processor, err) {
+					case reporting.HaltRetry:
+						log.Warnf("Retrying %s after error: %v", processor, err)
+						continue
+					case reporting.HaltSkip:
+						log.Warnf("Skipping past %s error: %v", processor, err)
+						if procErr == nil {
+							procErr = err
+						}
+						stepErrs = append(stepErrs, types.StepError{Processor: processor, Err: err})
+					default: // abort
+						reporting.Emit(reporting.ProcFinished{Processor: processor, Err: err, Dur: time.Since(procStarted)})
 						return fmt.Errorf("error processing %s: %w", processor, err)
 					}
-					stepErrs = append(stepErrs, types.StepError{Processor: processor, Err: err})
+					break
 				}
 			}
+			reporting.Emit(reporting.ProcFinished{Processor: processor, Err: procErr, Dur: time.Since(procStarted)})
 		}
 	}
 

--- a/internal/processors/bootstrap.go
+++ b/internal/processors/bootstrap.go
@@ -30,6 +30,10 @@ func RunBootstrap(initConfig *types.InitConfig, osInfo *types.OSInfo) error {
 	initConfig.Variables.Flags.ForceBootstrap = true
 	defer func() { initConfig.Variables.Flags.ForceBootstrap = previous }()
 
+	// The standalone entry sets the import-template seam itself; the All()
+	// path has already set it by the time bootstrap runs.
+	defer helpers.SetTemplateVariables(&initConfig.Variables)()
+
 	return ProcessBootstrap(bootstrapFile, initConfig, osInfo)
 }
 
@@ -43,6 +47,12 @@ func ProcessBootstrap(blueprintFile string, initConfig *types.InitConfig, osInfo
 	}
 
 	log.Info("Starting bootstrap processor...")
+
+	// The run-once marker is only earned by a bootstrap where every step
+	// succeeded. Steps that record-and-continue (an SSH key whose GitHub
+	// upload fails) used to be papered over: the marker was written anyway,
+	// every later run skipped bootstrap, and the failed step never retried.
+	failuresBefore := failureCount()
 
 	var bootstrapData types.BootstrapData
 	var blueprintData []byte
@@ -155,7 +165,13 @@ func ProcessBootstrap(blueprintFile string, initConfig *types.InitConfig, osInfo
 		return err
 	}
 
-	// Set the bootstrap file
+	// Set the bootstrap file - only when every step succeeded. A bootstrap
+	// with recorded failures stays unmarked so the next run retries it
+	// (completed steps are idempotent and skip fast).
+	if failed := failureCount() - failuresBefore; failed > 0 {
+		log.Warnf("Bootstrap finished with %d failed step(s); NOT writing the run-once marker - the next run will retry bootstrap", failed)
+		return nil
+	}
 	log.Debugf("Setting bootstrap fileProcessDirectories")
 	if err := writeBootstrapMarker(); err != nil {
 		log.Errorf("Error setting bootstrap file: %v", err)

--- a/internal/processors/bootstrap.go
+++ b/internal/processors/bootstrap.go
@@ -34,7 +34,19 @@ func RunBootstrap(initConfig *types.InitConfig, osInfo *types.OSInfo) error {
 	// path has already set it by the time bootstrap runs.
 	defer helpers.SetTemplateVariables(&initConfig.Variables)()
 
-	return ProcessBootstrap(bootstrapFile, initConfig, osInfo)
+	// The standalone entry owns its exit code: recorded step failures
+	// (record-and-continue paths like a failed SSH-key upload) must reach
+	// it, or `rwr bootstrap` exits 0 for a bootstrap the code itself
+	// considered failed and refused to mark. All() keeps its own ledger
+	// check at run end, so this stays out of ProcessBootstrap.
+	failuresBefore := failureCount()
+	if err := ProcessBootstrap(bootstrapFile, initConfig, osInfo); err != nil {
+		return err
+	}
+	if failed := failureCount() - failuresBefore; failed > 0 {
+		return fmt.Errorf("bootstrap finished with %d failed step(s)", failed)
+	}
+	return nil
 }
 
 // ProcessBootstrap runs one-time system bootstrap operations including packages,

--- a/internal/processors/packageManager.go
+++ b/internal/processors/packageManager.go
@@ -108,11 +108,23 @@ func ProcessPackageManagers(packageManagers []types.PackageManagerInfo, osInfo *
 
 			switch step.Action {
 			case "command":
+				// Resolve through FindTool, not the raw process PATH: an
+				// install sequence runs the binary it just installed (rustup
+				// puts cargo in ~/.cargo/bin, brew lands in /opt/homebrew/bin)
+				// and none of those are on the PATH rwr started with.
+				execPath := step.Exec
+				if tool := system.FindTool(step.Exec); tool.Exists {
+					execPath = tool.Bin
+				}
 				cmd = types.Command{
-					Exec:     step.Exec,
+					Exec:     execPath,
 					Args:     step.Args,
 					Elevated: provider.Elevated,
 					AsUser:   pm.AsUser,
+					// The provider's environment applies to its own install
+					// steps too: brew's NONINTERACTIVE is what keeps the
+					// official install.sh from stopping at "Press RETURN".
+					Variables: provider.Environment,
 				}
 			case "download":
 				if system.IsDryRun() {
@@ -140,6 +152,10 @@ func ProcessPackageManagers(packageManagers []types.PackageManagerInfo, osInfo *
 			}
 
 			if err := system.RunCommand(cmd, initConfig.Variables.Flags.Debug); err != nil {
+				if step.Optional {
+					log.Warnf("Optional %s step for %s failed (ignored): %v", pm.Action, pm.Name, err)
+					continue
+				}
 				return fmt.Errorf("error executing package manager step: %w", err)
 			}
 		}

--- a/internal/processors/packages.go
+++ b/internal/processors/packages.go
@@ -176,22 +176,22 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 			}
 
 			// Execute command directly with environment variables
-			elevated := provider.Elevated || pkg.Elevated
 			cmd := types.Command{
 				Exec: provider.BinPath,
 				Args: args,
 				// The provider decides whether its package manager needs elevation;
 				// a blueprint may ask for it on top (a user-scoped manager invoked
 				// against a system path), but may not take it away.
-				Elevated:  elevated,
+				Elevated:  provider.Elevated || pkg.Elevated,
 				Variables: provider.Environment,
-				// Terminal handover only when this command can actually need
-				// one: an explicit per-item `interactive: true`, or sudo that
-				// may prompt for a password. Routing EVERY package through the
-				// terminal (the old behavior under the default interactive
-				// run) suspended the TUI per package and splattered raw
-				// package-manager output across the dashboard.
-				Interactive: helpers.ResolveInteractive(pkg.Interactive, initConfig.Variables.Flags.Interactive && elevated),
+				// Terminal handover only on an explicit per-item
+				// `interactive: true`. Routing every package through the
+				// terminal suspended the TUI per package and splattered raw
+				// package-manager output across the dashboard - and the one
+				// legitimate need, sudo's password prompt, is served by
+				// ensureSudoCredentials validating before captured elevated
+				// commands run.
+				Interactive: helpers.ResolveInteractive(pkg.Interactive, false),
 			}
 			started := time.Now()
 			if err := system.RunCommand(cmd, initConfig.Variables.Flags.Debug); err != nil {

--- a/internal/processors/packages.go
+++ b/internal/processors/packages.go
@@ -9,6 +9,7 @@ import (
 
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/types"
 )
@@ -89,19 +90,31 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 		var provider *types.Provider
 		var exists bool
 
+		// A package entry that cannot reach a package manager is a FAILURE,
+		// not a skip. Blueprint trees are per-OS, so a declared
+		// package_manager is a demand: skipping here meant a machine without
+		// cargo "successfully" ran a tree whose init file exists to install
+		// cargo's packages, and the run exited 0 having installed none of
+		// them. The ledger keeps the run going but puts it in the exit code.
+		subject := pkg.Name
+		if subject == "" && len(pkg.Names) > 0 {
+			subject = strings.Join(pkg.Names, " ")
+		}
 		if pkg.PackageManager != "" {
 			// Use specified package manager
 			provider, exists = system.GetProvider(pkg.PackageManager)
 			if !exists {
-				log.Warnf("Specified package manager %s not available, skipping package %s", pkg.PackageManager, pkg.Name)
-				track.item(pkg.PackageManager, pkg.Name, pkg.Action, types.StatusSkipped, "package manager not available", 0)
+				recordFailure("packages", subject,
+					fmt.Errorf("required package manager %q is not available on this system; declare it under packageManagers in the init file (action: install) or install it manually", pkg.PackageManager))
+				track.item(pkg.PackageManager, subject, pkg.Action, types.StatusFailed, "package manager not available", 0)
 				continue
 			}
 		} else {
 			provider, exists = defaultProviderFor(osInfo, available)
 			if !exists {
-				log.Warnf("No package manager available for package %s, skipping", pkg.Name)
-				track.item("", pkg.Name, pkg.Action, types.StatusSkipped, "no package manager available", 0)
+				recordFailure("packages", subject,
+					errors.New("no package manager available for this entry; declare one under packageManagers in the init file (action: install) or set package_manager on the entry"))
+				track.item("", subject, pkg.Action, types.StatusFailed, "no package manager available", 0)
 				continue
 			}
 		}
@@ -125,6 +138,10 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 
 	for _, unit := range units {
 		pkg, provider := unit.pkg, unit.provider
+
+		// The provider stamp fills the log view's provider column for every
+		// line this unit's work produces (rwr's own and captured output).
+		reporting.SetCurrentProvider(provider.Name)
 
 		// Process each package
 		for _, name := range unit.names {
@@ -159,15 +176,22 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 			}
 
 			// Execute command directly with environment variables
+			elevated := provider.Elevated || pkg.Elevated
 			cmd := types.Command{
 				Exec: provider.BinPath,
 				Args: args,
 				// The provider decides whether its package manager needs elevation;
 				// a blueprint may ask for it on top (a user-scoped manager invoked
 				// against a system path), but may not take it away.
-				Elevated:    provider.Elevated || pkg.Elevated,
-				Variables:   provider.Environment,
-				Interactive: helpers.ResolveInteractive(pkg.Interactive, initConfig.Variables.Flags.Interactive),
+				Elevated:  elevated,
+				Variables: provider.Environment,
+				// Terminal handover only when this command can actually need
+				// one: an explicit per-item `interactive: true`, or sudo that
+				// may prompt for a password. Routing EVERY package through the
+				// terminal (the old behavior under the default interactive
+				// run) suspended the TUI per package and splattered raw
+				// package-manager output across the dashboard.
+				Interactive: helpers.ResolveInteractive(pkg.Interactive, initConfig.Variables.Flags.Interactive && elevated),
 			}
 			started := time.Now()
 			if err := system.RunCommand(cmd, initConfig.Variables.Flags.Debug); err != nil {
@@ -180,6 +204,7 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 			log.Infof("Successfully %s package %s via %s", pastTense(pkg.Action), name, provider.Name)
 		}
 	}
+	reporting.SetCurrentProvider("")
 
 	return nil
 }

--- a/internal/processors/packages_test.go
+++ b/internal/processors/packages_test.go
@@ -613,3 +613,44 @@ func TestProcessPackages_NamesWinsOverName(t *testing.T) {
 		t.Errorf("missing installs %v; recorded %v", want, installed)
 	}
 }
+
+// A package entry whose declared package_manager is not available must land in
+// the failure ledger, not be silently skipped: a machine without cargo used to
+// "successfully" run a tree whose entire cargo file installed nothing, and the
+// run exited 0. The run keeps going (other entries still process) but the
+// ledger puts the miss in the exit code.
+func TestProcessPackages_UnavailableManagerIsFailure(t *testing.T) {
+	useTestProvider(t)
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+	resetFailures()
+	t.Cleanup(resetFailures)
+
+	data := []byte("packages:\n" +
+		"  - name: bandwhich\n    action: install\n    package_manager: cargo\n" +
+		"  - name: vim\n    action: install\n    package_manager: pacman\n")
+	if err := ProcessPackages(data, nil, t.TempDir(), "yaml", newTestOSInfo(), &types.InitConfig{}); err != nil {
+		t.Fatalf("ProcessPackages: %v", err)
+	}
+
+	err := failureError()
+	if err == nil {
+		t.Fatal("unavailable package manager was not recorded as a failure")
+	}
+	if !strings.Contains(err.Error(), "cargo") || !strings.Contains(err.Error(), "bandwhich") {
+		t.Fatalf("failure does not name the manager and package: %v", err)
+	}
+
+	// The available-manager entry still ran: the miss must not abort the rest.
+	var sawVim bool
+	for _, call := range rec.Calls {
+		for _, arg := range call.Args {
+			if arg == "vim" {
+				sawVim = true
+			}
+		}
+	}
+	if !sawVim {
+		t.Fatalf("pacman entry did not run after the cargo failure; calls: %v", rec.Calls)
+	}
+}

--- a/internal/processors/plan.go
+++ b/internal/processors/plan.go
@@ -24,12 +24,21 @@ func ResolveStage1(initConfig *types.InitConfig) (*types.Plan, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting blueprint run order: %w", err)
 	}
-	plan.Order = order
 
 	location := initConfig.Init.Location
 	fileOrder, err := GetBlueprintFileOrder(location, initConfig.Init.Order, initConfig.Init.RunOnlyListed, initConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error getting blueprint file order: %w", err)
+	}
+
+	// The plan's order carries only the processors this tree configures. The
+	// executor already skips processors with no files; keeping them in the
+	// plan just rendered phantom rows (a tree with no ssh_keys blueprints
+	// showed an ssh_keys processor pending forever).
+	for _, processor := range order {
+		if _, ok := fileOrder[processor]; ok {
+			plan.Order = append(plan.Order, processor)
+		}
 	}
 
 	for processor, files := range fileOrder {

--- a/internal/processors/plan_stage2.go
+++ b/internal/processors/plan_stage2.go
@@ -10,8 +10,16 @@ import (
 // and the resource enumeration the lanes count. It cannot run earlier -
 // bootstrap can install the package manager later blueprints depend on, so
 // detecting providers before it produces wrong lanes.
-func ResolveStage2(plan *types.Plan) {
-	for name, provider := range system.GetAvailableProviders() {
+//
+// osInfo picks the default provider for entries that do not pin a
+// package_manager (nil falls back to the alphabetically first available).
+// The plan must name the provider the executor will actually use: keying
+// unpinned entries on "" put them in an "items" lane that no runtime
+// LaneUpdate (which keys on the resolved provider) ever touched, so the
+// checklist showed a full brew bar and a ghost pending lane forever.
+func ResolveStage2(plan *types.Plan, osInfo *types.OSInfo) {
+	available := system.GetAvailableProviders()
+	for name, provider := range available {
 		plan.Providers = append(plan.Providers, types.ProviderState{
 			Name:      name,
 			Available: true,
@@ -19,9 +27,14 @@ func ResolveStage2(plan *types.Plan) {
 		})
 	}
 
+	defaultProvider := ""
+	if provider, ok := defaultProviderFor(osInfo, available); ok {
+		defaultProvider = provider.Name
+	}
+
 	for processor, files := range plan.Files {
 		for _, file := range files {
-			plan.Resources = append(plan.Resources, enumerateResources(processor, file)...)
+			plan.Resources = append(plan.Resources, enumerateResources(processor, file, defaultProvider)...)
 		}
 	}
 }
@@ -29,11 +42,17 @@ func ResolveStage2(plan *types.Plan) {
 // enumerateResources lists the planned units of work one resolved file
 // declares. Decode failures return nothing here: stage 1 already reported
 // them as diagnostics, and stage 2 must not duplicate the noise.
-func enumerateResources(processor string, file types.ResolvedFile) []types.Resource {
+// defaultProvider fills in for package/repository entries that do not pin a
+// package_manager, matching what the executor will resolve at run time.
+func enumerateResources(processor string, file types.ResolvedFile, defaultProvider string) []types.Resource {
+	usesProviders := processor == types.BlueprintTypePackages || processor == types.BlueprintTypeRepositories
 	var resources []types.Resource
 	add := func(provider, name, action string) {
 		if name == "" {
 			return
+		}
+		if provider == "" && usesProviders {
+			provider = defaultProvider
 		}
 		resources = append(resources, types.Resource{
 			Processor: processor,

--- a/internal/processors/plan_test.go
+++ b/internal/processors/plan_test.go
@@ -51,7 +51,7 @@ func TestResolveStage2_ProvidersAndResources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveStage1: %v", err)
 	}
-	ResolveStage2(plan)
+	ResolveStage2(plan, nil)
 
 	foundProvider := false
 	for _, p := range plan.Providers {

--- a/internal/processors/reporter_output_test.go
+++ b/internal/processors/reporter_output_test.go
@@ -61,6 +61,12 @@ func TestAll_HeadlessOutputUnchanged(t *testing.T) {
 	osInfo := &types.OSInfo{}
 	osInfo.System.OS = runtime.GOOS
 	osInfo.Tools.Bash = types.ToolInfo{Exists: true, Bin: "/bin/bash"}
+	// A detected manager keeps All() out of the darwin "no package manager,
+	// install one" bootstrap branch - this test is about the processor loop's
+	// output, and on a mac an empty Managers map reads as a fresh machine.
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{
+		"pacman": {Name: "pacman", Bin: bin},
+	}
 
 	if err := All(initConfig, osInfo, []string{"packages", "scripts"}); err != nil {
 		t.Fatalf("All: %v", err)
@@ -120,6 +126,10 @@ func TestAll_NonInteractiveCollectsErrorsAndContinues(t *testing.T) {
 	osInfo := &types.OSInfo{}
 	osInfo.System.OS = runtime.GOOS
 	osInfo.Tools.Bash = types.ToolInfo{Exists: true, Bin: "/bin/bash"}
+	// Same as above: keep All() out of the darwin bootstrap branch.
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{
+		"sh": {Name: "sh", Bin: "/bin/sh"},
+	}
 
 	err := All(initConfig, osInfo, []string{"scripts", "files"})
 	if err == nil {

--- a/internal/processors/repository.go
+++ b/internal/processors/repository.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/types"
 )
@@ -107,6 +108,8 @@ func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *
 	if !exists {
 		return fmt.Errorf("unsupported package manager: %s", repo.PackageManager)
 	}
+	reporting.SetCurrentProvider(provider.Name)
+	defer reporting.SetCurrentProvider("")
 
 	// A signing key fetched without a declared digest is trusted on nothing
 	// but the TLS connection that served it. Warn now; a later major refuses
@@ -160,10 +163,14 @@ func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *
 		switch step.Action {
 		case "exec", "command": // Support both "exec" and "command" action types
 			cmd = types.Command{
-				Exec:        step.Exec,
-				Args:        step.Args,
-				Elevated:    provider.Elevated,
-				Interactive: helpers.ResolveInteractive(repo.Interactive, initConfig.Variables.Flags.Interactive),
+				Exec:      step.Exec,
+				Args:      step.Args,
+				Elevated:  provider.Elevated,
+				Variables: provider.Environment,
+				// Same routing as packages: the terminal is handed over only on
+				// an explicit per-item `interactive: true` or when sudo may
+				// prompt - not for every step of every repository.
+				Interactive: helpers.ResolveInteractive(repo.Interactive, initConfig.Variables.Flags.Interactive && provider.Elevated),
 				// chocolatey's --password and cargo's login token are accepted
 				// only as arguments, so they cannot move to stdin. They can at
 				// least be kept out of the debug and dry-run log lines, which
@@ -258,6 +265,12 @@ func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *
 		}
 
 		if err := system.RunCommand(cmd, initConfig.Variables.Flags.Debug); err != nil {
+			if step.Optional {
+				// A version-dependent step (brew 6's `brew trust`) that this
+				// machine's tool doesn't have; the action does not fail on it.
+				log.Warnf("Optional repository step for %s failed (ignored): %v", repo.Name, err)
+				continue
+			}
 			return fmt.Errorf("error executing repository step: %w", err)
 		}
 	}

--- a/internal/processors/repository.go
+++ b/internal/processors/repository.go
@@ -167,10 +167,10 @@ func processRepository(repo types.Repository, osInfo *types.OSInfo, initConfig *
 				Args:      step.Args,
 				Elevated:  provider.Elevated,
 				Variables: provider.Environment,
-				// Same routing as packages: the terminal is handed over only on
-				// an explicit per-item `interactive: true` or when sudo may
-				// prompt - not for every step of every repository.
-				Interactive: helpers.ResolveInteractive(repo.Interactive, initConfig.Variables.Flags.Interactive && provider.Elevated),
+				// Same routing as packages: terminal handover only on an
+				// explicit per-item `interactive: true`; sudo's password is
+				// served by ensureSudoCredentials before captured commands.
+				Interactive: helpers.ResolveInteractive(repo.Interactive, false),
 				// chocolatey's --password and cargo's login token are accepted
 				// only as arguments, so they cannot move to stdin. They can at
 				// least be kept out of the debug and dry-run log lines, which

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/fynxlabs/rwr/internal/credentials"
 	"github.com/fynxlabs/rwr/internal/helpers"
 	"github.com/fynxlabs/rwr/internal/prompts"
+	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/types"
 	"github.com/spf13/viper"
@@ -287,28 +289,47 @@ func setAsRWRSSHKey(keyPath string) error {
 
 // AuthenticateWithGitHub performs OAuth device flow authentication with GitHub,
 // returning an access token that can be used for API operations like uploading SSH keys.
+//
+// The whole flow - instructions, code, polling - runs under the terminal
+// lease. Under the TUI the instructions used to go to the log store while the
+// dashboard showed an early frame with no log panel: the operator saw
+// nothing, and the flow silently polled a URL nobody visited until it timed
+// out. The operator is actively authenticating here; holding the suspension
+// until they finish is the point.
 func AuthenticateWithGitHub(initConfig *types.InitConfig) (string, error) {
-	log.Infof("Starting GitHub authentication...")
+	log.Debugf("Starting GitHub authentication...")
 
 	// Step 1: Request device code
 	deviceResp, err := requestDeviceCode()
 	if err != nil {
 		return "", fmt.Errorf("failed to request device code: %w", err)
 	}
+	log.Debugf("GitHub device flow: %s code %s", deviceResp.VerificationURI, deviceResp.UserCode)
 
-	// Step 2: Display instructions to user
-	log.Infof("")
-	log.Infof("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-	log.Infof("  GitHub Authentication Required")
-	log.Infof("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-	log.Infof("")
-	log.Infof("1. Visit: %s", deviceResp.VerificationURI)
-	log.Infof("2. Enter code: %s", deviceResp.UserCode)
-	log.Infof("")
-	log.Infof("Waiting for authorization...")
-	log.Infof("")
-	// Step 3: Poll for access token
-	token, err := pollForAccessToken(deviceResp.DeviceCode, deviceResp.Interval)
+	// Steps 2+3: show instructions on the real terminal and poll there.
+	var token string
+	err = reporting.WithTerminal(func() error {
+		fmt.Println()
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		fmt.Println("  GitHub Authentication Required")
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		fmt.Println()
+		fmt.Printf("1. Visit: %s\n", deviceResp.VerificationURI)
+		fmt.Printf("2. Enter code: %s\n", deviceResp.UserCode)
+		fmt.Println()
+		fmt.Println("Waiting for authorization (5 minute timeout)...")
+		fmt.Println()
+
+		// Best effort: put the verification page in front of the operator.
+		openBrowser(deviceResp.VerificationURI)
+
+		var pollErr error
+		token, pollErr = pollForAccessToken(deviceResp.DeviceCode, deviceResp.Interval)
+		if pollErr == nil {
+			fmt.Println("Authorized.")
+		}
+		return pollErr
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to get access token: %w", err)
 	}
@@ -322,6 +343,23 @@ func AuthenticateWithGitHub(initConfig *types.InitConfig) (string, error) {
 	}
 
 	return token, nil
+}
+
+// openBrowser opens url in the operator's default browser, best effort - the
+// printed instructions are the contract, this is a convenience.
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url) // #nosec G204 -- argv, not a shell; url is GitHub's device-flow verification_uri
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url) // #nosec G204 -- argv, not a shell; url is GitHub's device-flow verification_uri
+	default:
+		cmd = exec.Command("xdg-open", url) // #nosec G204 -- argv, not a shell; url is GitHub's device-flow verification_uri
+	}
+	if err := cmd.Start(); err != nil {
+		log.Debugf("could not open browser for %s: %v", url, err)
+	}
 }
 
 // requestDeviceCode requests a device code from GitHub
@@ -496,9 +534,16 @@ func copySSHKeyToGitHub(sshKey types.SSHKey, initConfig *types.InitConfig) error
 			return fmt.Errorf("error getting hostname: %v", err)
 		}
 
-		reader := bufio.NewReader(os.Stdin)
-		fmt.Printf("Enter GitHub SSH key title (default: %s): ", hostname)
-		input, err := reader.ReadString('\n')
+		// Through the terminal lease: a bare stdin read under the TUI freezes
+		// the run (the dashboard eats every keystroke, including ctrl-c).
+		var input string
+		err = reporting.WithTerminal(func() error {
+			reader := bufio.NewReader(os.Stdin)
+			fmt.Printf("Enter GitHub SSH key title (default: %s): ", hostname)
+			line, readErr := reader.ReadString('\n')
+			input = line
+			return readErr
+		})
 		if err != nil {
 			return fmt.Errorf("error reading user input: %v", err)
 		}

--- a/internal/processors/ssh_key_test.go
+++ b/internal/processors/ssh_key_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fynxlabs/rwr/internal/credentials"
 	"github.com/fynxlabs/rwr/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +17,7 @@ import (
 
 // TestGetGitHubToken_Priority tests token retrieval priority.
 func TestGetGitHubToken_Priority(t *testing.T) {
+	withEmptyKeyring(t)
 	tests := []struct {
 		name           string
 		configToken    string
@@ -313,6 +315,7 @@ func TestCopySSHKeyToGitHub_Errors(t *testing.T) {
 
 // TestGetGitHubToken_EnvVarOnly tests GITHUB_TOKEN environment variable.
 func TestGetGitHubToken_EnvVarOnly(t *testing.T) {
+	withEmptyKeyring(t)
 	oldGitHubToken := os.Getenv("GITHUB_TOKEN")
 	defer os.Setenv("GITHUB_TOKEN", oldGitHubToken)
 
@@ -336,6 +339,7 @@ func TestGetGitHubToken_EnvVarOnly(t *testing.T) {
 
 // TestGetGitHubToken_NoToken tests error when no token available.
 func TestGetGitHubToken_NoToken(t *testing.T) {
+	withEmptyKeyring(t)
 	oldGitHubToken := os.Getenv("GITHUB_TOKEN")
 	defer os.Setenv("GITHUB_TOKEN", oldGitHubToken)
 
@@ -378,4 +382,19 @@ func TestPollForAccessToken_Timeout(t *testing.T) {
 	// Note: This would require making the timeout configurable
 	// For now, we document the expected behavior
 	// In production, pollForAccessToken should timeout after 5 minutes
+}
+
+// emptyKeyring isolates token tests from the developer's real OS keyring: a
+// machine where `rwr --gh-auth` has ever succeeded has a real token stored,
+// and un-stubbed tests started failing the moment auth worked.
+type emptyKeyring struct{}
+
+func (emptyKeyring) Get(string) (string, error) { return "", credentials.ErrKeyringNotFound }
+func (emptyKeyring) Set(string, string) error   { return nil }
+
+func withEmptyKeyring(t *testing.T) {
+	t.Helper()
+	previous := credentials.Ring
+	credentials.Ring = emptyKeyring{}
+	t.Cleanup(func() { credentials.Ring = previous })
 }

--- a/internal/prompts/github.go
+++ b/internal/prompts/github.go
@@ -11,6 +11,7 @@ import (
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/credentials"
 	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/types"
 	"github.com/spf13/viper"
 )
@@ -43,7 +44,9 @@ func PromptGitHubAuthMethod() (GitHubAuthChoice, error) {
 		),
 	)
 
-	err := form.Run()
+	// Through the terminal lease, never bare: a form that reads stdin while
+	// the TUI owns it freezes the run (and ctrl-c with it).
+	err := reporting.WithTerminal(form.Run)
 	if err != nil {
 		return "", fmt.Errorf("authentication prompt failed: %w", err)
 	}
@@ -67,7 +70,7 @@ func PromptGitHubToken() (string, error) {
 		),
 	)
 
-	err := form.Run()
+	err := reporting.WithTerminal(form.Run)
 	if err != nil {
 		return "", fmt.Errorf("token entry failed: %w", err)
 	}
@@ -188,7 +191,7 @@ func PromptConfirmTokenReplace() (bool, error) {
 		),
 	)
 
-	err := form.Run()
+	err := reporting.WithTerminal(form.Run)
 	if err != nil {
 		return false, fmt.Errorf("confirmation prompt failed: %w", err)
 	}

--- a/internal/reporting/json_capture_test.go
+++ b/internal/reporting/json_capture_test.go
@@ -75,3 +75,25 @@ func TestAppend_SplitsMultilineMessages(t *testing.T) {
 		}
 	}
 }
+
+// Records and Append race under real load (render tick vs run goroutine);
+// run with -race to catch slice-header tears on view.idx.
+func TestStore_ConcurrentAppendAndRecords(t *testing.T) {
+	store := NewStore(200)
+	view := store.NewView("")
+	stop := make(chan struct{})
+	go func() {
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				store.Append(LogRecord{Msg: "line", Processor: "packages"})
+			}
+		}
+	}()
+	for i := 0; i < 500; i++ {
+		store.Records(view)
+	}
+	close(stop)
+}

--- a/internal/reporting/json_capture_test.go
+++ b/internal/reporting/json_capture_test.go
@@ -1,0 +1,77 @@
+package reporting
+
+import (
+	"strings"
+	"testing"
+)
+
+// The TUI capture path parses charm log's JSON formatter output into
+// structured records: level, message, and caller survive as fields, and the
+// text formatter's `<file:line>` / `rwr: :` artifacts can never reach the
+// screen because the screen renders from these fields.
+func TestJSONCaptureWriter_ParsesFields(t *testing.T) {
+	store := NewStore(100)
+	w := &JSONCaptureWriter{Store: store}
+	SetCurrentProcessor("packages")
+	SetCurrentProvider("brew")
+	defer SetCurrentProcessor("")
+	defer SetCurrentProvider("")
+
+	line := `{"time":"2026/08/11 13:30:00","level":"info","caller":"processors/packages.go:199","msg":"Successfully installed package jq via brew"}` + "\n"
+	if _, err := w.Write([]byte(line)); err != nil {
+		t.Fatal(err)
+	}
+
+	view := store.NewView("")
+	records := store.Records(view)
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	r := records[0]
+	if r.Level != "INFO" {
+		t.Fatalf("level = %q, want INFO", r.Level)
+	}
+	if r.Msg != "Successfully installed package jq via brew" {
+		t.Fatalf("msg = %q", r.Msg)
+	}
+	if r.Caller != "packages.go:199" {
+		t.Fatalf("caller = %q, want packages.go:199", r.Caller)
+	}
+	if r.Processor != "packages" || r.Provider != "brew" {
+		t.Fatalf("attribution = %s/%s, want packages/brew", r.Processor, r.Provider)
+	}
+}
+
+// A non-JSON line (a stray print) is kept verbatim, not dropped.
+func TestJSONCaptureWriter_KeepsNonJSON(t *testing.T) {
+	store := NewStore(100)
+	w := &JSONCaptureWriter{Store: store}
+	if _, err := w.Write([]byte("plain text line\n")); err != nil {
+		t.Fatal(err)
+	}
+	records := store.Records(store.NewView(""))
+	if len(records) != 1 || records[0].Msg != "plain text line" {
+		t.Fatalf("records = %+v", records)
+	}
+}
+
+// A message carrying embedded newlines (an error with a command's stderr
+// blob) splits into one record per line: the display budgets panel height by
+// record, and a single 20-line record pushed the whole frame past the
+// terminal - the dashboard scrolled away and looked broken.
+func TestAppend_SplitsMultilineMessages(t *testing.T) {
+	store := NewStore(100)
+	store.Append(LogRecord{Msg: "Error running command: exit status 101\nStderr: Updating index\n\n Downloading crates ...", Level: "ERRO"})
+	records := store.Records(store.NewView(""))
+	if len(records) != 3 {
+		t.Fatalf("got %d records, want 3 (blank line dropped): %+v", len(records), records)
+	}
+	for _, r := range records {
+		if strings.Contains(r.Msg, "\n") {
+			t.Fatalf("record still carries a newline: %q", r.Msg)
+		}
+		if r.Level != "ERRO" {
+			t.Fatalf("split record lost its level: %+v", r)
+		}
+	}
+}

--- a/internal/reporting/reporter.go
+++ b/internal/reporting/reporter.go
@@ -66,6 +66,33 @@ type TerminalReq struct {
 	Done      chan error
 }
 
+// TerminalFunc asks the display layer to lend the real terminal to an
+// in-process interaction - a huh form, a raw stdin prompt. The TerminalReq
+// counterpart for code that runs in this process rather than a child.
+type TerminalFunc struct {
+	Run  func() error
+	Done chan error
+}
+
+// HaltDecision is the operator's answer to an interactive halt.
+type HaltDecision int
+
+const (
+	HaltAbort HaltDecision = iota
+	HaltRetry
+	HaltSkip
+)
+
+// HaltReq reports a processor error in an interactive run and waits for the
+// operator: retry the processor, skip past the error, or abort the run. The
+// LogReporter answers abort, which is exactly the pre-halt behavior (an
+// interactive headless run returned the error immediately).
+type HaltReq struct {
+	Processor string
+	Err       error
+	Decision  chan HaltDecision
+}
+
 // RunFinished carries the collected step errors of a push-through run.
 type RunFinished struct {
 	Errs []types.StepError
@@ -77,6 +104,8 @@ func (ProcSkipped) runEvent()  {}
 func (LaneUpdate) runEvent()   {}
 func (ResourceDone) runEvent() {}
 func (TerminalReq) runEvent()  {}
+func (TerminalFunc) runEvent() {}
+func (HaltReq) runEvent()      {}
 func (RunFinished) runEvent()  {}
 
 // processorLabels are the exact strings the pre-event loop logged per
@@ -119,6 +148,13 @@ func (LogReporter) Emit(event Event) {
 		e.Cmd.Stdout = os.Stdout
 		e.Cmd.Stderr = os.Stderr
 		e.Done <- e.Cmd.Run()
+	case TerminalFunc:
+		// Headless the terminal is already free; just run the interaction.
+		e.Done <- e.Run()
+	case HaltReq:
+		// Headless interactive keeps its historical behavior: the first
+		// processor error aborts the run.
+		e.Decision <- HaltAbort
 	case ProcFinished, LaneUpdate, ResourceDone, RunFinished:
 		// The streaming output never printed these as their own lines; the
 		// processors' own log calls carry the detail.
@@ -139,3 +175,23 @@ func Set(r Reporter) (restore func()) {
 
 // Emit sends an event to the active reporter.
 func Emit(event Event) { current.Emit(event) }
+
+// RequestHalt reports an interactive processor error and blocks until the
+// operator (or the LogReporter's abort default) decides what happens next.
+func RequestHalt(processor string, err error) HaltDecision {
+	decision := make(chan HaltDecision, 1)
+	Emit(HaltReq{Processor: processor, Err: err, Decision: decision})
+	return <-decision
+}
+
+// WithTerminal runs fn with exclusive use of the real terminal. Headless it
+// runs fn directly; under the TUI the dashboard suspends itself first and
+// resumes after. Every in-process prompt (huh forms, raw stdin reads) MUST go
+// through this: a prompt that reads stdin while the dashboard owns it
+// deadlocks the run - the prompt never gets keystrokes, the dashboard keeps
+// eating them, and ctrl-c dies with both.
+func WithTerminal(fn func() error) error {
+	done := make(chan error, 1)
+	Emit(TerminalFunc{Run: fn, Done: done})
+	return <-done
+}

--- a/internal/reporting/reporter.go
+++ b/internal/reporting/reporter.go
@@ -189,18 +189,35 @@ func (LogReporter) Emit(event Event) {
 
 // current is the active reporter. Package state mirrors the executor seam in
 // internal/system: the run loop and runCommand emit without threading a
-// reporter through every processor signature.
-var current Reporter = LogReporter{}
+// reporter through every processor signature. Guarded by a mutex because the
+// TUI runner swaps it back to the LogReporter mid-run when the dashboard
+// exits early - the run goroutine reads it on every Emit, and an interface
+// value is two words, so an unsynchronized swap can tear.
+var (
+	currentMu sync.RWMutex
+	current   Reporter = LogReporter{}
+)
 
 // Set installs a reporter and returns a restore func (test/TUI seam).
 func Set(r Reporter) (restore func()) {
+	currentMu.Lock()
 	previous := current
 	current = r
-	return func() { current = previous }
+	currentMu.Unlock()
+	return func() {
+		currentMu.Lock()
+		current = previous
+		currentMu.Unlock()
+	}
 }
 
 // Emit sends an event to the active reporter.
-func Emit(event Event) { current.Emit(event) }
+func Emit(event Event) {
+	currentMu.RLock()
+	r := current
+	currentMu.RUnlock()
+	r.Emit(event)
+}
 
 // terminalLost, when set, is closed by the TUI runner the moment the
 // dashboard program exits. Bubbletea silently drops Sends once its context

--- a/internal/reporting/reporter.go
+++ b/internal/reporting/reporter.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"charm.land/log/v2"
@@ -65,14 +66,19 @@ type TerminalReq struct {
 	Processor string
 	Cmd       *exec.Cmd
 	Done      chan error
+	// Claim makes the request run-once: the servicer and the waiter's
+	// terminal-lost fallback CAS it, and only the winner executes. Without
+	// it, a quit racing the exec callback could run the request twice.
+	Claim *atomic.Bool
 }
 
 // TerminalFunc asks the display layer to lend the real terminal to an
 // in-process interaction - a huh form, a raw stdin prompt. The TerminalReq
 // counterpart for code that runs in this process rather than a child.
 type TerminalFunc struct {
-	Run  func() error
-	Done chan error
+	Run   func() error
+	Done  chan error
+	Claim *atomic.Bool
 }
 
 // HaltDecision is the operator's answer to an interactive halt.
@@ -92,6 +98,16 @@ type HaltReq struct {
 	Processor string
 	Err       error
 	Decision  chan HaltDecision
+	// Claim is CAS'd by whoever answers - the operator's keypress or the
+	// terminal-lost fallback - so a decision is made exactly once.
+	Claim *atomic.Bool
+}
+
+// TryClaim reports whether the caller won the right to service a claimable
+// request. A nil claim (an event constructed directly, e.g. in tests) is
+// always claimable.
+func TryClaim(claim *atomic.Bool) bool {
+	return claim == nil || claim.CompareAndSwap(false, true)
 }
 
 // RunFinished carries the collected step errors of a push-through run.
@@ -143,6 +159,9 @@ func (LogReporter) Emit(event Event) {
 	case TerminalReq:
 		// The pre-event direct wiring: the command owns the real terminal.
 		// stderr is deliberately not captured (sudo's prompt lives there).
+		if !TryClaim(e.Claim) {
+			return
+		}
 		if e.Cmd.Stdin == nil {
 			e.Cmd.Stdin = os.Stdin
 		}
@@ -151,10 +170,16 @@ func (LogReporter) Emit(event Event) {
 		e.Done <- e.Cmd.Run()
 	case TerminalFunc:
 		// Headless the terminal is already free; just run the interaction.
+		if !TryClaim(e.Claim) {
+			return
+		}
 		e.Done <- e.Run()
 	case HaltReq:
 		// Headless interactive keeps its historical behavior: the first
 		// processor error aborts the run.
+		if !TryClaim(e.Claim) {
+			return
+		}
 		e.Decision <- HaltAbort
 	case ProcFinished, LaneUpdate, ResourceDone, RunFinished:
 		// The streaming output never printed these as their own lines; the
@@ -215,18 +240,19 @@ func TerminalLost() <-chan struct{} {
 // taken rather than blocking forever on a dropped Send.
 func RequestHalt(processor string, err error) HaltDecision {
 	decision := make(chan HaltDecision, 1)
-	Emit(HaltReq{Processor: processor, Err: err, Decision: decision})
+	claim := &atomic.Bool{}
+	Emit(HaltReq{Processor: processor, Err: err, Decision: decision, Claim: claim})
 	select {
 	case d := <-decision:
 		return d
 	case <-TerminalLost():
-		// The answer may have raced the program's death; prefer it.
-		select {
-		case d := <-decision:
-			return d
-		default:
+		// Whoever wins the claim answers; losing it means an answer is
+		// already on its way (the claimant writes the buffered channel
+		// immediately after claiming), so waiting is safe.
+		if claim.CompareAndSwap(false, true) {
 			return HaltAbort
 		}
+		return <-decision
 	}
 }
 
@@ -238,19 +264,19 @@ func RequestHalt(processor string, err error) HaltDecision {
 // eating them, and ctrl-c dies with both.
 func WithTerminal(fn func() error) error {
 	done := make(chan error, 1)
-	Emit(TerminalFunc{Run: fn, Done: done})
+	claim := &atomic.Bool{}
+	Emit(TerminalFunc{Run: fn, Done: done, Claim: claim})
 	select {
 	case err := <-done:
 		return err
 	case <-TerminalLost():
-		// The answer may have raced the program's death; prefer it. If the
-		// Send was dropped, the terminal is free now - run directly, which
-		// is the headless behavior.
-		select {
-		case err := <-done:
-			return err
-		default:
+		// Run-once via the claim: if the dashboard already claimed this
+		// request, its exec callback runs independently of the program's
+		// lifetime and will write done - wait for it. Winning the claim
+		// means nobody ran fn; the terminal is free now, run it directly.
+		if claim.CompareAndSwap(false, true) {
 			return fn()
 		}
+		return <-done
 	}
 }

--- a/internal/reporting/reporter.go
+++ b/internal/reporting/reporter.go
@@ -8,6 +8,7 @@ package reporting
 import (
 	"os"
 	"os/exec"
+	"sync"
 	"time"
 
 	"charm.land/log/v2"
@@ -176,12 +177,57 @@ func Set(r Reporter) (restore func()) {
 // Emit sends an event to the active reporter.
 func Emit(event Event) { current.Emit(event) }
 
+// terminalLost, when set, is closed by the TUI runner the moment the
+// dashboard program exits. Bubbletea silently drops Sends once its context
+// is cancelled, so a blocking event emitted in the window between program
+// exit and the reporter swap would leave its waiter blocked forever - the
+// waiters below select on this and fall back to the headless behavior.
+var (
+	terminalLostMu sync.RWMutex
+	terminalLost   chan struct{}
+)
+
+// SetTerminalLost installs the channel the TUI runner closes on program
+// exit (nil clears). Returns a restore func.
+func SetTerminalLost(ch chan struct{}) (restore func()) {
+	terminalLostMu.Lock()
+	previous := terminalLost
+	terminalLost = ch
+	terminalLostMu.Unlock()
+	return func() {
+		terminalLostMu.Lock()
+		terminalLost = previous
+		terminalLostMu.Unlock()
+	}
+}
+
+// TerminalLost returns the current lost-channel; nil (which never fires in
+// a select) when no dashboard is running.
+func TerminalLost() <-chan struct{} {
+	terminalLostMu.RLock()
+	defer terminalLostMu.RUnlock()
+	return terminalLost
+}
+
 // RequestHalt reports an interactive processor error and blocks until the
 // operator (or the LogReporter's abort default) decides what happens next.
+// If the dashboard dies before answering, the headless default (abort) is
+// taken rather than blocking forever on a dropped Send.
 func RequestHalt(processor string, err error) HaltDecision {
 	decision := make(chan HaltDecision, 1)
 	Emit(HaltReq{Processor: processor, Err: err, Decision: decision})
-	return <-decision
+	select {
+	case d := <-decision:
+		return d
+	case <-TerminalLost():
+		// The answer may have raced the program's death; prefer it.
+		select {
+		case d := <-decision:
+			return d
+		default:
+			return HaltAbort
+		}
+	}
 }
 
 // WithTerminal runs fn with exclusive use of the real terminal. Headless it
@@ -193,5 +239,18 @@ func RequestHalt(processor string, err error) HaltDecision {
 func WithTerminal(fn func() error) error {
 	done := make(chan error, 1)
 	Emit(TerminalFunc{Run: fn, Done: done})
-	return <-done
+	select {
+	case err := <-done:
+		return err
+	case <-TerminalLost():
+		// The answer may have raced the program's death; prefer it. If the
+		// Send was dropped, the terminal is free now - run directly, which
+		// is the headless behavior.
+		select {
+		case err := <-done:
+			return err
+		default:
+			return fn()
+		}
+	}
 }

--- a/internal/reporting/store.go
+++ b/internal/reporting/store.go
@@ -205,13 +205,18 @@ func (s *Store) NewView(processor string) *View {
 }
 
 // Records returns the view's live records, dropping evicted Seqs lazily.
+// The lock covers the whole read: appendOne mutates view.idx under s.mu, and
+// the render tick calling this concurrently with the run goroutine's log
+// writes would otherwise race on the slice header - stale lengths (lines
+// silently missing from the viewport) or a re-slice clobbering an append.
 func (s *Store) Records(view *View) []LogRecord {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	oldest := uint64(0)
 	if len(s.buf) > 0 {
 		oldest = s.buf[0].Seq
 	}
-	s.mu.Unlock()
 
 	start := 0
 	for start < len(view.idx) && view.idx[start] < oldest {
@@ -221,9 +226,10 @@ func (s *Store) Records(view *View) []LogRecord {
 
 	out := make([]LogRecord, 0, len(view.idx))
 	for _, seq := range view.idx {
-		if record, ok := s.Get(seq); ok {
-			out = append(out, record)
+		if len(s.buf) == 0 || seq < s.buf[0].Seq || seq > s.seq {
+			continue
 		}
+		out = append(out, s.buf[seq-s.buf[0].Seq])
 	}
 	return out
 }

--- a/internal/reporting/store.go
+++ b/internal/reporting/store.go
@@ -2,8 +2,13 @@ package reporting
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -23,10 +28,11 @@ const (
 type LogRecord struct {
 	Seq       uint64
 	Time      time.Time
-	Level     string
+	Level     string // "DEBU" "INFO" "WARN" "ERRO" "FATA"; "" for raw command output
 	Processor string
 	Provider  string
 	Msg       string
+	Caller    string // "packages.go:199"; display renders it at debug level only
 	Src       Source
 }
 
@@ -42,6 +48,22 @@ func SetCurrentProcessor(name string) { currentProcessor.Store(name) }
 // CurrentProcessor returns the active stamp ("" before any dispatch).
 func CurrentProcessor() string {
 	if v, ok := currentProcessor.Load().(string); ok {
+		return v
+	}
+	return ""
+}
+
+// currentProvider is the provider-lane stamp, set by the loops that know
+// which provider is doing the work (packages, repositories). It fills the
+// provider column of the log view.
+var currentProvider atomic.Value
+
+// SetCurrentProvider stamps subsequent captured records ("" clears).
+func SetCurrentProvider(name string) { currentProvider.Store(name) }
+
+// CurrentProvider returns the active provider stamp.
+func CurrentProvider() string {
+	if v, ok := currentProvider.Load().(string); ok {
 		return v
 	}
 	return ""
@@ -82,8 +104,28 @@ func (s *Store) AttachRunLog(path string) error {
 	return nil
 }
 
-// Append records one line and returns its Seq.
+// Append records one line and returns its Seq. A message with embedded
+// newlines (an error carrying a command's stderr) is split into one record
+// per line: the display budgets height by record, so a single 20-line record
+// would push the frame past the terminal and scroll the dashboard away.
 func (s *Store) Append(record LogRecord) uint64 {
+	if i := strings.IndexByte(record.Msg, '\n'); i >= 0 {
+		lines := strings.Split(record.Msg, "\n")
+		var last uint64
+		for _, line := range lines {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			sub := record
+			sub.Msg = line
+			last = s.appendOne(sub)
+		}
+		return last
+	}
+	return s.appendOne(record)
+}
+
+func (s *Store) appendOne(record LogRecord) uint64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -100,9 +142,14 @@ func (s *Store) Append(record LogRecord) uint64 {
 	s.buf = append(s.buf, record)
 
 	if s.file != nil {
-		// Best-effort by design: a full disk must not take the run down with
-		// the log of the run.
-		fmt.Fprintf(s.file, "%s [%s] %s\n", record.Time.Format(time.RFC3339Nano), record.Processor, record.Msg) //nolint:errcheck // a full disk must not take the run down with its own log
+		// Full fidelity including level and caller - rendering rules are
+		// display-only. Best-effort by design: a full disk must not take the
+		// run down with the log of the run.
+		level := record.Level
+		if level == "" {
+			level = "OUT " // raw command output
+		}
+		fmt.Fprintf(s.file, "%s %s [%s] %s %s\n", record.Time.Format(time.RFC3339Nano), level, record.Processor, record.Msg, record.Caller) //nolint:errcheck // a full disk must not take the run down with its own log
 	}
 
 	for _, view := range s.views {
@@ -206,6 +253,7 @@ func (w *LineWriter) Write(p []byte) (int, error) {
 		}
 		w.Store.Append(LogRecord{
 			Processor: CurrentProcessor(),
+			Provider:  CurrentProvider(),
 			Msg:       line[:len(line)-1],
 			Src:       w.Src,
 			Level:     levelOf(line),
@@ -223,4 +271,101 @@ func levelOf(line string) string {
 		}
 	}
 	return ""
+}
+
+// JSONCaptureWriter parses charm log's JSON formatter output - one object per
+// line - into structured LogRecords. This is the TUI capture path: level,
+// message, timestamp, and caller survive as fields, so the viewport renders
+// them itself and the text formatter's `<file:line>` and level prefixes never
+// reach the screen.
+type JSONCaptureWriter struct {
+	Store *Store
+
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+// shortLevel maps the JSON formatter's level values onto the four-letter
+// forms the display filters use.
+var shortLevel = map[string]string{
+	"debug": "DEBU", "info": "INFO", "warn": "WARN", "error": "ERRO", "fatal": "FATA",
+}
+
+// Write implements io.Writer.
+func (w *JSONCaptureWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf.Write(p)
+	for {
+		line, err := w.buf.ReadString('\n')
+		if err != nil {
+			w.buf.WriteString(line)
+			break
+		}
+		w.Store.Append(w.parse(line[:len(line)-1]))
+	}
+	return len(p), nil
+}
+
+// parse decodes one JSON log line; a line that is not JSON (a stray print)
+// is kept verbatim rather than dropped.
+func (w *JSONCaptureWriter) parse(line string) LogRecord {
+	record := LogRecord{Processor: CurrentProcessor(), Provider: CurrentProvider(), Src: SrcLog}
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(line), &obj); err != nil {
+		record.Msg = line
+		return record
+	}
+
+	if v, ok := obj["msg"].(string); ok {
+		record.Msg = v
+		delete(obj, "msg")
+	}
+	if v, ok := obj["level"].(string); ok {
+		record.Level = shortLevel[v]
+		delete(obj, "level")
+	}
+	if v, ok := obj["caller"].(string); ok {
+		// The formatter emits a full path; the display wants file.go:line.
+		record.Caller = filepath.Base(v)
+		delete(obj, "caller")
+	}
+	if v, ok := obj["time"].(string); ok {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			record.Time = t
+		}
+		delete(obj, "time")
+	}
+	// The logger's own prefix ("rwr: ") is branding, not data.
+	delete(obj, "prefix")
+	// Remaining structured fields append as k=v so nothing is lost.
+	if len(obj) > 0 {
+		keys := make([]string, 0, len(obj))
+		for k := range obj {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			record.Msg += fmt.Sprintf(" %s=%v", k, obj[k])
+		}
+	}
+	return record
+}
+
+// commandSink, when set, receives captured stdout/stderr of non-interactive
+// commands so they render in the log view (the `≫` lines at debug level).
+var commandSink atomic.Pointer[Store]
+
+// SetCommandSink routes captured command output into store (nil clears).
+func SetCommandSink(store *Store) { commandSink.Store(store) }
+
+// CommandOutputWriter returns a writer that records command output lines, or
+// nil when no sink is installed (headless: output flows as it always has).
+func CommandOutputWriter(src Source) io.Writer {
+	store := commandSink.Load()
+	if store == nil {
+		return nil
+	}
+	return &LineWriter{Store: store, Src: src}
 }

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"charm.land/log/v2"
@@ -126,20 +127,21 @@ func ensureSudoCredentials() {
 // runOnTerminal hands cmd the real terminal via the display layer, falling
 // back to direct wiring if the dashboard dies before servicing the request -
 // bubbletea drops Sends after its context cancels, and a dropped TerminalReq
-// would otherwise block its waiter forever.
+// would otherwise block its waiter forever. The claim makes the request
+// run-once: losing it means a servicer is executing the command and its
+// callback will write done regardless of the program's lifetime, so waiting
+// is safe - and Run() is never called twice on the same *exec.Cmd.
 func runOnTerminal(command *exec.Cmd) error {
 	done := make(chan error, 1)
-	reporting.Emit(reporting.TerminalReq{Cmd: command, Done: done})
+	claim := &atomic.Bool{}
+	reporting.Emit(reporting.TerminalReq{Cmd: command, Done: done, Claim: claim})
 	select {
 	case err := <-done:
 		return err
 	case <-reporting.TerminalLost():
-		select {
-		case err := <-done:
-			return err
-		default:
-			// The terminal is free now: wire it directly, exactly as the
-			// LogReporter would have.
+		if claim.CompareAndSwap(false, true) {
+			// Nobody serviced it; the terminal is free now - wire it
+			// directly, exactly as the LogReporter would have.
 			if command.Stdin == nil {
 				command.Stdin = os.Stdin
 			}
@@ -147,6 +149,7 @@ func runOnTerminal(command *exec.Cmd) error {
 			command.Stderr = os.Stderr
 			return command.Run()
 		}
+		return <-done
 	}
 }
 
@@ -220,10 +223,13 @@ func runCommand(cmd types.Command, debug bool) error {
 	{
 		// Under the TUI, captured stderr also streams into the log view (the
 		// `≫` lines); the buffer still holds full text for the error path.
+		// Headless, it streams to the real stderr like the pre-TUI wiring
+		// did - package-manager output must land somewhere the operator
+		// (or their `> install.log` redirect) can see it.
 		if w := reporting.CommandOutputWriter(reporting.SrcStderr); w != nil {
 			command.Stderr = io.MultiWriter(&stderr, w)
 		} else {
-			command.Stderr = &stderr
+			command.Stderr = io.MultiWriter(&stderr, os.Stderr)
 		}
 		logFile, err := setOutputStreams(command, debug, cmd.LogName)
 		if err != nil {
@@ -300,6 +306,9 @@ func setOutputStreams(cmd *exec.Cmd, debug bool, logName string) (*os.File, erro
 
 	// Under the TUI, command stdout is captured into the store so it renders
 	// in the log view at debug display level, instead of tearing the frame.
+	// Headless (no sink), it streams to the real stdout - the pre-TUI
+	// contract is that `rwr all > install.log` carries the package-manager
+	// output, and a nil writer here silently threw it away.
 	captured := reporting.CommandOutputWriter(reporting.SrcStdout)
 
 	if debug {
@@ -313,7 +322,11 @@ func setOutputStreams(cmd *exec.Cmd, debug bool, logName string) (*os.File, erro
 	}
 
 	if logName == "" {
-		cmd.Stdout = captured // nil is fine: exec discards
+		if captured != nil {
+			cmd.Stdout = captured
+		} else {
+			cmd.Stdout = os.Stdout
+		}
 		return nil, nil
 	}
 

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -8,11 +8,14 @@ package system
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+	"time"
 
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/reporting"
@@ -74,6 +77,43 @@ func setupCommandEnvironment(command *exec.Cmd, cmd types.Command) {
 	command.Env = env
 }
 
+// sudoValidatedAt throttles credential validation: sudo's cache lives for
+// minutes, so re-checking before every one of hundreds of elevated commands
+// would be pure overhead.
+var (
+	sudoValidateMu  sync.Mutex
+	sudoValidatedAt time.Time
+)
+
+// ensureSudoCredentials makes sure sudo can run without prompting. When the
+// cached credentials have expired, the password prompt runs as its own
+// terminal handover (`sudo -v`), so under the TUI the dashboard suspends
+// cleanly instead of painting over the prompt.
+func ensureSudoCredentials() error {
+	sudoValidateMu.Lock()
+	defer sudoValidateMu.Unlock()
+
+	if time.Since(sudoValidatedAt) < time.Minute {
+		return nil
+	}
+
+	// Cheap probe: -n never prompts, it just reports whether the cache holds.
+	probe := exec.Command("sudo", "-n", "-v")
+	if err := probe.Run(); err == nil {
+		sudoValidatedAt = time.Now()
+		return nil
+	}
+
+	// Cache expired: ask for the password on the real terminal.
+	done := make(chan error, 1)
+	reporting.Emit(reporting.TerminalReq{Cmd: exec.Command("sudo", "-v"), Done: done})
+	if err := <-done; err != nil {
+		return err
+	}
+	sudoValidatedAt = time.Now()
+	return nil
+}
+
 // dryRunMode controls whether commands are actually executed.
 // When true, RunCommand and RunCommandOutput log the command but skip execution.
 var dryRunMode bool
@@ -131,8 +171,25 @@ func runCommand(cmd types.Command, debug bool) error {
 		}
 		return nil
 	}
+
+	// A captured elevated command can still make sudo prompt: sudo reads the
+	// password from /dev/tty, straight past the captured pipes - under the
+	// TUI the prompt and the dashboard then fight over the terminal and the
+	// dashboard eats half the password. Validate credentials first, through
+	// a proper terminal handover when the cache has expired.
+	if (cmd.Elevated || cmd.AsUser != "") && runtime.GOOS != "windows" {
+		if err := ensureSudoCredentials(); err != nil {
+			return fmt.Errorf("sudo authentication failed: %w", err)
+		}
+	}
 	{
-		command.Stderr = &stderr
+		// Under the TUI, captured stderr also streams into the log view (the
+		// `≫` lines); the buffer still holds full text for the error path.
+		if w := reporting.CommandOutputWriter(reporting.SrcStderr); w != nil {
+			command.Stderr = io.MultiWriter(&stderr, w)
+		} else {
+			command.Stderr = &stderr
+		}
 		logFile, err := setOutputStreams(command, debug, cmd.LogName)
 		if err != nil {
 			return err
@@ -149,7 +206,13 @@ func runCommand(cmd types.Command, debug bool) error {
 	}
 
 	if err := command.Run(); err != nil {
-		log.Errorf("Error running command: %v\nStderr: %s", err, stderr.String())
+		if reporting.CommandOutputWriter(reporting.SrcStderr) != nil {
+			// The TUI already streamed stderr live into the log view;
+			// embedding the whole blob again would render it twice.
+			log.Errorf("Error running command: %v (stderr in the log above)", err)
+		} else {
+			log.Errorf("Error running command: %v\nStderr: %s", err, stderr.String())
+		}
 		return err
 	}
 
@@ -200,13 +263,22 @@ func setOutputStreams(cmd *exec.Cmd, debug bool, logName string) (*os.File, erro
 	log.Debugf("Debug: %v", debug)
 	log.Debugf("Log Name: %v", logName)
 
+	// Under the TUI, command stdout is captured into the store so it renders
+	// in the log view at debug display level, instead of tearing the frame.
+	captured := reporting.CommandOutputWriter(reporting.SrcStdout)
+
 	if debug {
 		log.Debugf("Debug set, configuring stdout for command: %v", cmd.Path)
-		cmd.Stdout = os.Stdout
+		if captured != nil {
+			cmd.Stdout = captured
+		} else {
+			cmd.Stdout = os.Stdout
+		}
 		return nil, nil
 	}
 
 	if logName == "" {
+		cmd.Stdout = captured // nil is fine: exec discards
 		return nil, nil
 	}
 
@@ -226,7 +298,11 @@ func setOutputStreams(cmd *exec.Cmd, debug bool, logName string) (*os.File, erro
 		return nil, fmt.Errorf("error opening log file %q: %w", logName, err)
 	}
 
-	cmd.Stdout = file
+	if captured != nil {
+		cmd.Stdout = io.MultiWriter(file, captured)
+	} else {
+		cmd.Stdout = file
+	}
 	return file, nil
 }
 

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -247,13 +247,9 @@ func runCommand(cmd types.Command, debug bool) error {
 	}
 
 	if err := command.Run(); err != nil {
-		if reporting.CommandOutputWriter(reporting.SrcStderr) != nil {
-			// The TUI already streamed stderr live into the log view;
-			// embedding the whole blob again would render it twice.
-			log.Errorf("Error running command: %v (stderr in the log above)", err)
-		} else {
-			log.Errorf("Error running command: %v\nStderr: %s", err, stderr.String())
-		}
+		// stderr was streamed live (to the log view under the TUI, to the
+		// real stderr headless); repeating the blob here renders it twice.
+		log.Errorf("Error running command: %v (stderr above)", err)
 		return err
 	}
 

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -186,8 +186,6 @@ func runCommand(cmd types.Command, debug bool) error {
 	command := buildCommand(cmd)
 	setupCommandEnvironment(command, cmd)
 
-	var stderr bytes.Buffer
-
 	if cmd.Stdin != "" {
 		// Supplied input wins over the terminal even for an interactive command:
 		// the caller is feeding the tool something specific, and inheriting
@@ -203,7 +201,7 @@ func runCommand(cmd types.Command, debug bool) error {
 		// a TUI suspends itself around the child instead. This path also
 		// serves per-item `interactive: true` inside non-interactive runs.
 		if err := runOnTerminal(command); err != nil {
-			log.Errorf("Error running command: %v\nStderr: %s", err, stderr.String())
+			log.Errorf("Error running command: %v (stderr above)", err)
 			return err
 		}
 		return nil
@@ -221,15 +219,15 @@ func runCommand(cmd types.Command, debug bool) error {
 		ensureSudoCredentials()
 	}
 	{
-		// Under the TUI, captured stderr also streams into the log view (the
-		// `≫` lines); the buffer still holds full text for the error path.
-		// Headless, it streams to the real stderr like the pre-TUI wiring
-		// did - package-manager output must land somewhere the operator
-		// (or their `> install.log` redirect) can see it.
+		// Under the TUI, captured stderr streams into the log view (the `≫`
+		// lines); headless it streams to the real stderr like the pre-TUI
+		// wiring did. No buffer: the error path points at the stream, and
+		// accumulating hundreds of KB of compiler progress just to discard
+		// it unread was pure memory overhead.
 		if w := reporting.CommandOutputWriter(reporting.SrcStderr); w != nil {
-			command.Stderr = io.MultiWriter(&stderr, w)
+			command.Stderr = w
 		} else {
-			command.Stderr = io.MultiWriter(&stderr, os.Stderr)
+			command.Stderr = os.Stderr
 		}
 		logFile, err := setOutputStreams(command, debug, cmd.LogName)
 		if err != nil {

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -20,6 +20,7 @@ import (
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/types"
+	"golang.org/x/term"
 )
 
 // buildCommand creates an *exec.Cmd from the given types.Command.
@@ -85,33 +86,68 @@ var (
 	sudoValidatedAt time.Time
 )
 
-// ensureSudoCredentials makes sure sudo can run without prompting. When the
-// cached credentials have expired, the password prompt runs as its own
-// terminal handover (`sudo -v`), so under the TUI the dashboard suspends
-// cleanly instead of painting over the prompt.
-func ensureSudoCredentials() error {
+// ensureSudoCredentials tries to make sure sudo can run without prompting.
+// When the cached credentials have expired and a real terminal exists, the
+// password prompt runs as its own terminal handover (`sudo -v`), so under
+// the TUI the dashboard suspends cleanly instead of painting over the
+// prompt. Best effort by design: without a tty (CI), or when validation
+// fails (a command-scoped NOPASSWD rule makes `sudo -v` itself want a
+// password), the command proceeds and fails or succeeds on its own terms,
+// exactly as it did before validation existed.
+func ensureSudoCredentials() {
 	sudoValidateMu.Lock()
 	defer sudoValidateMu.Unlock()
 
 	if time.Since(sudoValidatedAt) < time.Minute {
-		return nil
+		return
 	}
 
 	// Cheap probe: -n never prompts, it just reports whether the cache holds.
 	probe := exec.Command("sudo", "-n", "-v")
 	if err := probe.Run(); err == nil {
 		sudoValidatedAt = time.Now()
-		return nil
+		return
+	}
+
+	// No terminal, no prompt: leave it to the command (CI runs are
+	// NOPASSWD or root, where sudo never needed a tty in the first place).
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return
 	}
 
 	// Cache expired: ask for the password on the real terminal.
-	done := make(chan error, 1)
-	reporting.Emit(reporting.TerminalReq{Cmd: exec.Command("sudo", "-v"), Done: done})
-	if err := <-done; err != nil {
-		return err
+	if err := runOnTerminal(exec.Command("sudo", "-v")); err != nil {
+		log.Debugf("sudo validation inconclusive (%v); running the command anyway", err)
+		return
 	}
 	sudoValidatedAt = time.Now()
-	return nil
+}
+
+// runOnTerminal hands cmd the real terminal via the display layer, falling
+// back to direct wiring if the dashboard dies before servicing the request -
+// bubbletea drops Sends after its context cancels, and a dropped TerminalReq
+// would otherwise block its waiter forever.
+func runOnTerminal(command *exec.Cmd) error {
+	done := make(chan error, 1)
+	reporting.Emit(reporting.TerminalReq{Cmd: command, Done: done})
+	select {
+	case err := <-done:
+		return err
+	case <-reporting.TerminalLost():
+		select {
+		case err := <-done:
+			return err
+		default:
+			// The terminal is free now: wire it directly, exactly as the
+			// LogReporter would have.
+			if command.Stdin == nil {
+				command.Stdin = os.Stdin
+			}
+			command.Stdout = os.Stdout
+			command.Stderr = os.Stderr
+			return command.Run()
+		}
+	}
 }
 
 // dryRunMode controls whether commands are actually executed.
@@ -163,9 +199,7 @@ func runCommand(cmd types.Command, debug bool) error {
 		// reporter: LogReporter wires os.Std* exactly as this code used to;
 		// a TUI suspends itself around the child instead. This path also
 		// serves per-item `interactive: true` inside non-interactive runs.
-		done := make(chan error, 1)
-		reporting.Emit(reporting.TerminalReq{Cmd: command, Done: done})
-		if err := <-done; err != nil {
+		if err := runOnTerminal(command); err != nil {
 			log.Errorf("Error running command: %v\nStderr: %s", err, stderr.String())
 			return err
 		}
@@ -176,11 +210,12 @@ func runCommand(cmd types.Command, debug bool) error {
 	// password from /dev/tty, straight past the captured pipes - under the
 	// TUI the prompt and the dashboard then fight over the terminal and the
 	// dashboard eats half the password. Validate credentials first, through
-	// a proper terminal handover when the cache has expired.
+	// a proper terminal handover when the cache has expired. Advisory only:
+	// a failed validation must not fail the command - `sudo -v` is not
+	// command-scoped, so a NOPASSWD rule for just this command makes
+	// validation want a password the command itself never needs.
 	if (cmd.Elevated || cmd.AsUser != "") && runtime.GOOS != "windows" {
-		if err := ensureSudoCredentials(); err != nil {
-			return fmt.Errorf("sudo authentication failed: %w", err)
-		}
+		ensureSudoCredentials()
 	}
 	{
 		// Under the TUI, captured stderr also streams into the log view (the

--- a/internal/system/definitions/brew.cue
+++ b/internal/system/definitions/brew.cue
@@ -3,6 +3,16 @@ package providers
 providers: "brew": {
  "name": "brew",
  "elevated": false,
+ // Homebrew 6 made "ask mode" the default: every install stops at a
+ // "Do you want to proceed? [y/n]" prompt, which deadlocks an automated
+ // run. HOMEBREW_NO_ASK restores unattended installs (older brew ignores
+ // it; a -y flag would be rejected by older brew as an unknown option).
+ // NONINTERACTIVE does the same for Homebrew's official install.sh used
+ // by the bootstrap steps below (it skips the "Press RETURN" prompt).
+ "environment": {
+  "HOMEBREW_NO_ASK": "1",
+  "NONINTERACTIVE": "1"
+ },
  "detection": {
   "binary": "brew",
   "files": [
@@ -109,6 +119,20 @@ providers: "brew": {
       "tap",
       "{{ .URL }}"
      ]
+    },
+    // Homebrew 6 refuses to load formulae/casks from untrusted third-party
+    // taps until `brew trust` records them. Declaring the tap in a blueprint
+    // IS the operator's trust decision, so trust follows the tap. Optional:
+    // older brew has no trust command and must not fail the add.
+    {
+     "action": "command",
+     "exec": "brew",
+     "args": [
+      "trust",
+      "--tap",
+      "{{ .URL }}"
+     ],
+     "optional": true
     }
    ]
   },

--- a/internal/system/definitions/cargo.cue
+++ b/internal/system/definitions/cargo.cue
@@ -16,7 +16,13 @@ providers: "cargo": {
   ]
  },
  "commands": {
-  "install": "install",
+  // --locked: build with each crate's committed Cargo.lock instead of
+  // re-resolving dependencies at install time. Fresh resolution pulls
+  // whatever currently solves, and eza's unlocked solve chose a palette
+  // version that no longer compiles under current rustc (E0433 in its
+  // derive macros). Crates published without a lockfile fall back with a
+  // warning, so this is strictly safer.
+  "install": "install --locked",
   "update": "install-update --all",
   "remove": "uninstall",
   "list": "install --list",

--- a/internal/system/definitions/schema.cue
+++ b/internal/system/definitions/schema.cue
@@ -32,6 +32,10 @@ package providers
 	args?: [...string]
 	content?:   string
 	condition?: string & =~#conditionPattern
+	// A step whose failure is logged but does not fail the action - for
+	// version-dependent tooling (brew 6's `brew trust` does not exist on
+	// older brew).
+	optional?: bool
 }
 
 // Install/remove steps: the package-manager processor implements only these
@@ -46,6 +50,7 @@ package providers
 	args?: [...string & !~"/tmp/"]
 	content?:   string & !~"/tmp/"
 	condition?: string & =~#conditionPattern
+	optional?:  bool
 }
 
 #Detection: {

--- a/internal/system/embedded_test.go
+++ b/internal/system/embedded_test.go
@@ -386,3 +386,47 @@ func containsValidTemplate(content string, validTemplates []string) bool {
 }
 
 // Helper function to parse TOML configuration.
+
+// Homebrew 6 made "ask mode" the default for installs; the brew provider's
+// environment block is what keeps automated runs from stopping at a
+// "Do you want to proceed? [y/n]" prompt (and the official install.sh from
+// stopping at "Press RETURN"). This asserts the CUE environment block actually
+// decodes into Provider.Environment - if the field mapping breaks, brew runs
+// start prompting again with no compile error anywhere.
+func TestLoadEmbeddedProviders_BrewEnvironmentDecodes(t *testing.T) {
+	providers, err := LoadEmbeddedProviders()
+	if err != nil {
+		t.Fatalf("LoadEmbeddedProviders() failed: %v", err)
+	}
+	brew, ok := providers["brew"]
+	if !ok {
+		t.Fatal("brew provider missing")
+	}
+	if brew.Environment["HOMEBREW_NO_ASK"] != "1" {
+		t.Fatalf("brew environment HOMEBREW_NO_ASK not decoded from CUE; got %v", brew.Environment)
+	}
+	if brew.Environment["NONINTERACTIVE"] != "1" {
+		t.Fatalf("brew environment NONINTERACTIVE not decoded from CUE; got %v", brew.Environment)
+	}
+}
+
+// Homebrew 6 refuses formulae/casks from untrusted third-party taps; the brew
+// provider's repository.add must tap and then trust (optional, since older
+// brew has no trust command). Asserts the step and its optional flag decode.
+func TestLoadEmbeddedProviders_BrewTapTrustStep(t *testing.T) {
+	providers, err := LoadEmbeddedProviders()
+	if err != nil {
+		t.Fatalf("LoadEmbeddedProviders() failed: %v", err)
+	}
+	steps := providers["brew"].Repository.Add.Steps
+	if len(steps) < 2 {
+		t.Fatalf("brew repository.add has %d steps, want tap then trust", len(steps))
+	}
+	trust := steps[1]
+	if trust.Exec != "brew" || len(trust.Args) < 2 || trust.Args[0] != "trust" {
+		t.Fatalf("second add step is not brew trust: %+v", trust)
+	}
+	if !trust.Optional {
+		t.Fatal("brew trust step must be optional - older brew has no trust command")
+	}
+}

--- a/internal/system/files.go
+++ b/internal/system/files.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/types"
 )
 
@@ -659,15 +660,23 @@ func CopyDirectory(source, target string, elevated, interactive bool) error {
 			// Check if the file already exists at the target path
 			_, err := os.Stat(targetPath)
 			if err == nil {
-				// File exists, prompt for confirmation if interactive mode is enabled
+				// File exists, prompt for confirmation if interactive mode is
+				// enabled. The whole interaction - notice, diff, question -
+				// holds the terminal lease: printing a multi-line diff and
+				// reading stdin over the dashboard tore the viewport and
+				// fought it for keystrokes.
 				if interactive {
-					fmt.Printf("File '%s' already exists at the target location.\n", targetPath)
-					fmt.Printf("Diff:\n")
-					err := ShowDiff(path, targetPath)
-					if err != nil {
-						log.Errorf("Failed to show diff: %v", err)
-					}
-					overwrite, promptErr := promptOverwrite()
+					var overwrite bool
+					promptErr := reporting.WithTerminal(func() error {
+						fmt.Printf("File '%s' already exists at the target location.\n", targetPath)
+						fmt.Printf("Diff:\n")
+						if diffErr := ShowDiff(path, targetPath); diffErr != nil {
+							log.Errorf("Failed to show diff: %v", diffErr)
+						}
+						var innerErr error
+						overwrite, innerErr = promptOverwrite()
+						return innerErr
+					})
 					if promptErr != nil {
 						return promptErr
 					}

--- a/internal/system/managers.go
+++ b/internal/system/managers.go
@@ -41,7 +41,7 @@ func setDefaultManager(osInfo *types.OSInfo, preferred []string) {
 	for _, name := range preferred {
 		if pm, ok := osInfo.PackageManager.Managers[name]; ok && pm.Bin != "" {
 			osInfo.PackageManager.Default = pm
-			log.Infof("Set %s as default package manager", pm.Name)
+			log.Debugf("Set %s as default package manager", pm.Name)
 			return
 		}
 	}
@@ -55,7 +55,7 @@ func setDefaultManager(osInfo *types.OSInfo, preferred []string) {
 	for _, name := range names {
 		if pm := osInfo.PackageManager.Managers[name]; pm.Bin != "" {
 			osInfo.PackageManager.Default = pm
-			log.Infof("Set %s as default package manager", pm.Name)
+			log.Debugf("Set %s as default package manager", pm.Name)
 			return
 		}
 	}

--- a/internal/system/packages.go
+++ b/internal/system/packages.go
@@ -46,9 +46,10 @@ func InstallOpenSSL(osInfo *types.OSInfo, initConfig *types.InitConfig) error {
 	// Install each package
 	log.Debugf("Installing OpenSSL packages with %s: %v", provider.Name, packages)
 	installCmd := types.Command{
-		Exec:     provider.BinPath,
-		Args:     append(strings.Fields(provider.Commands.Install), packages...),
-		Elevated: provider.Elevated,
+		Exec:      provider.BinPath,
+		Args:      append(strings.Fields(provider.Commands.Install), packages...),
+		Elevated:  provider.Elevated,
+		Variables: provider.Environment,
 	}
 
 	if err := RunCommand(installCmd, initConfig.Variables.Flags.Debug); err != nil {
@@ -99,9 +100,10 @@ func InstallBuildEssentials(osInfo *types.OSInfo, initConfig *types.InitConfig) 
 	// Install each package
 	log.Debugf("Installing build essential packages with %s: %v", provider.Name, packages)
 	installCmd := types.Command{
-		Exec:     provider.BinPath,
-		Args:     append(strings.Fields(provider.Commands.Install), packages...),
-		Elevated: provider.Elevated,
+		Exec:      provider.BinPath,
+		Args:      append(strings.Fields(provider.Commands.Install), packages...),
+		Elevated:  provider.Elevated,
+		Variables: provider.Environment,
 	}
 
 	if err := RunCommand(installCmd, initConfig.Variables.Flags.Debug); err != nil {

--- a/internal/system/prompt.go
+++ b/internal/system/prompt.go
@@ -7,28 +7,42 @@ import (
 	"strings"
 
 	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/reporting"
 )
 
 // PromptUserChoice displays an interactive selection prompt and returns
 // the user's chosen option, falling back to defaultOption on invalid input.
 func PromptUserChoice(prompt string, options []string, defaultOption string) string {
-	reader := bufio.NewReader(os.Stdin)
+	choice := defaultOption
+	// Through the terminal lease: headless this runs directly; under the TUI
+	// the dashboard suspends around it. A bare stdin read while the dashboard
+	// owns the terminal freezes the run.
+	_ = reporting.WithTerminal(func() error { //nolint:errcheck // a failed read falls back to the default
+		reader := bufio.NewReader(os.Stdin)
+		for {
+			fmt.Printf("%s [%s]: ", prompt, strings.Join(options, "/"))
+			input, err := reader.ReadString('\n')
+			input = strings.TrimSpace(input)
 
-	for {
-		fmt.Printf("%s [%s]: ", prompt, strings.Join(options, "/"))
-		input, _ := reader.ReadString('\n') //nolint:errcheck
-		input = strings.TrimSpace(input)
-
-		if input == "" {
-			return defaultOption
-		}
-
-		for _, option := range options {
-			if strings.EqualFold(input, option) {
-				return option
+			if input == "" {
+				choice = defaultOption
+				return err
 			}
-		}
 
-		log.Warnf("Invalid input. Please choose from the available options.")
-	}
+			for _, option := range options {
+				if strings.EqualFold(input, option) {
+					choice = option
+					return nil
+				}
+			}
+			if err != nil {
+				// Stdin is closed or unreadable; looping would spin forever.
+				choice = defaultOption
+				return err
+			}
+
+			log.Warnf("Invalid input. Please choose from the available options.")
+		}
+	})
+	return choice
 }

--- a/internal/system/providers.go
+++ b/internal/system/providers.go
@@ -101,7 +101,10 @@ func GetAvailableProviders() map[string]*types.Provider {
 		if binPath, ok := isProviderAvailable(provider, currentOS, currentDistro); ok {
 			provider.BinPath = binPath
 			available[name] = provider
-			log.Infof("GetAvailableProviders: Provider %s is available with binary at %s", name, binPath)
+			// Debug, not info: detection runs several times per invocation and
+			// at info this printed every provider 3+ times before the TUI even
+			// started. The zero-providers case below stays loud.
+			log.Debugf("GetAvailableProviders: Provider %s is available with binary at %s", name, binPath)
 		}
 	}
 
@@ -129,8 +132,8 @@ func getSystemInfo() (string, string) {
 //
 // Availability is decided by evidence on the machine rather than by what the
 // distribution calls itself. A named distro match is accepted, but so is the
-// combination of "the binary is installed" plus "every file the provider declares
-// as proof of itself exists" - for pacman that is /etc/pacman.conf and
+// combination of "the binary is installed" plus "at least one file the provider
+// declares as proof of itself exists" - for pacman that is /etc/pacman.conf or
 // /var/lib/pacman. There are far more Arch and Debian derivatives than any list
 // can track (this was found on PrismLinux, which no provider names and which sets
 // no ID_LIKE), and a machine that has pacman's binary and pacman's database is
@@ -151,7 +154,7 @@ func isProviderAvailable(provider *types.Provider, currentOS, currentDistro stri
 		return "", false
 	}
 
-	if !areRequiredFilesPresent(provider) {
+	if !anyDetectionFilePresent(provider) {
 		return "", false
 	}
 
@@ -213,24 +216,32 @@ func supportsSystem(provider *types.Provider, currentOS, currentDistro string) b
 	return false
 }
 
-// areRequiredFilesPresent checks that all files listed in provider.Detection.Files exist.
-func areRequiredFilesPresent(provider *types.Provider) bool {
+// anyDetectionFilePresent reports whether at least one of the provider's
+// detection files exists. The lists are alternative evidence, not a checklist:
+// brew declares /usr/local/bin/brew (Intel), /opt/homebrew/bin/brew (Apple
+// Silicon), and two Linuxbrew prefixes - no machine ever has all of them.
+// Requiring every entry rejected brew on every Apple Silicon Mac.
+// An empty list demands nothing.
+func anyDetectionFilePresent(provider *types.Provider) bool {
+	if len(provider.Detection.Files) == 0 {
+		return true
+	}
 	for _, file := range provider.Detection.Files {
 		expandedFile := file
 		if file[0] == '~' {
 			home, err := os.UserHomeDir()
 			if err != nil {
 				log.Debugf("GetAvailableProviders: Provider %s - error expanding %s: %v", provider.Name, file, err)
-				return false
+				continue
 			}
 			expandedFile = filepath.Join(home, file[1:])
 		}
-		if _, err := os.Stat(expandedFile); err != nil {
-			log.Debugf("GetAvailableProviders: Provider %s missing required file: %s", provider.Name, expandedFile)
-			return false
+		if _, err := os.Stat(expandedFile); err == nil {
+			return true
 		}
 	}
-	return true
+	log.Debugf("GetAvailableProviders: Provider %s has none of its detection files: %v", provider.Name, provider.Detection.Files)
+	return false
 }
 
 // GetProvider returns a specific provider by name from the available providers.
@@ -547,7 +558,7 @@ func logDetectionSummary(currentOS, currentDistro string) {
 		log.Debugf("Provider: %s", name)
 		log.Debugf("  Binary: %s", provider.Detection.Binary)
 		log.Debugf("  Supported distributions: %v", provider.Detection.Distributions)
-		log.Debugf("  Required files: %v", provider.Detection.Files)
+		log.Debugf("  Detection files (any-of): %v", provider.Detection.Files)
 
 		compatible := supportsSystem(provider, currentOS, currentDistro)
 		log.Debugf("  System compatible: %v", compatible)
@@ -558,7 +569,7 @@ func logDetectionSummary(currentOS, currentDistro string) {
 			if tool.Exists {
 				log.Debugf("  Binary path: %s", tool.Bin)
 			}
-			log.Debugf("  All files exist: %v", areRequiredFilesPresent(provider))
+			log.Debugf("  Any detection file exists: %v", anyDetectionFilePresent(provider))
 		}
 		log.Debugf("  ---")
 	}

--- a/internal/tui/checklist_test.go
+++ b/internal/tui/checklist_test.go
@@ -83,3 +83,35 @@ func TestPrompting_HaltDecisions(t *testing.T) {
 		}
 	}
 }
+
+// Fresh-machine ghost lane: stage 2 planned unpinned entries into an "items"
+// lane because no provider existed yet; the first runtime LaneUpdate for the
+// resolved provider re-keys that lane instead of leaving it pending forever
+// next to the real one.
+func TestLaneUpdate_RekeysGhostItemsLane(t *testing.T) {
+	plan := &types.Plan{
+		Order: []string{"packages"},
+		Resources: []types.Resource{
+			{Processor: "packages", Provider: "", Name: "jq", Action: "install", Status: types.StatusPlanned},
+			{Processor: "packages", Provider: "", Name: "fd", Action: "install", Status: types.StatusPlanned},
+		},
+	}
+	m := New(mustTheme("rwr"), plan, reporting.NewStore(10), false, "")
+
+	if _, has := m.procs[0].Lanes["items"]; !has {
+		t.Fatal("plan lane for unpinned entries missing")
+	}
+
+	m.apply(reporting.LaneUpdate{Processor: "packages", Provider: "brew", Done: 1, Total: 2, Status: types.StatusOK})
+
+	if _, has := m.procs[0].Lanes["items"]; has {
+		t.Fatal("ghost items lane survived the first provider update")
+	}
+	lane, has := m.procs[0].Lanes["brew"]
+	if !has {
+		t.Fatal("re-keyed brew lane missing")
+	}
+	if lane.Done != 1 || lane.Total != 2 {
+		t.Fatalf("re-keyed lane counts = %d/%d, want 1/2", lane.Done, lane.Total)
+	}
+}

--- a/internal/tui/checklist_test.go
+++ b/internal/tui/checklist_test.go
@@ -115,3 +115,33 @@ func TestLaneUpdate_RekeysGhostItemsLane(t *testing.T) {
 		t.Fatalf("re-keyed lane counts = %d/%d, want 1/2", lane.Done, lane.Total)
 	}
 }
+
+// The mixed fresh-Mac layout: unpinned entries (default provider, planned as
+// "items" because no provider existed at stage 2) alongside entries pinned to
+// cargo. The first brew update must re-key the ghost even though the
+// processor already has a cargo lane.
+func TestLaneUpdate_RekeysGhostAmongPinnedLanes(t *testing.T) {
+	plan := &types.Plan{
+		Order: []string{"packages"},
+		Resources: []types.Resource{
+			{Processor: "packages", Provider: "", Name: "jq", Action: "install", Status: types.StatusPlanned},
+			{Processor: "packages", Provider: "cargo", Name: "eza", Action: "install", Status: types.StatusPlanned},
+		},
+	}
+	m := New(mustTheme("rwr"), plan, reporting.NewStore(10), false, "")
+	if len(m.procs[0].Lanes) != 2 {
+		t.Fatalf("plan lanes = %d, want 2 (items + cargo)", len(m.procs[0].Lanes))
+	}
+
+	m.apply(reporting.LaneUpdate{Processor: "packages", Provider: "brew", Done: 1, Total: 1, Status: types.StatusOK})
+
+	if _, has := m.procs[0].Lanes["items"]; has {
+		t.Fatal("ghost items lane survived despite the pinned cargo lane")
+	}
+	if _, has := m.procs[0].Lanes["brew"]; !has {
+		t.Fatal("brew lane missing after re-key")
+	}
+	if _, has := m.procs[0].Lanes["cargo"]; !has {
+		t.Fatal("cargo lane lost")
+	}
+}

--- a/internal/tui/checklist_test.go
+++ b/internal/tui/checklist_test.go
@@ -1,0 +1,85 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/fynxlabs/rwr/internal/reporting"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// The processor checklist is visible by default during a run: one named row
+// per processor, whatever its state. The collapsed (x) mode remains the
+// space-saving option; it must not be the default - a run whose progress list
+// only appears on hover reads as frozen.
+func TestViewRunning_ChecklistVisibleByDefault(t *testing.T) {
+	plan := &types.Plan{Order: []string{"repositories", "packages", "scripts"}}
+	m := New(mustTheme("rwr"), plan, reporting.NewStore(100), false, "")
+	m.width, m.height = 100, 30
+
+	if !m.expanded {
+		t.Fatal("checklist must be expanded by default")
+	}
+
+	m.procs[0].State = ProcDone
+	m.procs[0].Dur = 2 * time.Second
+	m.procs[1].State = ProcRunning
+	m.procs[1].Started = time.Now()
+	// procs[2] stays pending
+	m.state = Running
+
+	out := m.viewRunning()
+	for _, name := range []string{"repositories", "packages", "scripts"} {
+		if !strings.Contains(out, name) {
+			t.Fatalf("running view missing checklist row for %q:\n%s", name, out)
+		}
+	}
+	if !strings.Contains(out, "pending") {
+		t.Fatalf("pending processor not labeled in checklist:\n%s", out)
+	}
+}
+
+// An interactive halt enters Prompting, and r/s/q answer the executor's
+// decision channel: retry, skip, abort. The keys exist only at a halt.
+func TestPrompting_HaltDecisions(t *testing.T) {
+	for _, tc := range []struct {
+		key  string
+		want reporting.HaltDecision
+	}{
+		{"r", reporting.HaltRetry},
+		{"R", reporting.HaltRetry},
+		{"s", reporting.HaltSkip},
+		{"q", reporting.HaltAbort},
+	} {
+		plan := &types.Plan{Order: []string{"packages"}}
+		m := New(mustTheme("rwr"), plan, reporting.NewStore(10), false, "")
+		m.width, m.height = 100, 30
+
+		decision := make(chan reporting.HaltDecision, 1)
+		m.apply(reporting.HaltReq{Processor: "packages", Err: errors.New("boom"), Decision: decision})
+		if m.state != Prompting {
+			t.Fatalf("state = %v after HaltReq, want Prompting", m.state)
+		}
+
+		// The typeahead grace window swallows keys right after the prompt
+		// appears (leftover child-process input); age past it.
+		m.resumedAt = time.Now().Add(-time.Second)
+
+		m.key(tea.KeyPressMsg{Code: rune(tc.key[0]), Text: tc.key})
+		select {
+		case got := <-decision:
+			if got != tc.want {
+				t.Fatalf("key %q sent %v, want %v", tc.key, got, tc.want)
+			}
+		default:
+			t.Fatalf("key %q sent no decision", tc.key)
+		}
+		if m.state != Running {
+			t.Fatalf("state = %v after decision, want Running", m.state)
+		}
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,10 +1,13 @@
 package tui
 
 import (
+	"io"
 	"strconv"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/log/v2"
 	"github.com/charmbracelet/harmonica"
 	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/types"
@@ -104,8 +107,9 @@ type Model struct {
 	views map[string]*reporting.View
 	scope string // "" = all
 
-	levelFilter  string // "" = all; "ERRO" = errors only
-	stdoutFilter bool
+	levelFilter  string // "" = all; "ERRO" = errors only (e)
+	displayLevel string // "info" (default) | "debug" | "warn"; d cycles
+	showOutput   bool   // o: show captured command output outside debug level
 	search       string
 	searching    bool
 
@@ -124,12 +128,36 @@ type Model struct {
 
 	runLogPath string
 	summaryTab int
-	expanded   bool // collapsed-success line expanded
+
+	// scrollOffset is lines back from the tail (0 = follow); manualHeight is
+	// the user's +/- panel size (0 = automatic); panelMax is the z toggle.
+	scrollOffset int
+	manualHeight int
+	panelMax     bool
+	scopeAll     bool // a: all-processor log scope instead of the selected one
+	changesOnly  bool // c: dry-run summary hides already-present rows
+	lastLogLines int  // log capacity of the last rendered panel
+
+	// halt is the pending interactive-halt request while state == Prompting.
+	halt *reporting.HaltReq
+	// resumedAt is when the terminal last came back from a child process or
+	// a prompt entered Prompting; plain keys within the grace window after
+	// it are typeahead, not commands.
+	resumedAt time.Time
+	// expanded shows the full processor checklist (one named row each);
+	// collapsed compresses successes onto one line for a bigger log panel.
+	// The checklist is the default - a run whose progress list is invisible
+	// until you hover an anonymous strip cell reads as frozen.
+	expanded bool
 
 	// zones maps rendered strip cells and list rows back to processors, so
 	// mouse work survives layout changes instead of hardcoding coordinates.
 	zones   *zone.Manager
 	hovered int // strip index under the pointer; -1 when none
+
+	// mouseCapture drives the frame's MouseMode; m toggles it off so the
+	// terminal's native selection and copy work without holding Shift.
+	mouseCapture bool
 }
 
 // event wraps a reporting.Event for the tea loop.
@@ -141,25 +169,50 @@ type tick time.Time
 // New builds the model for a run over plan.
 func New(theme Theme, plan *types.Plan, store *reporting.Store, dryRun bool, runLogPath string) *Model {
 	m := &Model{
-		theme:      theme,
-		plan:       plan,
-		store:      store,
-		views:      map[string]*reporting.View{"": store.NewView("")},
-		state:      Resolving,
-		started:    time.Now(),
-		dryRun:     dryRun,
-		runLogPath: runLogPath,
-		order:      map[string]int{},
-		focused:    true,
-		notifyMin:  30 * time.Second,
-		zones:      zone.New(),
-		hovered:    -1,
+		theme:        theme,
+		plan:         plan,
+		store:        store,
+		views:        map[string]*reporting.View{"": store.NewView("")},
+		state:        Resolving,
+		started:      time.Now(),
+		dryRun:       dryRun,
+		runLogPath:   runLogPath,
+		order:        map[string]int{},
+		focused:      true,
+		notifyMin:    30 * time.Second,
+		zones:        zone.New(),
+		hovered:      -1,
+		expanded:     true,
+		mouseCapture: true,
+		displayLevel: "info",
 	}
 	for i, name := range plan.Order {
 		proc := &Proc{Name: name, State: ProcPending, Lanes: map[string]*Lane{}}
 		m.procs = append(m.procs, proc)
 		m.order[name] = i
 		m.views[name] = store.NewView(name)
+	}
+	// Lanes come from the resolved plan, not just from runtime events: stage 2
+	// enumerated every declared resource, so each processor's configured
+	// providers render with their real denominators from the first frame
+	// ("brew 0/50 · cargo 0/24"), instead of lanes popping in as the executor
+	// happens to reach them. LaneUpdate refines Done/Total as the run
+	// progresses (profiles can filter the runtime count below the plan's).
+	for _, res := range plan.Resources {
+		i, ok := m.order[res.Processor]
+		if !ok {
+			continue
+		}
+		name := res.Provider
+		if name == "" {
+			name = "items"
+		}
+		lane, ok := m.procs[i].Lanes[name]
+		if !ok {
+			lane = &Lane{Provider: name, spring: harmonica.NewSpring(harmonica.FPS(8), 6.0, 0.9)}
+			m.procs[i].Lanes[name] = lane
+		}
+		lane.Total++
 	}
 	return m
 }
@@ -178,6 +231,15 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 	switch ev := e.(type) {
 	case reporting.ProcStarted:
 		m.state = Running
+		// Execution is sequential: exactly one processor runs at a time. A
+		// second ProcStarted before the prior ProcFinished means the executor
+		// stopped emitting Finished - the bug that showed every started
+		// processor spinning forever. Fail loudly, never silently.
+		for _, proc := range m.procs {
+			if proc.State == ProcRunning && proc.Name != ev.Processor {
+				log.Errorf("TUI invariant broken: %s started while %s is still marked running (missing ProcFinished)", ev.Processor, proc.Name)
+			}
+		}
 		if i, ok := m.order[ev.Processor]; ok {
 			if m.procs[i].State == ProcPending {
 				m.procs[i].State = ProcRunning
@@ -243,8 +305,37 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 			done <- err
 			return execDone{}
 		})
+	case reporting.HaltReq:
+		// Interactive halt: jump to the failing processor, unpin, apply
+		// errors-only so the operator sees why, and wait for r/R/s/q. The
+		// grace window keeps buffered typeahead from answering the prompt
+		// before the operator has even seen it.
+		m.state = Prompting
+		m.halt = &ev
+		m.resumedAt = time.Now()
+		if i, ok := m.order[ev.Processor]; ok {
+			m.cursor = i
+		}
+		m.pinned = false
+		m.levelFilter = "ERRO"
+		return nil
+	case reporting.TerminalFunc:
+		// Same handover as TerminalReq, for in-process interactions (huh
+		// forms, raw prompts): the program releases the terminal, the
+		// interaction runs on it, the dashboard resumes after.
+		m.state = Suspended
+		run := ev.Run
+		done := ev.Done
+		return tea.Exec(funcExec(run), func(err error) tea.Msg {
+			done <- err
+			return execDone{}
+		})
 	case reporting.RunFinished:
-		m.errs = ev.Errs
+		// Append, not replace: All() emits its collected step errors when it
+		// reaches the end, and the runner emits a second RunFinished carrying
+		// the run's own error when the run died early - replacing would let
+		// whichever arrived last erase the other.
+		m.errs = append(m.errs, ev.Errs...)
 		m.finished = time.Now()
 		m.state = SummaryState
 		return m.maybeNotify()
@@ -253,6 +344,17 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 }
 
 type execDone struct{}
+
+// funcExec adapts a plain func to tea.ExecCommand so tea.Exec can hand the
+// terminal to an in-process interaction. The io setters are no-ops: the
+// interaction (a huh form, a stdin read) talks to the real terminal, which
+// tea has released for the duration of Run.
+type funcExec func() error
+
+func (f funcExec) Run() error        { return f() }
+func (funcExec) SetStdin(io.Reader)  {}
+func (funcExec) SetStdout(io.Writer) {}
+func (funcExec) SetStderr(io.Writer) {}
 
 // stripZone and rowZone name a processor's strip cell and list row; the ids
 // differ because a Mark of the same id overwrites the earlier zone.
@@ -278,6 +380,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.apply(msg.e)
 	case execDone:
 		m.state = Running
+		// Typeahead guard: keystrokes buffered while a child owned the
+		// terminal (extra password characters, a stray Enter) are delivered
+		// to the dashboard the moment it resumes. Without a grace period a
+		// leftover 'q' quit the run and a leftover 's' answered a halt
+		// prompt nobody saw.
+		m.resumedAt = time.Now()
 		return m, nil
 	case tick:
 		m.spinnerFrame++
@@ -327,13 +435,30 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.hovered = m.procAt(msg)
 		return m, nil
 	case tea.MouseWheelMsg:
+		// Wheel scrolls the log viewport, 3 lines per tick; scrolling up
+		// disengages follow, scrolling back to the bottom re-engages it.
 		m.pinned = true
+		if msg.Button == tea.MouseWheelUp {
+			m.scrollOffset += 3
+		} else {
+			m.scrollOffset -= 3
+			if m.scrollOffset < 0 {
+				m.scrollOffset = 0
+			}
+		}
 		return m, nil
 	}
 	return m, nil
 }
 
 func (m *Model) key(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	// Typeahead grace: within 750ms of resuming from a terminal handover (or
+	// entering a halt prompt), plain keys are leftover input from the child -
+	// password characters, stray Enters - not commands. ctrl+c always works.
+	if msg.String() != "ctrl+c" && !m.resumedAt.IsZero() && time.Since(m.resumedAt) < 750*time.Millisecond {
+		return m, nil
+	}
+
 	if m.searching {
 		switch msg.String() {
 		case "enter", "esc":
@@ -346,6 +471,31 @@ func (m *Model) key(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			if len(msg.String()) == 1 {
 				m.search += msg.String()
 			}
+		}
+		return m, nil
+	}
+
+	// Prompting: r/R retry, s skip, q abort - these exist only at a halt.
+	if m.state == Prompting && m.halt != nil {
+		switch msg.String() {
+		case "r", "R":
+			m.halt.Decision <- reporting.HaltRetry
+			m.halt = nil
+			m.state = Running
+			m.levelFilter = ""
+			return m, nil
+		case "s":
+			m.halt.Decision <- reporting.HaltSkip
+			m.halt = nil
+			m.state = Running
+			m.levelFilter = ""
+			return m, nil
+		case "q", "ctrl+c":
+			// Abort the run; the summary follows via RunFinished.
+			m.halt.Decision <- reporting.HaltAbort
+			m.halt = nil
+			m.state = Running
+			return m, nil
 		}
 		return m, nil
 	}
@@ -363,22 +513,96 @@ func (m *Model) key(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.cursor > 0 {
 			m.cursor--
 		}
-	case "g":
-		// Unpin and snap back to live.
+	case "g", "f", "end":
+		// Follow: unpin, snap to live, tail the log.
 		m.pinned = false
 		m.cursor = m.live
+		m.scrollOffset = 0
+	case "pgup":
+		m.pinned = true
+		m.scrollOffset += m.panelLogLines()
+	case "pgdn":
+		m.pinned = true
+		m.scrollOffset -= m.panelLogLines()
+		if m.scrollOffset < 0 {
+			m.scrollOffset = 0
+		}
+	case "home":
+		m.pinned = true
+		m.scrollOffset = 1 << 30 // clamped to the top at render
 	case "e":
 		m.levelFilter = toggle(m.levelFilter, "ERRO")
+	case "E":
+		// Jump to the first failure with errors-only applied.
+		for i, proc := range m.procs {
+			if proc.State == ProcFailed || proc.State == ProcDegraded {
+				m.cursor, m.pinned = i, true
+				break
+			}
+		}
+		m.levelFilter = "ERRO"
 	case "o":
-		m.stdoutFilter = !m.stdoutFilter
+		m.showOutput = !m.showOutput
+	case "a":
+		// Scope: selected processor <-> all processors.
+		m.scopeAll = !m.scopeAll
+	case "d":
+		switch m.displayLevel {
+		case "info":
+			m.displayLevel = "debug"
+		case "debug":
+			m.displayLevel = "warn"
+		default:
+			m.displayLevel = "info"
+		}
 	case "/":
 		m.searching = true
 		m.search = ""
+	case "esc":
+		m.search = ""
+	case "n":
+		m.jumpMatch(true)
+	case "N":
+		m.jumpMatch(false)
 	case "x":
 		m.expanded = !m.expanded
-	case "tab":
+	case "m":
+		m.mouseCapture = !m.mouseCapture
+		if !m.mouseCapture {
+			m.hovered = -1
+		}
+	case "+", "=":
+		if m.manualHeight == 0 {
+			m.manualHeight = m.panelLogLines()
+		}
+		m.manualHeight++
+	case "-":
+		if m.manualHeight == 0 {
+			m.manualHeight = m.panelLogLines()
+		}
+		if m.manualHeight > 3 {
+			m.manualHeight--
+		}
+	case "z":
+		m.panelMax = !m.panelMax
+	case "y":
+		// Yank the visible viewport lines (plain text) to the clipboard.
+		return m, tea.SetClipboard(strings.Join(m.plainLines(m.panelLogLines()), "\n"))
+	case "Y":
+		if m.runLogPath != "" {
+			return m, tea.SetClipboard(m.runLogPath)
+		}
+	case "c":
+		if m.dryRun {
+			m.changesOnly = !m.changesOnly
+		}
+	case "tab", "l", "right":
 		if m.state == SummaryState {
 			m.summaryTab = (m.summaryTab + 1) % (len(m.procs) + 1)
+		}
+	case "h", "left":
+		if m.state == SummaryState {
+			m.summaryTab = (m.summaryTab + len(m.procs)) % (len(m.procs) + 1)
 		}
 	}
 	return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -56,6 +56,12 @@ type Lane struct {
 	Total    int
 	Status   types.Status
 
+	// Progress trackers are per blueprint file, so their counts reset when a
+	// processor's next file starts; doneBase/lastDone accumulate across files
+	// so the bar never jumps backwards mid-processor.
+	doneBase int
+	lastDone int
+
 	spring   harmonica.Spring
 	fill     float64
 	velocity float64
@@ -277,7 +283,19 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 				lane = &Lane{Provider: name, spring: harmonica.NewSpring(harmonica.FPS(8), 6.0, 0.9)}
 				m.procs[i].Lanes[name] = lane
 			}
-			lane.Done, lane.Total, lane.Status = ev.Done, ev.Total, ev.Status
+			// Counts accumulate across a processor's blueprint files: each
+			// file gets its own tracker starting at zero, and overwriting
+			// with the new file's counts made the bar jump backwards and
+			// replaced the plan's cross-file denominator.
+			if ev.Done < lane.lastDone {
+				lane.doneBase += lane.lastDone
+			}
+			lane.lastDone = ev.Done
+			lane.Done = lane.doneBase + ev.Done
+			if total := lane.doneBase + ev.Total; total > lane.Total {
+				lane.Total = total
+			}
+			lane.Status = ev.Status
 		}
 	case reporting.ResourceDone:
 		// Move the matching planned resource to its outcome so Summary

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,8 +2,10 @@ package tui
 
 import (
 	"io"
+	"os/exec"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -280,8 +282,22 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 			}
 			lane, ok := m.procs[i].Lanes[name]
 			if !ok {
-				lane = &Lane{Provider: name, spring: harmonica.NewSpring(harmonica.FPS(8), 6.0, 0.9)}
-				m.procs[i].Lanes[name] = lane
+				// Fresh-machine case: stage 2 ran before the package manager
+				// was installed, so unpinned entries planned into an "items"
+				// lane no runtime update will ever key. When the first real
+				// provider update arrives and the untouched "items" lane is
+				// the processor's only one, it IS those entries - re-key it
+				// instead of leaving a ghost pending at 0/N forever.
+				if ghost, has := m.procs[i].Lanes["items"]; has && name != "items" &&
+					len(m.procs[i].Lanes) == 1 && ghost.Done == 0 && ghost.doneBase == 0 {
+					delete(m.procs[i].Lanes, "items")
+					ghost.Provider = name
+					m.procs[i].Lanes[name] = ghost
+					lane = ghost
+				} else {
+					lane = &Lane{Provider: name, spring: harmonica.NewSpring(harmonica.FPS(8), 6.0, 0.9)}
+					m.procs[i].Lanes[name] = lane
+				}
 			}
 			// Counts accumulate across a processor's blueprint files: each
 			// file gets its own tracker starting at zero, and overwriting
@@ -317,9 +333,13 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 		}
 	case reporting.TerminalReq:
 		m.state = Suspended
-		cmd := ev.Cmd
 		done := ev.Done
-		return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		// The claim is taken inside the exec itself (which bubbletea runs
+		// inline on the event loop, where the program cannot die mid-way):
+		// claiming any earlier risks the program exiting between claim and
+		// exec, leaving a claimed-but-never-serviced request whose waiter
+		// blocks forever.
+		return tea.Exec(claimedExec{cmd: ev.Cmd, claim: ev.Claim}, func(err error) tea.Msg {
 			done <- err
 			return execDone{}
 		})
@@ -340,11 +360,18 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 	case reporting.TerminalFunc:
 		// Same handover as TerminalReq, for in-process interactions (huh
 		// forms, raw prompts): the program releases the terminal, the
-		// interaction runs on it, the dashboard resumes after.
+		// interaction runs on it, the dashboard resumes after. Claimed at
+		// run time for the same reason as TerminalReq above.
 		m.state = Suspended
 		run := ev.Run
+		claim := ev.Claim
 		done := ev.Done
-		return tea.Exec(funcExec(run), func(err error) tea.Msg {
+		return tea.Exec(funcExec(func() error {
+			if !reporting.TryClaim(claim) {
+				return nil // the waiter's fallback already ran it
+			}
+			return run()
+		}), func(err error) tea.Msg {
 			done <- err
 			return execDone{}
 		})
@@ -362,6 +389,41 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 }
 
 type execDone struct{}
+
+// claimedExec wraps an *exec.Cmd as a tea.ExecCommand whose Run first takes
+// the request's claim: if the waiter's terminal-lost fallback already ran
+// the command, Run is a no-op instead of a second execution. The io setters
+// mirror bubbletea's own osExecCommand (fill only when unset, so a preset
+// Stdin survives).
+type claimedExec struct {
+	cmd   *exec.Cmd
+	claim *atomic.Bool
+}
+
+func (c claimedExec) Run() error {
+	if !reporting.TryClaim(c.claim) {
+		return nil
+	}
+	return c.cmd.Run()
+}
+
+func (c claimedExec) SetStdin(r io.Reader) {
+	if c.cmd.Stdin == nil {
+		c.cmd.Stdin = r
+	}
+}
+
+func (c claimedExec) SetStdout(w io.Writer) {
+	if c.cmd.Stdout == nil {
+		c.cmd.Stdout = w
+	}
+}
+
+func (c claimedExec) SetStderr(w io.Writer) {
+	if c.cmd.Stderr == nil {
+		c.cmd.Stderr = w
+	}
+}
 
 // funcExec adapts a plain func to tea.ExecCommand so tea.Exec can hand the
 // terminal to an in-process interaction. The io setters are no-ops: the
@@ -494,25 +556,28 @@ func (m *Model) key(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Prompting: r/R retry, s skip, q abort - these exist only at a halt.
+	// The claim guarantees exactly one answer: if the terminal-lost
+	// fallback already aborted this halt, the keypress must not answer too.
 	if m.state == Prompting && m.halt != nil {
-		switch msg.String() {
-		case "r", "R":
-			m.halt.Decision <- reporting.HaltRetry
+		answer := func(d reporting.HaltDecision) {
+			if reporting.TryClaim(m.halt.Claim) {
+				m.halt.Decision <- d
+			}
 			m.halt = nil
 			m.state = Running
+		}
+		switch msg.String() {
+		case "r", "R":
+			answer(reporting.HaltRetry)
 			m.levelFilter = ""
 			return m, nil
 		case "s":
-			m.halt.Decision <- reporting.HaltSkip
-			m.halt = nil
-			m.state = Running
+			answer(reporting.HaltSkip)
 			m.levelFilter = ""
 			return m, nil
 		case "q", "ctrl+c":
 			// Abort the run; the summary follows via RunFinished.
-			m.halt.Decision <- reporting.HaltAbort
-			m.halt = nil
-			m.state = Running
+			answer(reporting.HaltAbort)
 			return m, nil
 		}
 		return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -284,12 +284,13 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 			if !ok {
 				// Fresh-machine case: stage 2 ran before the package manager
 				// was installed, so unpinned entries planned into an "items"
-				// lane no runtime update will ever key. When the first real
-				// provider update arrives and the untouched "items" lane is
-				// the processor's only one, it IS those entries - re-key it
+				// lane no runtime update will ever key. Unpinned entries all
+				// resolve to the one default provider, so when a provider
+				// update arrives with no lane of its own and the "items" lane
+				// is untouched, that lane IS those entries - re-key it
 				// instead of leaving a ghost pending at 0/N forever.
 				if ghost, has := m.procs[i].Lanes["items"]; has && name != "items" &&
-					len(m.procs[i].Lanes) == 1 && ghost.Done == 0 && ghost.doneBase == 0 {
+					ghost.Done == 0 && ghost.doneBase == 0 {
 					delete(m.procs[i].Lanes, "items")
 					ghost.Provider = name
 					m.procs[i].Lanes[name] = ghost

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -2,11 +2,14 @@ package tui
 
 import (
 	"fmt"
+	"regexp"
+	"sort"
 	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/types"
 )
 
@@ -15,9 +18,66 @@ import (
 func (m *Model) View() tea.View {
 	// Scan registers the zone marks the renderers injected and strips their
 	// escape sequences; all-motion mouse mode is what delivers hover events.
+	// m toggles capture off so terminal-native selection and copy work.
 	view := tea.NewView(m.zones.Scan(m.render()))
-	view.MouseMode = tea.MouseModeAllMotion
+	if m.mouseCapture {
+		view.MouseMode = tea.MouseModeAllMotion
+	} else {
+		view.MouseMode = tea.MouseModeNone
+	}
+	// The dashboard is a full-frame app: the alternate screen buffer is what
+	// keeps frames from smearing into the terminal's scrollback. Focus
+	// reporting feeds the completion notification's unfocused gate.
+	view.AltScreen = true
+	view.ReportFocus = true
+	view.WindowTitle = m.windowTitle()
+	view.ProgressBar = m.taskbarProgress()
 	return view
+}
+
+// windowTitle names the run in the terminal tab.
+func (m *Model) windowTitle() string {
+	failed := 0
+	for _, proc := range m.procs {
+		if proc.State == ProcFailed || proc.State == ProcDegraded {
+			failed++
+		}
+	}
+	switch {
+	case m.state == SummaryState && failed > 0:
+		return fmt.Sprintf("rwr · done · %d failed", failed)
+	case m.state == SummaryState:
+		return "rwr · done"
+	default:
+		return "rwr · running"
+	}
+}
+
+// taskbarProgress emits OSC 9;4: overall run percent from finished
+// processors, error state on the first failure. Passive state, not an alert -
+// terminals that don't render it ignore it.
+func (m *Model) taskbarProgress() *tea.ProgressBar {
+	if len(m.procs) == 0 {
+		return nil
+	}
+	finished, failed := 0, 0
+	for _, proc := range m.procs {
+		switch proc.State {
+		case ProcDone, ProcSkipped:
+			finished++
+		case ProcFailed, ProcDegraded:
+			finished++
+			failed++
+		}
+	}
+	if m.state == SummaryState {
+		return nil // clear it when the run ends
+	}
+	state := tea.ProgressBarDefault
+	if failed > 0 {
+		state = tea.ProgressBarError
+	}
+	return tea.NewProgressBar(state, finished*100/len(m.procs))
 }
 
 func (m *Model) render() string {
@@ -101,16 +161,23 @@ func (m *Model) viewStrip() string {
 		if i == m.hovered {
 			st = st.Reverse(true)
 		}
-		b.WriteString(m.zones.Mark(stripZone(i), st.Render(glyph)))
+		// Two cells plus separator: a 1-cell block is too small a mouse
+		// target; the separator keeps neighbors from reading as one bar.
+		b.WriteString(m.zones.Mark(stripZone(i), st.Render(glyph+glyph)) + " ")
 	}
 	if m.hovered >= 0 && m.hovered < len(m.procs) {
-		b.WriteString(" " + style(m.theme.Subtext).Render(m.procs[m.hovered].Name))
+		b.WriteString(style(m.theme.Subtext).Render(m.procs[m.hovered].Name))
 	}
 	return b.String()
 }
 
-// collapsed: successful processors compress onto one shared line; failed and
-// degraded always keep a full row with the reason in place of a duration.
+// viewCollapsed renders the processor checklist. Expanded (the default),
+// every processor keeps its own named row - done with a duration, running
+// with its elapsed clock, pending dimmed, failed with the reason - so the
+// run's shape is always on screen without hovering anything. Collapsed
+// (toggle with x), successful processors compress onto one shared line to
+// give the log panel the vertical space; failed and degraded always keep a
+// full row either way.
 func (m *Model) viewCollapsed() []string {
 	var lines []string
 	var done []string
@@ -120,22 +187,48 @@ func (m *Model) viewCollapsed() []string {
 		if i == m.hovered {
 			nameStyle = nameStyle.Underline(true)
 		}
+		glyph, st := m.glyphFor(proc.State)
+		row := func(detail string) string {
+			return m.zones.Mark(rowZone(i), fmt.Sprintf(" %s %s %s", st.Render(glyph), nameStyle.Render(fmt.Sprintf("%-16s", proc.Name)), detail))
+		}
 		switch proc.State {
 		case ProcDone:
 			if m.expanded {
-				glyph, st := m.glyphFor(proc.State)
-				lines = append(lines, m.zones.Mark(rowZone(i), fmt.Sprintf(" %s %s %s", st.Render(glyph), nameStyle.Render(fmt.Sprintf("%-16s", proc.Name)), style(m.theme.Muted).Render(proc.Dur.Round(time.Millisecond*100).String()))))
+				lines = append(lines, row(style(m.theme.Muted).Render(proc.Dur.Round(time.Millisecond*100).String())))
 			} else {
 				done = append(done, proc.Name)
 				doneDur += proc.Dur
 			}
 		case ProcFailed, ProcDegraded:
-			glyph, st := m.glyphFor(proc.State)
 			reason := ""
 			if proc.Err != nil {
-				reason = proc.Err.Error()
+				// One line no matter what the error carries: an embedded
+				// newline in a checklist row breaks the whole height budget.
+				reason = strings.ReplaceAll(proc.Err.Error(), "\n", " · ")
 			}
-			lines = append(lines, m.zones.Mark(rowZone(i), fmt.Sprintf(" %s %s %s", st.Render(glyph), nameStyle.Render(fmt.Sprintf("%-16s", proc.Name)), style(m.theme.Danger).Render(truncate(reason, m.width-24)))))
+			lines = append(lines, row(style(m.theme.Danger).Render(truncate(reason, m.width-24))))
+			// Failed subtrees never fold: the lanes stay visible so the
+			// failing provider is identifiable at a glance.
+			if m.expanded && len(proc.Lanes) > 0 {
+				lines = append(lines, m.laneRows(proc)...)
+			}
+		case ProcRunning:
+			if m.expanded {
+				lines = append(lines, row(style(m.theme.Muted).Render(time.Since(proc.Started).Round(time.Second).String())))
+				// Provider lanes nest under their processor's checklist row:
+				//   ⠧ packages        12s
+				//      brew   ███░░ 66/107
+				//      cargo  ░░░░░ 0/19
+				lines = append(lines, m.laneRows(proc)...)
+			}
+		case ProcSkipped:
+			if m.expanded {
+				lines = append(lines, row(style(m.theme.Muted).Render("skipped")))
+			}
+		case ProcPending:
+			if m.expanded {
+				lines = append(lines, row(style(m.theme.Dim).Render("pending")))
+			}
 		}
 	}
 	if len(done) > 0 && !m.expanded {
@@ -148,8 +241,44 @@ func (m *Model) viewCollapsed() []string {
 	return lines
 }
 
-// panel: the active processor with provider lanes and its log viewport. The
-// border takes the worst lane state.
+// laneRows renders a processor's provider lanes as indented checklist rows,
+// sorted so the map's random iteration cannot re-shuffle them every frame.
+// Each child row carries its own glyph; a done lane keeps its full bar with ✓
+// appended (per the normative frame). Denominators are declared resources,
+// not operations: 37/112 with the log carrying the rest, never implying the
+// count is total work.
+func (m *Model) laneRows(proc *Proc) []string {
+	laneNames := make([]string, 0, len(proc.Lanes))
+	for name := range proc.Lanes {
+		laneNames = append(laneNames, name)
+	}
+	sort.Strings(laneNames)
+	rows := make([]string, 0, len(laneNames))
+	for _, name := range laneNames {
+		lane := proc.Lanes[name]
+		bar := renderFillBar(lane.fill, 20, m.theme.Glyphs)
+		g := m.theme.Glyphs
+		var glyph, suffix string
+		switch {
+		case lane.Status == types.StatusFailed:
+			glyph = style(m.theme.Danger).Render(g.Failed)
+		case lane.Total > 0 && lane.Done >= lane.Total:
+			glyph = style(m.theme.Success).Render(g.Done)
+			suffix = " " + style(m.theme.Success).Render(g.Done)
+		case proc.State == ProcRunning:
+			glyph = style(m.theme.Accent).Render(g.Spinner[m.spinnerFrame%len(g.Spinner)])
+		default:
+			glyph = style(m.theme.Dim).Render(g.Pending)
+		}
+		rows = append(rows, fmt.Sprintf("    %s %-8s %s %d/%d%s", glyph, lane.Provider, bar, lane.Done, lane.Total, suffix))
+	}
+	return rows
+}
+
+// panel: the selected processor's log viewport. Its provider lanes live
+// nested under the processor's checklist row, not in here; collapsed mode
+// (which has no running rows to nest under) keeps them at the top of the
+// panel so progress stays visible. The border takes the worst lane state.
 func (m *Model) viewPanel(height int) string {
 	if m.cursor >= len(m.procs) || height < 3 {
 		return ""
@@ -158,15 +287,17 @@ func (m *Model) viewPanel(height int) string {
 	_, borderStyle := m.glyphFor(proc.State)
 
 	var b strings.Builder
-	for _, lane := range proc.Lanes {
-		bar := renderFillBar(lane.fill, 20, m.theme.Glyphs)
-		// Denominators are declared resources, not operations: 37/112 with
-		// the log carrying the rest, never implying the count is total work.
-		fmt.Fprintf(&b, " %-12s %s %d/%d\n", lane.Provider, bar, lane.Done, lane.Total)
+	laneCount := 0
+	if !m.expanded {
+		laneRows := m.laneRows(proc)
+		laneCount = len(laneRows)
+		for _, row := range laneRows {
+			b.WriteString(row + "\n")
+		}
 	}
 
 	// Log viewport: the per-processor view, with global filters on top.
-	logLines := m.filteredLines(height - len(proc.Lanes) - 2)
+	logLines := m.filteredLines(height - laneCount - 2)
 	for _, line := range logLines {
 		b.WriteString(" " + truncate(line, m.width-4) + "\n")
 	}
@@ -183,29 +314,193 @@ func (m *Model) viewPanel(height int) string {
 	return panel
 }
 
-// filteredLines applies the global level/stdout/search filters to a view.
+// visibleRecords applies the display level and output filters to the active
+// view. Search highlights rather than filters, so it does not remove lines.
+func (m *Model) visibleRecords() []recordView {
+	records := m.records()
+	out := records[:0:0]
+	for _, record := range records {
+		if m.recordVisible(record) {
+			out = append(out, record)
+		}
+	}
+	return out
+}
+
+// window slices the tail window of lines honoring the scroll offset, and
+// clamps the offset so scrolling past the top sticks at the top.
+func (m *Model) window(total, max int) (start, end int) {
+	if total <= max {
+		m.scrollOffset = 0
+		return 0, total
+	}
+	if m.scrollOffset > total-max {
+		m.scrollOffset = total - max
+	}
+	end = total - m.scrollOffset
+	return end - max, end
+}
+
+// filteredLines renders the visible tail window of the active view.
 func (m *Model) filteredLines(max int) []string {
 	if max < 3 {
 		max = 3 // active panel minimum, per the space priority
 	}
-	records := m.records()
-	var lines []string
-	for _, record := range records {
-		if m.levelFilter != "" && record.Level != m.levelFilter {
-			continue
-		}
-		if m.stdoutFilter && record.Src == 0 {
-			continue
-		}
-		if m.search != "" && !strings.Contains(strings.ToLower(record.Msg), strings.ToLower(m.search)) {
-			continue
-		}
-		lines = append(lines, record.Msg)
+	records := m.visibleRecords()
+	start, end := m.window(len(records), max)
+	lines := make([]string, 0, end-start)
+	for _, record := range records[start:end] {
+		lines = append(lines, m.renderRecord(record))
 	}
-	if len(lines) > max {
-		lines = lines[len(lines)-max:]
+	m.lastLogLines = max
+	return lines
+}
+
+// plainLines is the same window without styling, for the y yank.
+func (m *Model) plainLines(max int) []string {
+	if max < 3 {
+		max = 3
+	}
+	records := m.visibleRecords()
+	start, end := m.window(len(records), max)
+	lines := make([]string, 0, end-start)
+	for _, record := range records[start:end] {
+		line := record.Time.Format("15:04:05") + " "
+		if record.Provider != "" {
+			line += record.Provider + " "
+		}
+		line += normalizeMsg(record.Msg)
+		lines = append(lines, line)
 	}
 	return lines
+}
+
+// panelLogLines is the log capacity of the last rendered panel; key handlers
+// use it for page and resize step sizes.
+func (m *Model) panelLogLines() int {
+	if m.lastLogLines < 3 {
+		return 10
+	}
+	return m.lastLogLines
+}
+
+// jumpMatch scrolls the viewport to the next search match: older (above the
+// window) for n, newer for N. No-op without an active search.
+func (m *Model) jumpMatch(older bool) {
+	if m.search == "" {
+		return
+	}
+	records := m.visibleRecords()
+	max := m.panelLogLines()
+	start, end := m.window(len(records), max)
+	needle := strings.ToLower(m.search)
+	if older {
+		for i := start - 1; i >= 0; i-- {
+			if strings.Contains(strings.ToLower(records[i].Msg), needle) {
+				m.scrollOffset = len(records) - i - 1
+				m.pinned = true
+				return
+			}
+		}
+		return
+	}
+	for i := end; i < len(records); i++ {
+		if strings.Contains(strings.ToLower(records[i].Msg), needle) {
+			m.scrollOffset = len(records) - i - 1
+			if m.scrollOffset < 0 {
+				m.scrollOffset = 0
+			}
+			return
+		}
+	}
+}
+
+// recordVisible applies the display level (`d` cycles info/debug/warn), the
+// errors-only toggle (`e`), and the output toggle (`o`).
+func (m *Model) recordVisible(record recordView) bool {
+	if m.levelFilter == "ERRO" { // errors only
+		return record.Level == "ERRO" || record.Level == "FATA" || record.Src == int(reporting.SrcStderr)
+	}
+	if record.Src != int(reporting.SrcLog) {
+		// Captured command output: shown at debug display level, or when o
+		// forces it on; hidden otherwise.
+		return m.displayLevel == "debug" || m.showOutput
+	}
+	switch m.displayLevel {
+	case "debug":
+		return true
+	case "warn":
+		return record.Level == "WARN" || record.Level == "ERRO" || record.Level == "FATA"
+	default: // info
+		return record.Level != "DEBU"
+	}
+}
+
+// renderRecord renders one log line from its fields, per the design: time
+// (dim) · level glyph · provider (dim) · message · caller (debug only, dim).
+// The logger's own formatted text never reaches the screen.
+func (m *Model) renderRecord(record recordView) string {
+	ascii := m.theme.Glyphs.Done == "+"
+	glyph := m.logGlyph(record, ascii)
+
+	var b strings.Builder
+	if !record.Time.IsZero() {
+		b.WriteString(style(m.theme.Dim).Render(record.Time.Format("15:04:05")) + " ")
+	}
+	b.WriteString(glyph + " ")
+	if record.Provider != "" {
+		b.WriteString(style(m.theme.Muted).Render(fmt.Sprintf("%-6s", record.Provider)) + " ")
+	}
+	msg := normalizeMsg(record.Msg)
+	if m.search != "" {
+		// Highlight in place rather than filtering the line away.
+		if i := strings.Index(strings.ToLower(msg), strings.ToLower(m.search)); i >= 0 {
+			msg = msg[:i] + style(m.theme.Accent).Reverse(true).Render(msg[i:i+len(m.search)]) + msg[i+len(m.search):]
+		}
+	}
+	b.WriteString(msg)
+	if m.displayLevel == "debug" && record.Caller != "" {
+		b.WriteString("  " + style(m.theme.Dim).Render(record.Caller))
+	}
+	return b.String()
+}
+
+// logGlyph maps a record's level and source onto its display glyph.
+func (m *Model) logGlyph(record recordView, ascii bool) string {
+	switch {
+	case record.Src == int(reporting.SrcStderr):
+		return style(m.theme.Danger).Render(pick(ascii, ">>", "≫"))
+	case record.Src == int(reporting.SrcStdout):
+		return style(m.theme.Muted).Render(pick(ascii, ">>", "≫"))
+	case record.Level == "ERRO" || record.Level == "FATA":
+		return style(m.theme.Danger).Render(pick(ascii, "x", "✗"))
+	case record.Level == "WARN":
+		return style(m.theme.Warning).Render(pick(ascii, "!", "⚠"))
+	case record.Level == "DEBU":
+		return style(m.theme.Dim).Render(pick(ascii, ".", "·"))
+	default:
+		return style(m.theme.Subtext).Render(pick(ascii, ">", "›"))
+	}
+}
+
+func pick(ascii bool, a, u string) string {
+	if ascii {
+		return a
+	}
+	return u
+}
+
+// successfullyRe matches rwr's own success boilerplate so the viewport can
+// render "installed X" - the provider is already its own column.
+var successfullyRe = regexp.MustCompile(`^Successfully (\S+) package (\S+) via \S+$`)
+
+// normalizeMsg compresses known message shapes; unknown messages render
+// verbatim. Display-only - the run log keeps the full text.
+func normalizeMsg(msg string) string {
+	if match := successfullyRe.FindStringSubmatch(msg); match != nil {
+		return match[1] + " " + match[2]
+	}
+	return msg
 }
 
 // help bar; collapses to `? help` when space is short.
@@ -213,7 +508,15 @@ func (m *Model) viewHelp(short bool) string {
 	if short {
 		return style(m.theme.Dim).Render(" ? help")
 	}
-	keys := " j/k select · g follow · e errors · o stdout · / search · x expand · q quit"
+	// Arrows are what the bar advertises; vim keys work but are not required.
+	arrows := "↑↓"
+	if m.theme.Glyphs.Done == "+" {
+		arrows = "arrows"
+	}
+	keys := " " + arrows + " move · g follow · d level · e errors · o output · / search · +/- size · z zoom · x collapse · m mouse · ? help · q quit"
+	if !m.expanded {
+		keys = " " + arrows + " move · g follow · d level · e errors · o output · / search · +/- size · z zoom · x expand · m mouse · ? help · q quit"
+	}
 	if m.searching {
 		keys = " search: " + m.search + "▌"
 	}
@@ -234,21 +537,63 @@ func (m *Model) viewRunning() string {
 	var b strings.Builder
 	b.WriteString(m.viewHeader() + "\n")
 	b.WriteString(m.viewStrip() + "\n")
+
 	collapsed := m.viewCollapsed()
+	if m.panelMax {
+		// z: the panel takes everything except header and strip; failed rows
+		// are the one thing the checklist would never give up, and the strip
+		// and header counter still carry them.
+		collapsed = nil
+	} else if m.manualHeight > 0 {
+		// +/-: the user's height wins; pending rows are the first sacrifice
+		// (they render at the end of the expanded checklist).
+		want := m.manualHeight + 2 // border rows
+		excess := 4 + len(collapsed) + want - m.height
+		for excess > 0 && len(collapsed) > 0 {
+			collapsed = collapsed[:len(collapsed)-1]
+			excess--
+		}
+	}
 	for _, line := range collapsed {
 		b.WriteString(line + "\n")
 	}
+
 	panelHeight := m.height - 4 - len(collapsed)
-	b.WriteString(m.viewPanel(panelHeight) + "\n")
-	// pending chips
-	var pending []string
-	for _, proc := range m.procs {
-		if proc.State == ProcPending {
-			pending = append(pending, proc.Name)
+	if m.manualHeight > 0 && !m.panelMax {
+		want := m.manualHeight + 2
+		if want < 5 {
+			want = 5
+		}
+		if want < panelHeight {
+			panelHeight = want
 		}
 	}
-	if len(pending) > 0 {
-		b.WriteString(style(m.theme.Dim).Render(truncate(" pending: "+strings.Join(pending, " "), m.width)) + "\n")
+	if m.panelMax {
+		panelHeight = m.height - 3
+	}
+	b.WriteString(m.viewPanel(panelHeight) + "\n")
+	// pending chips - only in collapsed mode; the expanded checklist already
+	// has a named row per pending processor.
+	if !m.expanded && !m.panelMax {
+		var pending []string
+		for _, proc := range m.procs {
+			if proc.State == ProcPending {
+				pending = append(pending, proc.Name)
+			}
+		}
+		if len(pending) > 0 {
+			b.WriteString(style(m.theme.Dim).Render(truncate(" pending: "+strings.Join(pending, " "), m.width)) + "\n")
+		}
+	}
+	if m.state == Prompting && m.halt != nil {
+		// The halt prompt replaces the help bar; r/R/s/q only exist here.
+		reason := ""
+		if m.halt.Err != nil {
+			reason = truncate(strings.ReplaceAll(m.halt.Err.Error(), "\n", " · "), m.width-40)
+		}
+		b.WriteString(style(m.theme.Danger).Render(" "+m.theme.Glyphs.Failed+" "+m.halt.Processor+" failed: "+reason) + "\n")
+		b.WriteString(style(m.theme.Warning).Render(" r retry · R redo processor · s skip · q abort"))
+		return b.String()
 	}
 	b.WriteString(m.viewHelp(m.height < 20))
 	return b.String()
@@ -272,11 +617,17 @@ func (m *Model) viewSummary() string {
 	}
 	b.WriteString(" " + truncate(strings.Join(tabLine, "  "), m.width) + "\n\n")
 
-	applied, skipped, failed, unknown := 0, 0, 0, 0
+	// Planned is its own bucket: in dry-run vocabulary it is "would apply",
+	// but in a real run a resource still Planned at summary time NEVER RAN
+	// (the run died before its processor started). Folding it into "applied"
+	// made a run that failed before doing anything report "applied 237".
+	applied, skipped, failed, planned, unknown := 0, 0, 0, 0, 0
 	for _, res := range m.plan.Resources {
 		switch res.Status {
-		case types.StatusOK, types.StatusPlanned:
+		case types.StatusOK:
 			applied++
+		case types.StatusPlanned:
+			planned++
 		case types.StatusSkipped, types.StatusPresent:
 			skipped++
 		case types.StatusFailed:
@@ -306,6 +657,11 @@ func (m *Model) viewSummary() string {
 			if m.search != "" && !strings.Contains(res.Name, m.search) {
 				continue
 			}
+			// c (dry run): changes only - most runs on an existing machine
+			// are mostly no-ops, hide the already-present rows.
+			if m.changesOnly && res.Status == types.StatusPresent {
+				continue
+			}
 			glyph := m.statusGlyph(res.Status)
 			fmt.Fprintf(&b, " %s %-10s %-24s %s\n", glyph, res.Provider, truncate(res.Name, 24), res.Action)
 			count++
@@ -318,9 +674,13 @@ func (m *Model) viewSummary() string {
 
 	b.WriteString("\n")
 	if m.dryRun {
-		b.WriteString(style(m.theme.Muted).Render(fmt.Sprintf(" would apply %d · already present %d · unresolved %d", applied, skipped, unknown)) + "\n")
+		b.WriteString(style(m.theme.Muted).Render(fmt.Sprintf(" would apply %d · already present %d · unresolved %d", applied+planned, skipped, unknown)) + "\n")
 	} else {
-		b.WriteString(style(m.theme.Muted).Render(fmt.Sprintf(" applied %d · skipped %d · failed %d · unknown %d", applied, skipped, failed, unknown)) + "\n")
+		counts := fmt.Sprintf(" applied %d · skipped %d · failed %d · unknown %d", applied, skipped, failed, unknown)
+		if planned > 0 {
+			counts += fmt.Sprintf(" · never ran %d", planned)
+		}
+		b.WriteString(style(m.theme.Muted).Render(counts) + "\n")
 	}
 	if m.runLogPath != "" {
 		b.WriteString(style(m.theme.Dim).Render(" run log: "+m.runLogPath) + "\n")
@@ -382,22 +742,38 @@ func (m *Model) viewCompact() string {
 }
 
 func (m *Model) records() []recordView {
-	view := m.views[m.scope]
+	// The panel is the selected processor's view, per the design ("the active
+	// processor with provider lanes and its log viewport") - the global
+	// stream made sequential processors look interleaved. `a` widens to all;
+	// explicit scope overrides; otherwise the cursor decides.
+	scope := m.scope
+	if m.scopeAll {
+		scope = ""
+	} else if scope == "" && m.cursor < len(m.procs) {
+		scope = m.procs[m.cursor].Name
+	}
+	view := m.views[scope]
 	if view == nil {
 		view = m.views[""]
 	}
 	records := m.store.Records(view)
 	out := make([]recordView, 0, len(records))
 	for _, record := range records {
-		out = append(out, recordView{Msg: record.Msg, Level: record.Level, Src: int(record.Src)})
+		out = append(out, recordView{
+			Msg: record.Msg, Level: record.Level, Src: int(record.Src),
+			Time: record.Time, Provider: record.Provider, Caller: record.Caller,
+		})
 	}
 	return out
 }
 
 type recordView struct {
-	Msg   string
-	Level string
-	Src   int
+	Msg      string
+	Level    string
+	Src      int
+	Time     time.Time
+	Provider string
+	Caller   string
 }
 
 func renderFillBar(fraction float64, width int, glyphs Glyphs) string {

--- a/internal/types/providers.go
+++ b/internal/types/providers.go
@@ -96,6 +96,11 @@ type ActionStep struct {
 	// was dropped and mutually exclusive steps all ran - flatpak added a remote
 	// both --user and --system, chocolatey added a source twice.
 	Condition string `toml:"condition,omitempty"`
+	// Optional marks a step whose failure is logged but does not fail the
+	// action. For steps that only exist on some tool versions: brew 6's
+	// `brew trust` does not exist on older brew, and the tap add must not
+	// fail there because the trust step after it cannot run.
+	Optional bool `toml:"optional,omitempty"`
 }
 
 // GetCorePackagesForDistro returns the appropriate core packages for a given distribution

--- a/openspec/changes/add-tui/design-v2.md
+++ b/openspec/changes/add-tui/design-v2.md
@@ -1,0 +1,765 @@
+# rwr TUI Implementation Plan
+
+Target repo: `github.com/fynxlabs/rwr` (master)
+
+Replaces the current streaming-log output with a Bubble Tea dashboard. Non-TTY behavior is unchanged.
+
+> Supersedes design.md where the two disagree. The normative frame in §7 is the
+> spec; implement it, not an interpretation of it.
+
+---
+
+## 1. Terminology
+
+| Term | Meaning |
+|---|---|
+| Processor | The 10 blueprint types plus pre-steps (blueprints, init, bootstrap). One strip block each. |
+| Provider | Package manager from `internal/system/definitions/providers/*.toml`. Renders as an indented child row under its processor in the checklist tree. |
+| Resource | A single item: one package, one file, one service, one font. Recorded always, rendered only in the summary. |
+
+Do not use "step" or "engine" in user-facing strings. Help bar uses `↑↓ move`, not `j/k processor`. Vim keys work but arrows are what the bar advertises.
+
+---
+
+## 2. Dependencies
+
+Already in `go.sum` via `charm.land/huh/v2`. Promote to direct in `go.mod`:
+
+- `charm.land/bubbletea/v2` v2.0.2
+- `charm.land/bubbles/v2` v2.0.0
+- `charm.land/lipgloss/v2` v2.0.1
+- `github.com/catppuccin/go` v0.3.0
+- `github.com/charmbracelet/colorprofile` v0.4.3
+
+New:
+
+- `github.com/charmbracelet/harmonica`
+- `github.com/lrstanley/bubblezone/v2` — the `/v2` path, not the root module. Root bubblezone targets bubbletea v1 and will not compile against `charm.land/bubbletea/v2`. Verified: bubblezone/v2 depends on `charm.land/bubbletea/v2` directly.
+
+### v2 API facts (verified against v2.0.2 source, not docs)
+
+`Model.View()` returns a `tea.View` **struct**, not a string. Build content with `tea.NewView(s)` and set behavior as fields on it. This is where several things the plan needs actually live:
+
+| Need | v2 mechanism |
+|---|---|
+| Window title (§15) | `View.WindowTitle` field, rendered per frame. There is no `SetWindowTitle` command |
+| Mouse enable (§12) | `View.MouseMode` = `MouseModeCellMotion`. The `m` toggle sets `MouseModeNone`. No `WithMouseCellMotion` program option exists |
+| Focus/blur for notifications (§15) | `View.ReportFocus = true`, then `FocusMsg`/`BlurMsg` arrive in Update. Off by default; tmux additionally needs `focus-events on` |
+| Full-screen | `View.AltScreen = true`. Use it; the dashboard is a full-frame app |
+| No painted background (§10) | `View.BackgroundColor` nil is the terminal default. The rule falls out of not setting the field |
+| OS taskbar progress | `View.ProgressBar` emits OSC 9;4. Free feature: set overall run percent, `ProgressBarError` state on first failure. Windows Terminal and some others render it in the taskbar, unsupported terminals ignore it. Complements §15 for the walked-away case |
+| Clipboard (§12) | `tea.SetClipboard(s)` command, OSC52. Confirmed present |
+| Terminal handoff (§3.3) | `tea.ExecProcess(cmd, cb)` confirmed present in exec.go |
+| Mouse messages | `MouseClickMsg`, `MouseReleaseMsg`, `MouseWheelMsg`, `MouseMotionMsg`, each convertible via `.Mouse()` |
+| Keys | `KeyPressMsg` / `KeyReleaseMsg` |
+
+`View.OnMouse` exists as a per-frame hit-testing hook. bubblezone/v2 remains the plan for zones; `OnMouse` is the fallback if zone marking fights lipgloss output for any region.
+
+Bubble Tea v2 changed message types. Key events are `KeyPressMsg`/`KeyReleaseMsg`; mouse events are split into click, motion, wheel, and release messages rather than a single `MouseMsg`. Verify against v2.0.2 source. Most examples online are v1 and will not compile.
+
+Components to use rather than hand-roll: `viewport`, `progress`, `spinner`, `stopwatch`, `help`, `key`, `textinput`. Only the strip and the panel height animation are custom.
+
+---
+
+## 3. Prerequisites
+
+Three changes outside the TUI. All are on the critical path.
+
+### 3.1 Resolve phase and `Plan`
+
+Hoist file reading, template resolution, and unmarshalling out of the execution loop in `internal/processors/all.go` into a resolve phase producing one struct.
+
+```go
+type Plan struct {
+    Init      *types.InitConfig
+    Order     []string                  // from GetBlueprintRunOrder
+    Files     map[string][]ResolvedFile // from GetBlueprintFileOrder, plus resolved content
+    Providers []ProviderState
+    Resources []Resource
+    Diags     []Diagnostic
+}
+```
+
+Two stages, because provider detection has a dependency the rest does not:
+
+| Stage | Runs | Produces |
+|---|---|---|
+| 1 | before init, needs only `SetPaths` + `DetectOS` | parse, imports, schema, template resolution, diagnostics |
+| 2 | after init and bootstrap complete | provider states, resource enumeration, per-provider counts |
+
+Bootstrap can install the package manager later blueprints depend on. Detecting providers before bootstrap produces wrong child rows.
+
+Consumers of `Plan`: `rwr validate` (stage 1 only), the TUI, the executor. Do not add an output-format flag to validate and call it from the run path. That resolves twice.
+
+### 3.2 Error accumulation in `All()`
+
+`internal/processors/all.go` currently returns on the first processor error. Push-through mode does not exist yet.
+
+- Fatal in both modes, abort immediately: blueprint fetch, blueprint location missing, package manager install, run order unresolvable. Everything before the processor loop.
+- Recoverable, collected: anything returned by the ten `Process*` calls.
+
+```go
+if err != nil {
+    if interactive {
+        return fmt.Errorf("error processing %s: %w", processor, err)
+    }
+    stepErrs = append(stepErrs, StepError{Processor: processor, Err: err})
+}
+```
+
+Exit nonzero if `stepErrs` is non-empty.
+
+### 3.3 Output routing in `internal/system/commands.go`
+
+Two branches, handled differently.
+
+Interactive branch currently sets `command.Stdin/Stdout/Stderr = os.Std*`. This is deliberate. Capturing stderr swallows sudo's password prompt and hangs the run. Do not pipe it.
+
+```go
+if cmd.Interactive {
+    done := make(chan error, 1)
+    reporter.Emit(TerminalReq{Processor: currentProcessor, Cmd: command, Done: done})
+    return <-done
+}
+```
+
+TUI handles `TerminalReq` with `tea.ExecProcess`, which restores cooked mode, hands over the real tty, and repaints on exit. `LogReporter` implements it as the current direct wiring, so headless output is byte-identical to today.
+
+This path must work in non-interactive runs too. `helpers.ResolveInteractive` lets a single blueprint item set `interactive: true` inside an otherwise non-interactive run. Do not gate handoff on the global flag.
+
+Non-interactive branch, in `setOutputStreams`, replacing `cmd.Stdout = os.Stdout` under debug:
+
+```go
+cmd.Stdout = &lineWriter{proc: currentProcessor, src: SrcStdout}
+cmd.Stderr = io.MultiWriter(&stderr, &lineWriter{proc: currentProcessor, src: SrcStderr})
+```
+
+`lineWriter` buffers to newline and emits one record per line. Keep the existing `stderr bytes.Buffer` so the error path still has full text. Per-blueprint `logName` files keep working via `io.MultiWriter`.
+
+---
+
+## 4. Event bus
+
+Goal: `All()` and the ten processors do not know a TUI exists.
+
+```go
+type Reporter interface{ Emit(Event) }
+
+type ProcStarted   struct{ Processor string; Files int; Providers []string }
+type ProcFinished  struct{ Processor string; Err error; Dur time.Duration }
+type ProcSkipped   struct{ Processor, Reason string }
+type ProviderUpdate struct{ Processor, Provider string; Done, Total int; Status Status }
+type ResourceDone  struct{ Resource Resource }
+type TerminalReq   struct{ Processor string; Cmd *exec.Cmd; Done chan error }
+type RunFinished   struct{ Errs []StepError }
+```
+
+Two implementations, chosen in `cmd/`:
+
+- `TUIReporter` wraps `p.Send`
+- `LogReporter` reproduces current streaming output exactly
+
+### Log capture without touching the processors
+
+The processors call `log.Infof(...)` on `charmbracelet/log`'s package-level default logger, which formats and writes to an `io.Writer`. That writer is the capture point.
+
+At TUI startup:
+
+```go
+log.SetFormatter(log.JSONFormatter)
+log.SetOutput(&captureWriter{})   // parses one JSON object per line into LogRecord
+log.SetLevel(log.DebugLevel)      // capture everything; display level filters at render
+```
+
+`captureWriter` unmarshals each line, stamps it with the package-level atomic `currentProcessor`, and appends to the store. Level, message, timestamp, and structured fields all survive because the JSON formatter carries them. Every existing `log.Infof("Processing packages")` across all ten processor files lands in the buffer correctly attributed, with zero edits to those files. Same pattern as the existing `dryRunMode` and `current` executor package state.
+
+Verified against log v1.0.0 (rwr's pin): `JSONFormatter` exists, `SetLevel` is mutex-guarded so flipping capture level at runtime is safe. Do **not** use the "log implements `slog.Handler`" route for this. That interface routes slog callers *into* charm log; `log.Infof` never passes through it, and a custom handler installed there captures nothing.
+
+Rendering note: with JSON capture, charm log's ANSI styling never reaches the screen. The viewport styles records itself from the theme, which is required anyway for the level/stdout filters and search highlighting.
+
+Headless `LogReporter` keeps today's text formatter and stderr untouched. The formatter swap happens only on the TUI path.
+
+Explicit events are then needed in only two places: the `All()` loop, and `runCommand`.
+
+---
+
+## 5. Data model
+
+```go
+type LogRecord struct {
+    Seq       uint64
+    Time      time.Time
+    Level     log.Level
+    Processor string
+    Provider  string
+    Msg       string
+    Fields    map[string]any // structured fields from the JSON formatter
+    Src       Source // SrcLog | SrcStdout | SrcStderr
+}
+
+type Resource struct {
+    Processor string
+    Provider  string        // empty for files, services, git, scripts
+    Name      string        // "neovim", "~/.config/nvim/"
+    Action    string        // install, copy, enable, clone
+    Status    Status        // ok, failed, skipped, unknown, planned, present
+    Detail    string
+    Dur       time.Duration
+}
+
+type Diagnostic struct {
+    Severity  Severity // Error | Warning
+    Processor string
+    File      string
+    Line      int
+    Msg       string
+}
+```
+
+`unknown` is required. rwr shells out and several providers do not report per-package results reliably. Do not force those into ok or failed.
+
+Each `Process*` function emits one `ResourceDone` per item. Ten files touched, mechanical.
+
+### Buffer
+
+- One append-only store with monotonic `Seq`, capped ring
+- `--tui-buffer` sizes it, default 50k lines
+- Every record also writes to a run log file unconditionally at debug level, regardless of display level
+- Run log: `os.CreateTemp("", "rwr-<timestamp>-*.log")`, mode 0600. `--log-file` overrides. Path printed on exit
+- When scrolling past the top of the ring, show a boundary row pointing at the file. Do not silently truncate
+
+Eviction gotcha: views hold `Seq` values, not array indices. Track `oldest` and drop stale head entries lazily on read. Storing positions will panic or scramble output once the ring wraps.
+
+### Views
+
+```go
+type View struct {
+    Processor string   // "" = all
+    idx       []uint64 // Seqs matching, appended as records arrive
+    offset    int      // scroll position, remembered
+    follow    bool
+}
+```
+
+Records stored once. Filtering is O(1) at render, not a scan. Each view keeps its own scroll position and follow state.
+
+Level, stdout, and search filters are global, applied on top of whichever view is active.
+
+---
+
+## 6. Model and states
+
+```go
+type State int
+const (
+    Resolving State = iota
+    Running
+    Suspended  // terminal handed to child
+    Prompting  // interactive error halt
+    Summary
+)
+
+type Model struct {
+    plan   *Plan
+    procs  []Proc
+    cursor int
+    live   int
+    pinned bool
+    store  *Store
+    views  map[string]*View
+    scope  string
+    level  log.Level
+    stdout bool
+    state  State
+    errs   []StepError
+}
+```
+
+Processor states: `pending`, `running`, `done`, `degraded`, `failed`, `skipped`.
+
+`degraded` covers a processor where some providers succeeded and others failed. Maps to the `warning` token, no theme changes needed.
+
+Processor state derives from the worst child provider state. Do not set it directly.
+
+Pinning: selection follows execution until the user moves selection (arrows or `j`/`k`) or scrolls (wheel, `pgup`/`pgdn`). First manual input pins. Once pinned, execution continues and the checklist updates but the viewport does not move. Status line shows where live is. `g` unpins and snaps back.
+
+---
+
+## 7. Layout
+
+### Target render (normative)
+
+This frame is the spec. Implement this, not an interpretation of it. Widths shrink to terminal, structure does not change.
+
+```
+rwr  ~/git/thefynx/rwr-blueprints/macOS                                  1m27s
+▰▰▱▱▱▱▱▱▱
+ ✓ repositories     8s
+ ⣻ packages         1m23s
+    ✓ brew   ██████████ 107/107 ✓
+    ⣻ cargo  ██░░░░░░░░ 3/19
+ ○ users            pending
+ ○ files            pending
+ ○ fonts            pending
+ ○ services         pending
+ ○ git              pending
+ ○ scripts          pending
+ ○ configuration    pending
+╭─ logs ── packages ── info ── live ─────────────────────────────────────────╮
+│ 13:02:41 › cargo  installing bacon                                         │
+│ 13:02:39 ⚠ brew   lazydocker already installed, skipped                    │
+│ 13:02:12 › brew   107 packages complete                                    │
+╰─────────────────────────────────────────────────── 412 lines ── ? help ────╯
+```
+
+Checklist styling, confirmed against a live build:
+
+- Durations sit directly after the name, left cluster, not right-aligned into a column
+- Pending processors each keep a full row with the dim word `pending`. The full board stays visible; do NOT collapse pending to one line
+- A done provider under a running processor keeps its full bar with `✓` appended
+- Provider rows indent under their processor with name, bar, `done/total`. No duration on provider rows while running
+- Clean-finished processors fold their provider subtree; the processor line keeps only glyph, name, duration. Failed subtrees never fold (§9)
+
+Rules the frame encodes, each one violated by the first implementation attempt:
+
+1. **Providers nest under their processor in the checklist.** brew and cargo are indented children of `packages`, with their own glyph, progress, and duration. They are NOT rows inside the log panel. Any processor that resolved providers (`packages`, `repositories`) renders its children the moment it starts. Processors without providers have no children.
+2. **The log viewport contains only log lines.** No progress bars, no provider rows, no counters. Its border carries the metadata (scope, level, follow, line count). One region per concern.
+3. **Pending processors keep full rows** with the dim word `pending`, per the frame above. The full board stays visible at all times. (Earlier drafts collapsed pending to one line; that is superseded — the space-priority rules in §Vertical space priority still let pending rows compress first when height runs out.)
+4. **Finished providers stay visible under a running processor** (brew done, cargo running), and the whole subtree collapses to one line when the processor finishes clean. Failed subtrees never collapse (§9).
+5. **Exactly one processor spinner at a time.** The screenshot showed `repositories` and `packages` both spinning, which means `ProcFinished` was never emitted or never consumed. Execution is sequential (§3.2). The model must assert one `running` processor; a second `ProcStarted` before the prior `ProcFinished` is a bug, log it loudly.
+6. **Log lines are re-rendered from `LogRecord` fields, never from the logger's formatted text.** Render `HH:MM:SS`, provider (dim), message. The `<system/providers.go:104>` caller prefix and the `rwr: :` artifact in the screenshot are the raw text formatter leaking through, which means capture was wired to the styled text output instead of the JSON formatter (§4). Caller info goes to the run log file only. Level word is omitted at info; WARN/ERROR render as colored glyphs.
+7. **Elapsed durations render right-aligned on every started row**, live-ticking for running ones.
+
+### Log line rendering (normative)
+
+Lines render from `LogRecord` fields, never the formatter's text. Two densities, one renderer.
+
+Info/warn display level:
+
+```
+│ 12:54:02 › brew  installed docker-compose                      │
+│ 12:54:04 ⚠ brew  lazydocker already installed, skipped         │
+│ 12:54:09 ✗ cargo bacon failed, exit 101                        │
+```
+
+Debug display level, same lines plus debug-source records and a dim caller column:
+
+```
+│ 12:54:02 › brew  installed docker-compose   packages.go:199    │
+│ 12:54:02 · brew  $ brew install lazydocker   commands.go:88    │
+│ 12:54:03 ≫ brew  ==> Pouring lazydocker.arm64_sequoia          │
+│ 12:54:04 › brew  installed lazydocker       packages.go:199    │
+```
+
+Rules:
+
+- Column order: `HH:MM:SS` (dim) · level glyph · provider (dim) · message · caller (debug only, dim, right)
+- Level glyphs: `›` info, `⚠` warn, `✗` error, `·` debug/command, `≫` captured stdout, stderr uses `≫` in the danger color. Glyphs come from the theme table (§10); ASCII fallbacks apply
+- The word INFO never renders. WARN/ERROR are carried by glyph and color only
+- Caller (`file.go:line`) renders at debug only. At info it is identical noise on every line
+- Seconds precision always. Minute precision makes 40 consecutive timestamps identical
+- Strip rwr's own message boilerplate at render: "Successfully installed package X via brew" renders as "installed X" with brew already in the provider column. Do this with a small verb-normalization pass on known message shapes; unknown messages render verbatim
+- The `rwr: :` artifact and `<file:line>` prefixes in the current output are the text formatter leaking through. They must never appear; if they do, capture is miswired (§4)
+- The run log file keeps everything at full fidelity including caller. Rendering rules are display-only
+
+### Regions
+
+Five regions, top to bottom:
+
+1. Header: `rwr`, blueprint source, host, failure counters, elapsed clock
+2. Strip: one block per processor, colored by state, one line total
+3. Collapsed completed processors
+4. Checklist tree with nested provider rows, then the log viewport
+5. Pending rows (full rows by default), then help bar
+
+### Viewport resizing
+
+The viewport height is user-adjustable, incrementally and as a toggle.
+
+- `+` (and `=`, so no shift needed) grows the viewport one row
+- `-` shrinks it one row
+- `z` toggles between maximum and the last manual height, or normal if none was set
+
+Bounds: minimum 3 log lines, maximum is everything except the header and strip. Growing takes rows in reverse space-priority order (§7): pending rows first (compressing them to one chip line), then the compressed success line, then help bar collapse, then finished provider child rows (running and failed children are never consumed). Shrinking returns them in the same order. Failed and degraded rows are the exception, they are never consumed by `+`; only `z` at full maximum hides them, and the strip and header counter still carry the failures.
+
+At maximum, the panel border collapses to a single title line with the processor name and filter state.
+
+- Manual height is remembered and survives processor transitions. The harmonica spring on processor change animates to the user's height, not the default
+- Filters, search, follow, and pinning are unaffected. This is layout state, not a mode
+- An interactive halt (`Prompting`) forces enough collapse to show the prompt and the failing provider rows, then restores the user's height on resume
+- Terminal resize re-clamps the manual height rather than resetting it
+- Compact mode ignores all three keys. It is already maximal
+
+### Collapse rules
+
+- Successful processors compress onto a single shared line: `✓ blueprints · init · repositories · files · services · git  41.2s`
+- Failed and degraded processors always keep a full row, with the reason in place of a duration
+- Selecting or clicking the compressed line expands it into individual rows
+- Pending compresses to one chip row. Expanding grows inline and shrinks the panel. Never an overlay, it would cover live output
+- Expansion is a manual toggle, does not auto-collapse when the next processor starts
+
+### Vertical space priority
+
+When height is constrained, sacrifice in this order, last first:
+
+1. Header and strip. Fixed, never sacrificed
+2. Failed and degraded rows. Never compressed, never scrolled out
+3. Active panel, minimum three log lines
+4. Help bar, collapses to `? help`
+5. Compressed success line
+6. Pending rows: compress to one chip line, then drop
+
+If failures alone exceed available height, that list becomes the scrollable region and the panel shrinks to minimum. Failures win over live output.
+
+### Provider rows
+
+Providers render as indented children of their processor in the checklist tree, per the target render. Never inside the log viewport. Each child row: glyph, provider name, progress bar, `done/total`, right-aligned duration. Processor state derives from worst child state (§6).
+
+Children appear when their processor starts, since resolve (§3.1) already produced the provider set and counts. A clean-finished processor collapses its subtree to one line; expanding it back is the same toggle as §Collapse rules. Failed children never collapse.
+
+Denominators are declared resources, not operations. Glob copies, URL sources, and dependency resolution all expand at execution time. Installing 112 declared packages may touch 400. Show `37/112` and let the log carry the rest. Do not imply the count is total work.
+
+### Compact mode
+
+Triggers below ~60 columns or ~14 rows. Either threshold trips it.
+
+Stays inside the TUI so filters and search survive. A raw stream would lose errors-only, which is what matters most on a small pane.
+
+Renders: one pinned status line (running processor, progress, failure counts), the log stream, one help line. No strip, no provider rows, no panel borders, no collapsed list.
+
+Switch live on `WindowSizeMsg`. Both layouts render from the same model, so resizing a tmux pane mid-run promotes or demotes with no state lost.
+
+---
+
+## 8. Frames
+
+### Resolving
+
+Progress list: init file, fetch, blueprint files, templates, providers, resources. First four are stage 1, last two are stage 2.
+
+Hold the frame behind a ~150ms delay. If resolve finishes first, go straight to the main view. A loading screen that appears for three frames is worse than none.
+
+Footer: `nothing has been modified yet`, `q` cancels.
+
+### Running
+
+The five regions above.
+
+### Summary
+
+Replaces the active panel when the run ends.
+
+- Tabs per processor, plus a `failures` tab first and selected by default
+- Rows are `Resource` records: glyph, provider, name, detail, duration
+- Footer totals: applied, skipped, failed, unknown
+- Run log path with `Y` to copy
+- `enter` on a row jumps to that resource's lines in the run log. The summary is an index into the log, not a dead end
+- `tab` cycles tabs, `/` searches within the current tab
+
+### Dry run
+
+Same frame as Summary. Dry run completes in under a second, so there is no live phase to design.
+
+Differences only:
+
+- `DRY RUN` badge in the header
+- Strip blocks render hollow rather than filled
+- Status vocabulary: `+` would apply, `=` already present, `?` cannot resolve
+- Footer counts: would apply, already present, unresolved
+- `c` filters to changes only, hiding already-present rows. Most runs on an existing machine are mostly no-ops
+
+Dry run is not necessarily clean. Unreachable file sources, dead font URLs, missing provider binaries, and unresolvable template variables are all detectable without touching the system. Render as amber `?`, not red. It is a plan problem, not a failure.
+
+### Validate
+
+Summary frame with a diagnostics tab instead of failures, and `Diagnostic` rows instead of `Resource` rows. Same tabs, same search, `enter` opens the offending file and line.
+
+---
+
+## 9. Error handling
+
+| | Interactive (default) | `--interactive=false` |
+|---|---|---|
+| On processor error | halt, jump viewport to it, errors-only auto-applied | mark row, record, continue |
+| Prompt | `r` retry failed provider, `R` retry processor, `s` skip provider, `q` abort | none |
+| Viewport | jumps and unpins | does not move |
+| End | resolved or aborted | Summary frame, nonzero exit |
+
+Retry defaults to the failed provider. Retrying the whole processor means reinstalling 112 packages to recover from one cargo failure. `R` exists for a deliberate clean redo.
+
+`r`, `R`, and `s` only render in `Prompting`. They cost nothing in the normal help bar.
+
+### Failure persistence
+
+Four surfaces, none of which scroll:
+
+1. Strip block turns red and stays red for the rest of the run
+2. Collapsed row keeps its glyph and swaps duration for the error summary
+3. Header counter `✗ 2 · ⚠ 1`, always present
+4. The processor row and its strip block take the worst child state
+
+---
+
+## 10. Theming
+
+Eleven roles. A theme file defines colors and glyphs together.
+
+| Role | Used for |
+|---|---|
+| `bg` `text` `subtext` | base surfaces and copy |
+| `muted` `dim` | pending, skipped, rules, timestamps |
+| `accent` | running, panel border, spinner, progress fill |
+| `success` | completed |
+| `danger` | failed, error lines |
+| `warning` | degraded, warn lines, unknown |
+| `info` | info-level markers |
+| `stdout` `stderr` | raw command output, distinct from rwr's own logs |
+
+Color by state, not by processor. Coloring 13 processors individually requires more distinguishable accents than most themes expose.
+
+Default theme `rwr`, built from Go brand colors: `#00ADD8` accent, `#00A29C` success, `#CE3262` danger, `#FDDD00` warning, `#5DC9E2` info.
+
+Ship embedded: `rwr`, catppuccin's four flavors (free from `catppuccin/go`), nord, gruvbox, dracula, tokyonight, rose-pine, solarized. User themes as TOML in the config dir, same schema, so a user can copy a built-in and edit it. Matches the existing providers pattern.
+
+Resolution order: `--theme`, `config.yaml`, `$RWR_THEME`, default. `NO_COLOR` overrides all of it.
+
+**Do not paint a background.** Inherit the terminal's and use theme colors for foreground and borders only. Light-theme and transparent-terminal users otherwise get a broken-looking frame.
+
+Degradation via `colorprofile`: truecolor gets hex, 256 quantizes, 16 falls back to ANSI names, no-color drops to glyphs and dim/bold. Test with `NO_COLOR=1` and `TERM=xterm`.
+
+### Glyphs
+
+Part of the theme, not a separate mechanism. ASCII set is a base theme others inherit.
+
+| Role | Unicode | ASCII |
+|---|---|---|
+| done | `✓` | `+` |
+| failed | `✗` | `x` |
+| degraded | `⚠` | `!` |
+| unknown | `?` | `?` |
+| pending | `○` | `.` |
+| skipped | `–` | `-` |
+| strip filled / empty | `▰` `▱` | `#` `.` |
+| progress full / empty | `█` `█` | `#` `-` |
+| spinner | braille | `\|` `/` `-` `\` |
+
+`lipgloss.ASCIIBorder()` handles panel frames, `spinner.Line` is the ASCII spinner, progress takes custom full and empty runes.
+
+Detection:
+
+- `LANG` or `LC_ALL` containing UTF-8 implies unicode is safe
+- On Windows, `WT_SESSION` present means Windows Terminal, unicode is fine. Absent means conhost, use ASCII
+- `--ascii` and `--unicode` force either way
+
+---
+
+## 11. Keybinds
+
+Arrow keys work everywhere vim keys do. Never require vim keys.
+
+| Key | Action |
+|---|---|
+| `↑` `↓` / `j` `k` | move selection, sets pinned |
+| `pgup` `pgdn` | scroll log viewport, sets pinned |
+| `home` `end` | viewport top / bottom |
+| `←` `→` / `h` `l` | cycle tabs in Summary; no-op while running |
+| `g` | follow: unpin, snap to live tail |
+| `x` | collapse/expand selected processor subtree |
+| `a` | toggle scope between selected processor and all |
+| `d` | cycle level: info, debug, warn |
+| `e` | errors only |
+| `o` | toggle stdout/stderr lines |
+| `E` | jump to first failure, apply errors-only |
+| `/` | search |
+| `n` `N` | cycle matches |
+| `esc` | clear search, or close expanded help |
+| `enter` | Summary: open selected resource in log |
+| `+` `=` / `-` | grow / shrink log viewport one row |
+| `z` | toggle viewport max / restore |
+| `f` | toggle follow |
+| `m` | toggle mouse reporting |
+| `y` | yank visible viewport |
+| `Y` | copy run log path |
+| `tab` | cycle summary tabs |
+| `c` | changes only, dry run |
+| `?` | full help |
+| `q` | quit, or abort at a halt |
+| `r` `R` `s` | retry provider, retry processor, skip. Prompting only |
+
+While the search `textinput` is focused, all keys route to it. Only `esc` (cancel) and `enter` (commit) escape. No action keys fire mid-typing.
+
+Keymap conflict to handle: bubbles' `viewport` default keymap binds `↑` `↓` `j` `k` to scrolling. That fights selection. Override the viewport's `KeyMap` so it owns only `pgup` `pgdn` `home` `end` and wheel, and route `↑` `↓` `j` `k` to selection at the model level. Do not forward key messages to the viewport blindly.
+
+`end` while running is equivalent to re-enabling follow. `home` while running disables it.
+
+Search scopes to the current view: selected processor plus active level and stdout filters. Matches highlight in place, `esc` clears. Widening scope is what `a` already does.
+
+---
+
+## 12. Mouse
+
+BubbleZone marks regions, `zone.Get(id).InBounds(msg)` in `Update`. Call `zone.Scan` on the final rendered output in top-level `View()`.
+
+| Zone | Click |
+|---|---|
+| Strip block | select that processor |
+| Collapsed done row | select and expand |
+| Pending row / compressed chip line | select processor / expand pending list |
+| Panel title bar | toggle viewport max / restore, same as `z` |
+| `info` / `live` / `stdout` in panel footer | cycle level, toggle follow, toggle raw output |
+| Help bar pills | fire that action |
+| Viewport | wheel scrolls, sets pinned |
+
+### Scroll wheel
+
+- Wheel over the log viewport scrolls it, 3 lines per tick (viewport default)
+- Scrolling up disengages follow and sets pinned. Scrolling back to the bottom edge re-engages follow, matching how terminal scrollback behaves
+- Wheel over the collapsed/failed processor list scrolls that region when it has overflowed (the failures-exceed-height case in §7)
+- Wheel anywhere else falls through to the viewport rather than being dropped
+- Wheel works in compact mode
+- Bubble Tea v2 delivers wheel as its own message type; do not look for it on click messages
+
+Strip blocks are 1 cell. Render each as 2 cells plus separator for a 3-cell target.
+
+Hover matters more than click. The strip is 13 unlabeled blocks. Brighten the hovered block and print its name to the right. Without it the strip is unusable by mouse.
+
+Guard re-render on `hoveredZone != lastHovered`. Motion events fire on every cell crossed.
+
+### Text selection
+
+Mouse tracking takes over drag-select. On a log-heavy TUI this is the first thing a user reaches for.
+
+- Most terminals bypass tracking on shift-drag. Document in `?` help
+- `m` toggles mouse reporting off entirely
+- `y` and `Y` provide a real copy path. Bubble Tea v2 pushes to system clipboard over OSC52, and `atotto/clipboard` is already in the dep tree
+- Mouse reporting must come down and go back up around terminal handoff. `tea.ExecProcess` restores terminal state, but verify the mouse specifically
+
+---
+
+## 13. Animation
+
+| What | Driver | Stops |
+|---|---|---|
+| Progress fill | `progress.SetPercent` spring | settled |
+| Spinner | `spinner.Tick` | processor finishes |
+| Elapsed | `stopwatch` | run ends |
+| Panel height on processor change | harmonica spring + `tea.Tick` | spring settles, then cancel the tick |
+| Strip block state flip | 3-frame brightness pulse | immediately |
+
+Kill the panel tick the moment the spring is within a cell of target and snap. Ticking at 60fps indefinitely costs real CPU on a laptop mid-install.
+
+---
+
+## 14. Activation
+
+Primary check: `term.IsTerminal(os.Stdout.Fd())`. `golang.org/x/term` is already a direct dep.
+
+Fall back to `LogReporter` on any of:
+
+- `--no-tui`
+- `CI` set. Some runners allocate a pty and would otherwise get escape sequences in a build log
+- `TERM=dumb`
+- not a TTY
+
+`rwr all > install.log` already fails the TTY check and behaves as today.
+
+### Single-processor runs
+
+`rwr run packages` uses the same TUI with one strip block. Collapsed success list is always empty, no pending rows exist, and the panel takes the freed vertical space. Result is the provider subtree plus a large viewport. Summary still works with fewer tabs.
+
+---
+
+## 15. Notifications
+
+One notification, at run completion, in both interactive and non-interactive modes. Nothing else.
+
+- Use OSC 9. Escape sequences travel over SSH, so provisioning a remote box notifies the machine you are sitting at. `notify-send` and `osascript` notify the remote box, which nobody sees. Also dependency-free, where libnotify may be missing on a system rwr is mid-build
+- Only fire if the run exceeded ~30s
+- Only fire when the terminal is unfocused. Bubble Tea reports focus and blur
+- Gate the sequence on a recognized terminal. Unknown OSC sequences are usually swallowed, but some older terminals print the payload as literal text into the log view
+- Never when not a TTY
+- `--no-notify` disables. No bell by default
+
+Payload carries counts: `rwr finished · 2 failed`.
+
+Additionally, keep `View.ProgressBar` updated with overall run percent throughout, switching to `ProgressBarError` on first failure. This is the OSC 9;4 taskbar progress from §2, costs one field assignment per frame, and gives walked-away users a taskbar signal with zero notification plumbing. Not gated by `--no-notify`, it is passive state, not an alert.
+
+---
+
+## 16. Validation gating
+
+Every run does stage 1 resolve as a precaution. Gating needs severity or the first person with a slightly odd blueprint cannot run at all.
+
+- Errors gate by default
+- Warnings surface as `⚠ n` in the header and do not stop anything
+- `--strict` promotes warnings to gating
+- `--skip-validate` escape hatch
+
+---
+
+## 17. Suggested sequencing
+
+1. `Plan` struct and stage 1 resolve. Wire `rwr validate` to it. No TUI yet, verify parity with current validate output
+2. Reporter interface and `LogReporter`. Wire into `All()` and `commands.go`. Output must be byte-identical to today. This is the safety net
+3. Store, views, JSON capture writer. Verify records land with correct processor attribution and fields intact
+4. Stage 2 resolve, provider grouping and counts
+5. Error accumulation in `All()`
+6. Static TUI: header, strip, collapsed list, panel, help bar. No animation, no mouse
+7. Terminal handoff via `tea.ExecProcess`. Test sudo prompts hard, this is the common path since interactive defaults true
+8. Filters, search, pinning
+9. Summary and dry-run frames
+10. Theming and glyph fallback
+11. Mouse and hover
+12. Animation
+13. Compact mode and resize
+14. Notifications
+
+Steps 1 through 5 are prerequisites and carry most of the risk. Steps 6 onward are additive.
+
+---
+
+## 18. Test checklist
+
+- `rwr all > file.log`, output matches current master byte for byte
+- `CI=true rwr all`, no escape sequences
+- `NO_COLOR=1`, readable, meaning carried by glyphs
+- `TERM=xterm`, 16-color degradation
+- `TERM=dumb`, falls back to LogReporter
+- Windows conhost, ASCII glyphs
+- Windows Terminal, unicode
+- sudo prompt in a `files` blueprint, handoff and repaint
+- `interactive: true` on one package inside `--interactive=false`, handoff still works
+- Ring wrap during a long debug run, no panic, boundary row renders
+- Resize below and above both thresholds mid-run
+- Processor failure at position 1 and at position 13, both stay visible at end
+- Provider partial failure, processor renders degraded not failed
+- Dry run against a system where everything is already installed
+- Light-background terminal, no painted background
+- Terminal with transparency, frame does not fill
+- Every action reachable by arrows/pgup/pgdn without touching a vim key
+- Wheel up mid-run disengages follow; wheel back to bottom re-engages
+- `↑`/`↓` move selection and do not scroll the viewport (keymap override holds)
+- Wheel scrolls in compact mode
+- `+`/`-` resize during a run, filters and pin state survive, failed rows never consumed by `+`
+- `z` at max hides failed rows, strip and header counter still show them, `z` restores
+- Manual height survives processor transition and terminal resize re-clamps it
+- Interactive halt while resized forces collapse, prompt visible, height restored on resume
+- Focus-gated notification inside tmux without `focus-events on`: notification still fires (treat unknown focus as unfocused, do not silently drop)
+- Taskbar progress renders in Windows Terminal, ignored cleanly elsewhere
+
+Regressions from the first implementation attempt, must not reappear:
+
+- Providers render nested under `packages` in the checklist, never inside the log viewport
+- Never two processor spinners at once; a second `ProcStarted` before `ProcFinished` fails loudly
+- Pending rows render per the target frame: full rows, dim `pending` word, compressed only under height pressure
+- No `<file:line>` caller prefix and no `rwr: :` in viewport lines; capture is the JSON formatter, render is from `LogRecord` fields
+- `repositories` marks finished before `packages` starts (verifies `ProcFinished` is emitted and consumed)
+
+---
+
+## 19. Out of scope
+
+- Resource-level granularity in the live view. Live stays at processor and provider. Resources are recorded and rendered only in Summary
+- Concurrent processor execution. `All()` is sequential and this design assumes it
+- Interactive plan approval before apply. Dry run and validate cover the need
+- Scrollbar dragging in the viewport


### PR DESCRIPTION
## What

A day of brute-force testing rwr on a near-fresh Apple Silicon Mac (macOS 26, Homebrew 6), fixing every defect the machine surfaced. Three groups:

### Execution correctness
- **Provider detection files are any-of, not all-of** — brew declares four alternative install prefixes; requiring all of them rejected brew on every Apple Silicon Mac, so a brew-equipped machine detected zero package managers.
- **Homebrew 6 compatibility** — `HOMEBREW_NO_ASK`/`NONINTERACTIVE` in the brew provider environment (ask-mode became the install default and deadlocked automated runs), and `repository.add` now runs `brew trust --tap` after tapping via a new schema-level `optional` step flag (older brew has no `trust` command and must not fail the add).
- **`cargo install --locked`** — install-time dependency re-resolution pulled a `palette` version that no longer compiles under current rustc, failing `eza` on a fresh machine.
- **Install steps resolve executables through `FindTool`** — rustup puts cargo in `~/.cargo/bin`, not on the PATH rwr started with, so "run the binary you just installed" failed.
- **Imported blueprints are template-resolved** — `{{ .User.home }}` in an imported file survived to execution as a literal path; rwr created a directory named `{{ .User.home }}`.
- **`Variables.System` is actually populated** — every `{{ .System.osArch }}` conditional rendered against empty strings; a users blueprint set the Intel fish path as the login shell on an ARM machine and broke every new terminal window.
- **Unavailable package manager = recorded failure**, not a silent skip that exits 0 having installed nothing.
- **Bootstrap's run-once marker is earned** — only written when every step succeeded; a failed SSH-key upload used to be papered over permanently.
- **Elevated captured commands validate sudo first** — sudo prompts on `/dev/tty` straight past captured pipes; under the dashboard the prompt and the frame fought and the dashboard ate the password. Credentials now validate via `sudo -n -v` probe + a clean terminal handover when expired.

### Reporting honesty
- **`ProcFinished` was never emitted anywhere** — every started processor showed as running forever (and `ProcStarted` fired once per file, not per processor).
- The summary counted planned-but-never-ran resources as "applied" — a run that died before doing anything reported `applied 237 · failed 0`.
- The run's own error now reaches the failures tab instead of `RunFinished{nil}` unconditionally.

### TUI (implements the new normative spec in `openspec/changes/add-tui/design-v2.md`)
- **Terminal lease** (`reporting.WithTerminal` + `tea.Exec`) for every in-process prompt — huh forms, raw stdin reads, the OAuth device flow (which now prints its URL/code on the real terminal and opens the browser). A prompt reading stdin while the dashboard owned it froze the run and Ctrl-C with it.
- **Structured log capture** — charm log's JSON formatter into `LogRecord`s; viewport renders time/glyph/provider/message from fields, caller at debug only; multi-line messages split one record per line (a stderr blob in one record pushed the frame past the terminal height).
- Interactive halts prompt `r`/`R`/`s`/`q`; headless keeps abort-on-first-error.
- Checklist default view with providers nested under their processor, lane denominators pre-populated from the stage-2 plan, only tree-configured processors shown.
- AltScreen, window title, OSC 9;4 taskbar progress, `m` mouse-capture toggle, viewport sizing (`+`/`-`/`z`), search highlight with `n`/`N`, `y`/`Y` OSC52 clipboard.
- **Typeahead grace after terminal handovers** — buffered password keystrokes used to quit the dashboard or answer halt prompts nobody saw.
- If the dashboard ever exits mid-run, the reporter falls back to headless immediately (no events into a dead program, no deadlockable halts).

## Why

Every item above was hit live during a real machine bring-up, in sequence, from `rwr run all` hanging forever at "resolving blueprints" to a fully clean interactive run. The regression tests pin the load-bearing fixes (detection any-of, brew env/trust decode, unavailable-manager failure, multiline record split, import templating, halt decisions, checklist visibility, JSON capture fields, keyring-hermetic token tests).

## Reviewer notes

- The commit is intentionally one unit: the fixes were discovered and verified as a chain and many span the same files.
- Commit is unsigned — made on a machine whose GPG key wasn't restored yet; will re-sign or squash-merge.
- `internal/tui` behavior is covered by model-level tests; the pty-level experience was verified manually across ~10 live runs on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)