### PR TITLE
test: the suite runs on darwin, and macOS CI gates on it

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,16 +53,22 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: ./scripts/coverage-gate.sh coverage.out
 
-      # The same run on macOS and Windows, reporting only.
-      #
-      # The suite has never executed on either platform, and a good deal of it
-      # assumes POSIX behaviour - unix file modes, /bin/bash, path separators.
-      # Gating on it immediately would paint master red for reasons unrelated to
-      # whatever change is being reviewed. This surfaces the failures so they can
-      # be triaged and skipped or fixed at their source; delete continue-on-error
-      # once that is done, so the platforms rwr provisions are really tested.
-      - name: Test (macOS/Windows, not yet gating)
-        if: matrix.os != 'ubuntu-latest'
+      # macOS gates. The suite passes there now: the two failures that kept it
+      # from gating were both fixtures describing a machine that cannot exist
+      # (a Mac with no package manager at all), not platform gaps in the code.
+      # Contributors on a Mac run this same suite in the hk pre-push hook, so a
+      # non-gating macOS leg meant CI was weaker than the hook they already run.
+      - name: Test (macOS)
+        if: matrix.os == 'macos-latest'
+        run: go test -race -v ./...
+
+      # Windows is still reporting only. A good deal of the suite assumes POSIX
+      # behaviour - unix file modes, /bin/bash, path separators - and nobody has
+      # triaged what that costs there yet. This surfaces the failures so they can
+      # be fixed at their source; delete continue-on-error once that is done, so
+      # every platform rwr provisions is really tested.
+      - name: Test (Windows, not yet gating)
+        if: matrix.os == 'windows-latest'
         continue-on-error: true
         run: go test -race -v ./...
 

--- a/internal/credentials/keyring.go
+++ b/internal/credentials/keyring.go
@@ -33,6 +33,36 @@ var ErrKeyringNotFound = errors.New("keyring entry not found")
 // keyring (Secret Service / macOS Keychain / Windows Credential Manager).
 var Ring Keyring = osKeyring{}
 
+// EmptyKeyring answers "not found" for every name and refuses every save. It
+// is what a test wants whenever the code under test happens to consult the
+// keyring but the test is not about the keyring.
+type EmptyKeyring struct{}
+
+// Get implements Keyring.
+func (EmptyKeyring) Get(string) (string, error) { return "", ErrKeyringNotFound }
+
+// Set implements Keyring.
+func (EmptyKeyring) Set(string, string) error { return errors.New("keyring unavailable") }
+
+// SetRingForTest installs a keyring for the duration of a test and returns the
+// restore func, in the same shape as system.SetProvidersForTest.
+//
+// It exists because reading the real keyring from a test is not merely flaky,
+// it is a disclosure: the "no token available" cases in the SSH key tests
+// found the developer's own GitHub token in the macOS Keychain and testify
+// printed the value into the terminal on the assertion failure. CI never saw
+// it because GitHub runners have no keyring backend, so the gate could not
+// catch it either.
+//
+// Any test that exercises a code path reaching FromKeyring must call this.
+//
+//	defer credentials.SetRingForTest(credentials.EmptyKeyring{})()
+func SetRingForTest(ring Keyring) (restore func()) {
+	previous := Ring
+	Ring = ring
+	return func() { Ring = previous }
+}
+
 type osKeyring struct{}
 
 func (osKeyring) Get(name string) (string, error) {

--- a/internal/credentials/keyring_test.go
+++ b/internal/credentials/keyring_test.go
@@ -1,0 +1,45 @@
+package credentials
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// EmptyKeyring is the stand-in every test outside this package reaches for, so
+// its two answers are the contract: nothing is ever found, nothing is ever
+// saved. A test that got a value back from it would be reading the machine.
+func TestEmptyKeyringFindsAndSavesNothing(t *testing.T) {
+	var ring Keyring = EmptyKeyring{}
+
+	value, err := ring.Get("gh_api_token")
+	assert.Empty(t, value)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrKeyringNotFound))
+
+	assert.Error(t, ring.Set("gh_api_token", "ghp_whatever"))
+}
+
+// FromKeyring turns the empty ring into the "not found" the precedence chain
+// expects, rather than surfacing the backend error.
+func TestFromKeyringWithEmptyRing(t *testing.T) {
+	defer SetRingForTest(EmptyKeyring{})()
+
+	value, ok := FromKeyring("gh_api_token")
+	assert.False(t, ok)
+	assert.Empty(t, value)
+}
+
+// The restore func has to put the real keyring back, or one test that swaps
+// the ring silently disarms every test that runs after it.
+func TestSetRingForTestRestores(t *testing.T) {
+	original := Ring
+
+	restore := SetRingForTest(EmptyKeyring{})
+	assert.NotEqual(t, original, Ring)
+
+	restore()
+	assert.Equal(t, original, Ring)
+}

--- a/internal/processors/reporter_output_test.go
+++ b/internal/processors/reporter_output_test.go
@@ -61,6 +61,7 @@ func TestAll_HeadlessOutputUnchanged(t *testing.T) {
 	osInfo := &types.OSInfo{}
 	osInfo.System.OS = runtime.GOOS
 	osInfo.Tools.Bash = types.ToolInfo{Exists: true, Bin: "/bin/bash"}
+	givePackageManager(osInfo, bin)
 
 	if err := All(initConfig, osInfo, []string{"packages", "scripts"}); err != nil {
 		t.Fatalf("All: %v", err)
@@ -120,6 +121,7 @@ func TestAll_NonInteractiveCollectsErrorsAndContinues(t *testing.T) {
 	osInfo := &types.OSInfo{}
 	osInfo.System.OS = runtime.GOOS
 	osInfo.Tools.Bash = types.ToolInfo{Exists: true, Bin: "/bin/bash"}
+	givePackageManager(osInfo, "sh")
 
 	err := All(initConfig, osInfo, []string{"scripts", "files"})
 	if err == nil {

--- a/internal/processors/ssh_key_test.go
+++ b/internal/processors/ssh_key_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fynxlabs/rwr/internal/credentials"
 	"github.com/fynxlabs/rwr/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,6 +48,11 @@ func TestGetGitHubToken_Priority(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// getGitHubToken consults the OS keyring between the environment
+			// and the prompt. Without this the "no token" case finds whatever
+			// the developer has stored and asserts against it.
+			defer credentials.SetRingForTest(credentials.EmptyKeyring{})()
+
 			// Setup test environment
 			oldGitHubToken := os.Getenv("GITHUB_TOKEN")
 			defer os.Setenv("GITHUB_TOKEN", oldGitHubToken)
@@ -336,6 +342,8 @@ func TestGetGitHubToken_EnvVarOnly(t *testing.T) {
 
 // TestGetGitHubToken_NoToken tests error when no token available.
 func TestGetGitHubToken_NoToken(t *testing.T) {
+	defer credentials.SetRingForTest(credentials.EmptyKeyring{})()
+
 	oldGitHubToken := os.Getenv("GITHUB_TOKEN")
 	defer os.Setenv("GITHUB_TOKEN", oldGitHubToken)
 
@@ -352,7 +360,9 @@ func TestGetGitHubToken_NoToken(t *testing.T) {
 
 	token, source, err := getGitHubToken(initConfig)
 
-	assert.Error(t, err)
+	// require, not assert: the assertions below dereference err, so a run
+	// that unexpectedly finds a token panicked instead of failing.
+	require.Error(t, err)
 	assert.Empty(t, token)
 	assert.Empty(t, source)
 	assert.Contains(t, err.Error(), "GitHub token not found")

--- a/internal/processors/test_helpers_test.go
+++ b/internal/processors/test_helpers_test.go
@@ -1,8 +1,31 @@
 package processors
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
 
 // containsString checks if a string contains a substring.
 func containsString(haystack, needle string) bool {
 	return strings.Contains(haystack, needle)
+}
+
+// givePackageManager records one detected package manager on a hand-built
+// OSInfo.
+//
+// All() treats a darwin machine with no detected package manager as a machine
+// that needs one installed, and goes off to install Homebrew before it reaches
+// the processor loop. That is right for a real Mac and wrong for a fixture: a
+// test about the run loop should not be describing a Mac with no package
+// manager at all, because no such Mac ever reaches All() in practice - DetectOS
+// fills this in.
+//
+// Leaving it empty is what made every All()-driven test fail on darwin with
+// "no provider definition for package manager brew" while passing on Linux,
+// where that branch does not exist.
+func givePackageManager(osInfo *types.OSInfo, bin string) {
+	info := types.PackageManagerInfo{Name: "pacman", Bin: bin}
+	osInfo.PackageManager.Default = info
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{"pacman": info}
 }

--- a/internal/prompts/github_save_test.go
+++ b/internal/prompts/github_save_test.go
@@ -39,13 +39,11 @@ func (m *mapKeyring) Set(name, value string) error {
 
 func withSaveFixture(t *testing.T, ring credentials.Keyring) string {
 	t.Helper()
-	origRing := credentials.Ring
-	credentials.Ring = ring
+	t.Cleanup(credentials.SetRingForTest(ring))
 	viper.Reset()
 	configFile := filepath.Join(t.TempDir(), "config.yaml")
 	viper.SetConfigFile(configFile)
 	t.Cleanup(func() {
-		credentials.Ring = origRing
 		viper.Reset()
 		types.RegisterCredentials(nil)
 	})


### PR DESCRIPTION
Two test-hermeticity defects that together made `go test ./...` fail on every Mac. Batched because each one blocks the other: hk's pre-push hook runs `go test -race ./...`, so neither could be pushed from a Mac while the other was outstanding.

## 1. Tests read the operator's OS keyring

`getGitHubToken` consults the keyring between the environment variable and the interactive prompt, and nothing stubbed it. On any machine with a keyring backend the two "no token available" cases found whatever the developer had stored, failed, and testify printed the token value into the terminal:

```
--- FAIL: TestGetGitHubToken_NoToken
    Error: Should be empty, but was ghu_...
```

Then it panicked: both cases assert on `err.Error()` after a bare `assert.Error`, so finding a token dereferenced nil and took the package's whole test binary down.

CI never saw it. GitHub runners have no keyring backend, so `FromKeyring` returns "not found" there and the gate is blind while every local `mise run test` fails.

`credentials.SetRingForTest` / `EmptyKeyring` follow the existing restore-func shape (`system.SetProvidersForTest`, `reporting.Set`). `internal/prompts` already open-coded the same swap and now uses the helper.

## 2. Two fixtures describe a Mac that cannot exist

`TestAll_HeadlessOutputUnchanged` and `TestAll_NonInteractiveCollectsErrorsAndContinues` set `System.OS` from `runtime.GOOS` but leave `PackageManager.Managers` empty. On darwin `All()` reads that as a machine needing a package manager, goes off to install Homebrew, and dies with `no provider definition for package manager brew` before reaching the processor loop the tests are about.

`DetectOS` always fills `Managers` in, so no real run reaches `All()` in that state. Fixed in the fixtures, not by special-casing darwin in `All()`, which is behaving correctly.

## macOS CI now gates

Those two fixtures were the entire gap: the full suite passes on darwin under `-race`. The macOS leg stops being advisory. Worth watching this PR's own macOS check, since `macos-latest` is the first real confirmation beyond a local Mac.

Windows keeps `continue-on-error` - nobody has triaged what the suite's POSIX assumptions cost there, and an unmeasured gate is worse than an honest one.

## Verification

- `go test -race ./...` green on darwin/arm64, all 17 packages
- `golangci-lint run` 0 issues, `go vet` clean, `gosec` and `govulncheck` clean

---

⚠️ Unrelated but urgent: the failure in #1 printed a live `ghu_` GitHub token from the maintainer's Keychain into terminal output. That token should be revoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)