### PR TITLE
fix(ssh): the RWR SSH key was stored in a form nothing could read

### DIFF
--- a/internal/helpers/git.go
+++ b/internal/helpers/git.go
@@ -166,18 +166,38 @@ func getHTTPAuthMethod(rawURL string, initConfig *types.InitConfig) (transport.A
 // carries only a truncated preview of the value.
 var ErrUnusableSSHKey = errors.New("ssh key is neither a readable file nor recognisable key material")
 
+// sshKeyEncodings are the base64 alphabets a hand-written --ssh-key value
+// might arrive in. Padded and unpadded, standard and URL-safe: which one an
+// operator's tooling emits is not something rwr gets to choose, and the cost
+// of trying all four is four failed string decodes.
+var sshKeyEncodings = []*base64.Encoding{
+	base64.StdEncoding,
+	base64.RawStdEncoding,
+	base64.URLEncoding,
+	base64.RawURLEncoding,
+}
+
 // sshKeyMaterial decides whether a configured ssh key value is the key itself
 // rather than a path to it, and returns the PEM bytes when it is.
 //
 // Two forms count as the key itself:
 //
-//   - the PEM as written. Every private key PEM is multi-line, so a newline is
-//     what identifies it.
-//   - base64 of that PEM. This is the form set_as_rwr_ssh_key writes into
+//   - the PEM as written, in any line ending.
+//   - base64 of that PEM, in any of the four alphabets above, wrapped at any
+//     column or not at all. This is the form set_as_rwr_ssh_key writes into
 //     repository.ssh_private_key and the form --ssh-key documents, and nothing
-//     decoded it: base64 has no newlines, so it fell through to the file-path
-//     branch and rwr tried to open the blob as a filename. set_as_rwr_ssh_key
-//     produced a config value that could never authenticate anything.
+//     decoded it at all until recently.
+//
+// One guard decides both: the bytes have to look like a private key. That is
+// what makes the classification honest in each direction.
+//
+//   - A newline does not identify key material. Testing for one caught
+//     column-wrapped base64 first and handed it to go-git as PEM, which it is
+//     not, because Go's base64 decoder ignores embedded LF and CRLF and would
+//     have decoded it perfectly well.
+//   - A successful decode does not identify key material either. A bare
+//     filename can be valid base64 by accident ("config" round-trips), so
+//     decoded bytes that are not a private key leave the value a path.
 //
 // An "ssh-" prefix deliberately does not count, though it used to. It only
 // ever matches a public key ("ssh-rsa AAAA..."), and this flow hands its bytes
@@ -187,24 +207,31 @@ var ErrUnusableSSHKey = errors.New("ssh key is neither a readable file nor recog
 // parsed as key data and failed with "ssh: no key found" instead of being
 // read.
 //
-// The decode has to prove itself: a bare filename can be valid base64 by
-// accident, so the decoded bytes must actually look like a private key before
-// they are treated as one, and anything else stays a path.
+// The raw form is checked first because a private key PEM cannot decode as
+// base64 under any of the four alphabets - it contains spaces, which none of
+// them ignore - so the order costs nothing and saves four decode attempts on
+// the common case.
 func sshKeyMaterial(value string) ([]byte, bool) {
-	if strings.Contains(value, "\n") {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil, false
+	}
+
+	if looksLikePrivateKey([]byte(trimmed)) {
 		log.Debugf("Using the SSH key material as supplied")
 		return []byte(value), true
 	}
 
-	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(value))
-	if err != nil {
-		return nil, false
+	for _, encoding := range sshKeyEncodings {
+		decoded, err := encoding.DecodeString(trimmed)
+		if err != nil || !looksLikePrivateKey(decoded) {
+			continue
+		}
+		log.Debugf("Using base64-encoded SSH key material")
+		return decoded, true
 	}
-	if !looksLikePrivateKey(decoded) {
-		return nil, false
-	}
-	log.Debugf("Using base64-encoded SSH key material")
-	return decoded, true
+
+	return nil, false
 }
 
 // looksLikePrivateKey reports whether bytes are plausibly a private key, so a

--- a/internal/helpers/git.go
+++ b/internal/helpers/git.go
@@ -1,8 +1,10 @@
 package helpers
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"io/fs"
 	neturl "net/url"
 	"os"
 	"path/filepath"
@@ -157,25 +159,90 @@ func getHTTPAuthMethod(rawURL string, initConfig *types.InitConfig) (transport.A
 	}, nil
 }
 
+// sshKeyMaterial decides whether a configured ssh key value is the key itself
+// rather than a path to it, and returns the PEM bytes when it is.
+//
+// Two forms count as the key itself:
+//
+//   - the PEM as written, which contains newlines (an "ssh-" prefix is
+//     accepted too, though that is a public key and go-git will reject it
+//     later with a better message than a stat failure would).
+//   - base64 of that PEM. This is the form set_as_rwr_ssh_key writes into
+//     repository.ssh_private_key and the form --ssh-key documents, and
+//     nothing decoded it: base64 has no newlines and no "ssh-" prefix, so it
+//     fell through to the file-path branch and rwr tried to open the blob as
+//     a filename. set_as_rwr_ssh_key produced a config value that could never
+//     authenticate anything.
+//
+// The decode has to prove itself: a bare filename can be valid base64 by
+// accident, so the decoded bytes must actually look like a key before they are
+// treated as one, and anything else stays a path.
+func sshKeyMaterial(value string) ([]byte, bool) {
+	if strings.Contains(value, "\n") || strings.HasPrefix(value, "ssh-") {
+		log.Debugf("Using the SSH key material as supplied")
+		return []byte(value), true
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(value))
+	if err != nil {
+		return nil, false
+	}
+	if !looksLikeSSHKey(decoded) {
+		return nil, false
+	}
+	log.Debugf("Using base64-encoded SSH key material")
+	return decoded, true
+}
+
+// looksLikeSSHKey reports whether bytes are plausibly an SSH key, so a path
+// that happens to decode as base64 is not mistaken for one.
+func looksLikeSSHKey(data []byte) bool {
+	text := string(data)
+	return strings.Contains(text, "PRIVATE KEY") || strings.HasPrefix(text, "ssh-")
+}
+
+// truncateForError keeps a bad ssh key value out of the log at full length: it
+// may be the key itself, and the point of the message is which value was
+// rejected, not what it contained.
+func truncateForError(value string) string {
+	const max = 32
+	if len(value) <= max {
+		return value
+	}
+	return value[:max] + "..."
+}
+
 func getSSHAuthMethod(initConfig *types.InitConfig) (transport.AuthMethod, error) {
 	// Use the specified SSH key or try to find a suitable key
 	sshKeyValue := initConfig.Variables.Flags.SSHKey
 
-	// Check if the value is a Base64-encoded key or a file path
+	// The value is key material (raw or base64) or a path to a key file.
 	if sshKeyValue != "" {
-		// If the value contains newlines or begins with "ssh-", it's likely a Base64-encoded key
-		if strings.Contains(sshKeyValue, "\n") || strings.HasPrefix(sshKeyValue, "ssh-") {
-			log.Debugf("Using Base64-encoded SSH key")
-			auth, err := ssh.NewPublicKeys("git", []byte(sshKeyValue), "")
+		if material, ok := sshKeyMaterial(sshKeyValue); ok {
+			auth, err := ssh.NewPublicKeys("git", material, "")
 			if err != nil {
-				return nil, fmt.Errorf("error creating SSH authentication from Base64 key: %w", err)
+				return nil, fmt.Errorf("error creating SSH authentication from the supplied key: %w", err)
 			}
 			return auth, nil
 		}
 
-		// Treat as a file path
-		if _, err := os.Stat(sshKeyValue); os.IsNotExist(err) {
-			return nil, fmt.Errorf("specified SSH key file does not exist: %s", sshKeyValue)
+		// Treat as a file path. Any stat failure disqualifies it, not just
+		// ENOENT: a base64 blob that failed to decode stats as ENAMETOOLONG,
+		// and reporting that as "error creating SSH authentication from file:
+		// open LS0tLS1CRUdJTi...: file name too long" told the operator
+		// nothing about what was actually wrong.
+		//
+		// The PathError's own Err is what gets wrapped, never the PathError
+		// itself: its message repeats the whole path, and when this value is
+		// key material rather than a path that is the private key going into
+		// an error string.
+		if _, err := os.Stat(sshKeyValue); err != nil {
+			reason := err
+			var pathErr *fs.PathError
+			if errors.As(err, &pathErr) {
+				reason = pathErr.Err
+			}
+			return nil, fmt.Errorf("ssh key %q is neither a readable file nor recognisable key material: %w", truncateForError(sshKeyValue), reason)
 		}
 
 		auth, err := ssh.NewPublicKeysFromFile("git", sshKeyValue, "")

--- a/internal/helpers/git.go
+++ b/internal/helpers/git.go
@@ -159,26 +159,39 @@ func getHTTPAuthMethod(rawURL string, initConfig *types.InitConfig) (transport.A
 	}, nil
 }
 
+// ErrUnusableSSHKey is returned when a configured ssh key value is neither a
+// readable file nor recognisable key material. It is a sentinel so callers and
+// tests can identify the condition without matching on message text, which
+// would otherwise be the only handle on it - and the message deliberately
+// carries only a truncated preview of the value.
+var ErrUnusableSSHKey = errors.New("ssh key is neither a readable file nor recognisable key material")
+
 // sshKeyMaterial decides whether a configured ssh key value is the key itself
 // rather than a path to it, and returns the PEM bytes when it is.
 //
 // Two forms count as the key itself:
 //
-//   - the PEM as written, which contains newlines (an "ssh-" prefix is
-//     accepted too, though that is a public key and go-git will reject it
-//     later with a better message than a stat failure would).
+//   - the PEM as written. Every private key PEM is multi-line, so a newline is
+//     what identifies it.
 //   - base64 of that PEM. This is the form set_as_rwr_ssh_key writes into
-//     repository.ssh_private_key and the form --ssh-key documents, and
-//     nothing decoded it: base64 has no newlines and no "ssh-" prefix, so it
-//     fell through to the file-path branch and rwr tried to open the blob as
-//     a filename. set_as_rwr_ssh_key produced a config value that could never
-//     authenticate anything.
+//     repository.ssh_private_key and the form --ssh-key documents, and nothing
+//     decoded it: base64 has no newlines, so it fell through to the file-path
+//     branch and rwr tried to open the blob as a filename. set_as_rwr_ssh_key
+//     produced a config value that could never authenticate anything.
+//
+// An "ssh-" prefix deliberately does not count, though it used to. It only
+// ever matches a public key ("ssh-rsa AAAA..."), and this flow hands its bytes
+// to ssh.NewPublicKeys, which needs the private half - so that branch could
+// never produce a working credential, only a worse error. What it did do is
+// swallow real paths: a key file named "ssh-key" or "ssh-private.pem" was
+// parsed as key data and failed with "ssh: no key found" instead of being
+// read.
 //
 // The decode has to prove itself: a bare filename can be valid base64 by
-// accident, so the decoded bytes must actually look like a key before they are
-// treated as one, and anything else stays a path.
+// accident, so the decoded bytes must actually look like a private key before
+// they are treated as one, and anything else stays a path.
 func sshKeyMaterial(value string) ([]byte, bool) {
-	if strings.Contains(value, "\n") || strings.HasPrefix(value, "ssh-") {
+	if strings.Contains(value, "\n") {
 		log.Debugf("Using the SSH key material as supplied")
 		return []byte(value), true
 	}
@@ -187,18 +200,21 @@ func sshKeyMaterial(value string) ([]byte, bool) {
 	if err != nil {
 		return nil, false
 	}
-	if !looksLikeSSHKey(decoded) {
+	if !looksLikePrivateKey(decoded) {
 		return nil, false
 	}
 	log.Debugf("Using base64-encoded SSH key material")
 	return decoded, true
 }
 
-// looksLikeSSHKey reports whether bytes are plausibly an SSH key, so a path
-// that happens to decode as base64 is not mistaken for one.
-func looksLikeSSHKey(data []byte) bool {
-	text := string(data)
-	return strings.Contains(text, "PRIVATE KEY") || strings.HasPrefix(text, "ssh-")
+// looksLikePrivateKey reports whether bytes are plausibly a private key, so a
+// path that happens to decode as base64 is not mistaken for one.
+//
+// Every PEM private key rwr can authenticate with says so in its header:
+// OPENSSH, RSA (PKCS#1), PKCS#8 and the encrypted forms all contain
+// "PRIVATE KEY". A public key does not, and could not be used here anyway.
+func looksLikePrivateKey(data []byte) bool {
+	return strings.Contains(string(data), "PRIVATE KEY")
 }
 
 // truncateForError keeps a bad ssh key value out of the log at full length: it
@@ -242,7 +258,7 @@ func getSSHAuthMethod(initConfig *types.InitConfig) (transport.AuthMethod, error
 			if errors.As(err, &pathErr) {
 				reason = pathErr.Err
 			}
-			return nil, fmt.Errorf("ssh key %q is neither a readable file nor recognisable key material: %w", truncateForError(sshKeyValue), reason)
+			return nil, fmt.Errorf("%w (%q): %v", ErrUnusableSSHKey, truncateForError(sshKeyValue), reason)
 		}
 
 		auth, err := ssh.NewPublicKeysFromFile("git", sshKeyValue, "")

--- a/internal/helpers/git_sshkey_test.go
+++ b/internal/helpers/git_sshkey_test.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"encoding/base64"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -42,11 +43,13 @@ func sshAuthFor(value string) (err error) {
 //
 // setAsRWRSSHKey stores base64 of the private key under
 // repository.ssh_private_key, and --ssh-key documents base64 as an accepted
-// input. Nothing decoded it: base64 has no newlines and no "ssh-" prefix, so
-// it fell through to the file-path branch and rwr tried to open the blob as a
-// filename, failing with "file name too long". set_as_rwr_ssh_key produced a
-// value that could never authenticate anything.
+// input. Nothing decoded it: base64 has no newlines, so it fell through to the
+// file-path branch and rwr tried to open the blob as a filename, failing with
+// "file name too long". set_as_rwr_ssh_key produced a value that could never
+// authenticate anything.
 func TestSSHAuthAcceptsBase64EncodedKey(t *testing.T) {
+	t.Parallel()
+
 	_, pem := generateKey(t)
 	encoded := base64.StdEncoding.EncodeToString(pem)
 
@@ -57,6 +60,8 @@ func TestSSHAuthAcceptsBase64EncodedKey(t *testing.T) {
 
 // The two forms that already worked must keep working.
 func TestSSHAuthAcceptsRawPEMAndPath(t *testing.T) {
+	t.Parallel()
+
 	path, pem := generateKey(t)
 
 	if err := sshAuthFor(string(pem)); err != nil {
@@ -67,10 +72,51 @@ func TestSSHAuthAcceptsRawPEMAndPath(t *testing.T) {
 	}
 }
 
+// A key file whose name begins with "ssh-" is a path, not key material.
+//
+// The classifier used to shortcut on that prefix, so "ssh-key" and
+// "ssh-private.pem" were parsed as key data and failed with "ssh: no key
+// found" while the same file's absolute path worked. The prefix only ever
+// matches a public key, which this flow cannot authenticate with, so the
+// shortcut could not enable any working case - it could only swallow paths.
+func TestSSHAuthTreatsSSHPrefixedNameAsPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, pem := generateKey(t)
+
+	for _, name := range []string{"ssh-key", "ssh-private.pem", "ssh-rsa"} {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, pem, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := sshAuthFor(path); err != nil {
+			t.Errorf("key file named %q rejected: %v", name, err)
+		}
+	}
+}
+
+// A public key is not a credential this flow can use. It must not be mistaken
+// for one, whether supplied directly or base64-encoded.
+func TestSSHAuthRejectsAPublicKey(t *testing.T) {
+	t.Parallel()
+
+	const pub = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHhkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA user@host"
+
+	if err := sshAuthFor(pub); err == nil {
+		t.Error("a public key was accepted as an authentication credential")
+	}
+	if err := sshAuthFor(base64.StdEncoding.EncodeToString([]byte(pub))); err == nil {
+		t.Error("a base64-encoded public key was accepted as an authentication credential")
+	}
+}
+
 // A path that happens to be valid base64 is still a path. "config" decodes
 // cleanly under StdEncoding, so the decode alone cannot be the test - the
 // decoded bytes have to look like a key.
 func TestSSHAuthTreatsBase64LookingPathAsPath(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	// "config" is 6 chars, a multiple of 3, so it round-trips as base64.
 	name := base64.StdEncoding.EncodeToString([]byte("config"))
@@ -90,14 +136,18 @@ func TestSSHAuthTreatsBase64LookingPathAsPath(t *testing.T) {
 // filename the operator never wrote. The message must not carry the whole
 // value, which may be the key itself.
 func TestSSHAuthRejectsUnusableValueClearly(t *testing.T) {
+	t.Parallel()
+
 	junk := strings.Repeat("z", 400)
 
 	err := sshAuthFor(junk)
 	if err == nil {
 		t.Fatal("expected an error for a value that is neither a key nor a path")
 	}
-	if !strings.Contains(err.Error(), "neither a readable file nor recognisable key material") {
-		t.Errorf("unhelpful error: %v", err)
+	// The sentinel, not the message text: the condition is part of the
+	// contract, the wording is not.
+	if !errors.Is(err, ErrUnusableSSHKey) {
+		t.Errorf("error is not ErrUnusableSSHKey: %v", err)
 	}
 	if strings.Contains(err.Error(), junk) {
 		t.Error("the error repeats the whole value; it may be a private key")

--- a/internal/helpers/git_sshkey_test.go
+++ b/internal/helpers/git_sshkey_test.go
@@ -1,0 +1,105 @@
+package helpers
+
+import (
+	"encoding/base64"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// generateKey writes a real ed25519 keypair and returns its path and PEM.
+// A hand-rolled fixture would not prove anything here: the point is that what
+// ssh-keygen produces, and what rwr stores about it, round-trips through
+// go-git.
+func generateKey(t *testing.T) (path string, pem []byte) {
+	t.Helper()
+	if _, err := exec.LookPath("ssh-keygen"); err != nil {
+		t.Skip("ssh-keygen not available")
+	}
+	path = filepath.Join(t.TempDir(), "id_ed25519")
+	if out, err := exec.Command("ssh-keygen", "-t", "ed25519", "-N", "", "-C", "rwr-test", "-f", path).CombinedOutput(); err != nil {
+		t.Skipf("ssh-keygen failed: %v: %s", err, out)
+	}
+	pem, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading generated key: %v", err)
+	}
+	return path, pem
+}
+
+func sshAuthFor(value string) (err error) {
+	cfg := &types.InitConfig{}
+	cfg.Variables.Flags.SSHKey = value
+	_, err = getSSHAuthMethod(cfg)
+	return err
+}
+
+// The regression this file exists for.
+//
+// setAsRWRSSHKey stores base64 of the private key under
+// repository.ssh_private_key, and --ssh-key documents base64 as an accepted
+// input. Nothing decoded it: base64 has no newlines and no "ssh-" prefix, so
+// it fell through to the file-path branch and rwr tried to open the blob as a
+// filename, failing with "file name too long". set_as_rwr_ssh_key produced a
+// value that could never authenticate anything.
+func TestSSHAuthAcceptsBase64EncodedKey(t *testing.T) {
+	_, pem := generateKey(t)
+	encoded := base64.StdEncoding.EncodeToString(pem)
+
+	if err := sshAuthFor(encoded); err != nil {
+		t.Fatalf("base64-encoded key rejected: %v", err)
+	}
+}
+
+// The two forms that already worked must keep working.
+func TestSSHAuthAcceptsRawPEMAndPath(t *testing.T) {
+	path, pem := generateKey(t)
+
+	if err := sshAuthFor(string(pem)); err != nil {
+		t.Errorf("raw PEM rejected: %v", err)
+	}
+	if err := sshAuthFor(path); err != nil {
+		t.Errorf("key path rejected: %v", err)
+	}
+}
+
+// A path that happens to be valid base64 is still a path. "config" decodes
+// cleanly under StdEncoding, so the decode alone cannot be the test - the
+// decoded bytes have to look like a key.
+func TestSSHAuthTreatsBase64LookingPathAsPath(t *testing.T) {
+	dir := t.TempDir()
+	// "config" is 6 chars, a multiple of 3, so it round-trips as base64.
+	name := base64.StdEncoding.EncodeToString([]byte("config"))
+	path := filepath.Join(dir, name)
+
+	_, pem := generateKey(t)
+	if err := os.WriteFile(path, pem, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sshAuthFor(path); err != nil {
+		t.Fatalf("base64-looking path rejected: %v", err)
+	}
+}
+
+// A value that is neither says so, rather than reporting a stat error about a
+// filename the operator never wrote. The message must not carry the whole
+// value, which may be the key itself.
+func TestSSHAuthRejectsUnusableValueClearly(t *testing.T) {
+	junk := strings.Repeat("z", 400)
+
+	err := sshAuthFor(junk)
+	if err == nil {
+		t.Fatal("expected an error for a value that is neither a key nor a path")
+	}
+	if !strings.Contains(err.Error(), "neither a readable file nor recognisable key material") {
+		t.Errorf("unhelpful error: %v", err)
+	}
+	if strings.Contains(err.Error(), junk) {
+		t.Error("the error repeats the whole value; it may be a private key")
+	}
+}

--- a/internal/helpers/git_sshkey_test.go
+++ b/internal/helpers/git_sshkey_test.go
@@ -153,3 +153,156 @@ func TestSSHAuthRejectsUnusableValueClearly(t *testing.T) {
 		t.Error("the error repeats the whole value; it may be a private key")
 	}
 }
+
+// wrapAt breaks a string into fixed-width lines, the way a hand-written or
+// tool-generated base64 blob usually arrives.
+func wrapAt(s string, width int, eol string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i += width {
+		end := i + width
+		if end > len(s) {
+			end = len(s)
+		}
+		b.WriteString(s[i:end])
+		b.WriteString(eol)
+	}
+	return b.String()
+}
+
+// Every base64 shape a hand-written --ssh-key value can arrive in.
+//
+// Column-wrapped base64 was the interesting one: it contains newlines, and the
+// classifier used to treat a newline as proof of raw PEM, so it went to go-git
+// as PEM and failed to parse. Go's decoder ignores embedded LF and CRLF, so it
+// would have decoded perfectly well - the value was rejected by the
+// classification, not by the encoding.
+func TestSSHAuthAcceptsEveryBase64Shape(t *testing.T) {
+	t.Parallel()
+
+	_, pem := generateKey(t)
+	std := base64.StdEncoding.EncodeToString(pem)
+
+	cases := map[string]string{
+		"unwrapped StdEncoding":   std,
+		"wrapped at 64 with LF":   wrapAt(std, 64, "\n"),
+		"wrapped at 64 with CRLF": wrapAt(std, 64, "\r\n"),
+		"wrapped at 76 with LF":   wrapAt(std, 76, "\n"),
+		"surrounded by space":     "  " + std + "\n",
+	}
+
+	for name, encoded := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if err := sshAuthFor(encoded); err != nil {
+				t.Errorf("%s rejected: %v", name, err)
+			}
+		})
+	}
+}
+
+// A PEM written on Windows has CRLF line endings, and is still the key.
+func TestSSHAuthAcceptsCRLFPEM(t *testing.T) {
+	t.Parallel()
+
+	_, pem := generateKey(t)
+	crlf := strings.ReplaceAll(string(pem), "\n", "\r\n")
+
+	if err := sshAuthFor(crlf); err != nil {
+		t.Errorf("CRLF PEM rejected: %v", err)
+	}
+}
+
+// A newline is not proof of key material. A path that somehow carries one is
+// still not a key, and must not be handed to the PEM parser.
+func TestSSHAuthDoesNotTreatANewlineAsKeyMaterial(t *testing.T) {
+	t.Parallel()
+
+	err := sshAuthFor("not-a-key\nnot-a-key-either")
+	if err == nil {
+		t.Fatal("a newline-containing non-key was accepted")
+	}
+	if !errors.Is(err, ErrUnusableSSHKey) {
+		t.Errorf("want ErrUnusableSSHKey, got: %v", err)
+	}
+}
+
+// paddedKeyLikePayload is PEM-shaped bytes chosen so the four base64 alphabets
+// actually disagree about it: its length is not a multiple of three (so the
+// unpadded encodings differ from the padded ones) and it contains bytes that
+// encode to "+" and "/" under the standard alphabet and to "-" and "_" under
+// the URL-safe one.
+//
+// A real ed25519 key will not do: its PEM is 411 bytes, a multiple of three,
+// with no bytes that diverge between the alphabets, so all four encodings
+// produce the identical string and a table of them tests one case four times.
+func paddedKeyLikePayload(t *testing.T) []byte {
+	t.Helper()
+
+	payload := append([]byte("-----BEGIN PRIVATE KEY-----\n"), 0xFF, 0xFE, 0xFD, 0xFB)
+	payload = append(payload, []byte("\n-----END PRIVATE KEY-----")...)
+	if len(payload)%3 == 0 {
+		payload = append(payload, '\n')
+	}
+
+	// The precondition this fixture exists for. If it ever stops holding, the
+	// table below silently stops testing anything.
+	if base64.StdEncoding.EncodeToString(payload) == base64.RawStdEncoding.EncodeToString(payload) {
+		t.Fatal("fixture no longer forces padding; the alphabets would not diverge")
+	}
+	if base64.StdEncoding.EncodeToString(payload) == base64.URLEncoding.EncodeToString(payload) {
+		t.Fatal("fixture no longer contains bytes that differ between the standard and URL alphabets")
+	}
+	return payload
+}
+
+// The classifier accepts all four base64 alphabets, padded and unpadded,
+// standard and URL-safe. Which one an operator's tooling emits is not
+// something rwr gets to choose.
+//
+// This drives sshKeyMaterial directly rather than going through go-git,
+// because the payload is PEM-shaped rather than a real key: the variation
+// under test is in the classification, and a real key cannot express it (see
+// paddedKeyLikePayload).
+func TestSSHKeyMaterialAcceptsEveryBase64Alphabet(t *testing.T) {
+	t.Parallel()
+
+	payload := paddedKeyLikePayload(t)
+
+	for name, encoding := range map[string]*base64.Encoding{
+		"StdEncoding":    base64.StdEncoding,
+		"RawStdEncoding": base64.RawStdEncoding,
+		"URLEncoding":    base64.URLEncoding,
+		"RawURLEncoding": base64.RawURLEncoding,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			decoded, ok := sshKeyMaterial(encoding.EncodeToString(payload))
+			if !ok {
+				t.Fatalf("%s-encoded key material was not recognised", name)
+			}
+			if string(decoded) != string(payload) {
+				t.Errorf("%s round-trip changed the bytes", name)
+			}
+		})
+	}
+}
+
+// Wrapping is orthogonal to the alphabet: a blob can arrive in either
+// alphabet at any column width.
+func TestSSHKeyMaterialAcceptsWrappedNonStandardAlphabets(t *testing.T) {
+	t.Parallel()
+
+	payload := paddedKeyLikePayload(t)
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+
+	for _, eol := range []string{"\n", "\r\n"} {
+		decoded, ok := sshKeyMaterial(wrapAt(encoded, 8, eol))
+		if !ok {
+			t.Fatalf("wrapped RawURLEncoding not recognised (eol %q)", eol)
+		}
+		if string(decoded) != string(payload) {
+			t.Errorf("wrapped RawURLEncoding round-trip changed the bytes (eol %q)", eol)
+		}
+	}
+}

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -266,11 +266,23 @@ func setAsRWRSSHKey(keyPath string) error {
 		return fmt.Errorf("error reading private key file: %v", err)
 	}
 
-	// Encode the private key as base64
+	// Encode the private key as base64. helpers.getSSHAuthMethod decodes this
+	// form; it is also what --ssh-key accepts, so the two agree.
 	encodedKey := base64.StdEncoding.EncodeToString(privateKey)
 
 	// Set the encoded key in Viper configuration
 	viper.Set("repository.ssh_private_key", encodedKey)
+
+	// The file is about to hold a private key, and viper writes at 0644 with
+	// no way to ask for less. Pre-creating it at 0600 means the key is never
+	// on disk world-readable, not even for the length of the write. The
+	// GitHub token path has done this since #234; this one still wrote first
+	// and tightened afterwards, on the more sensitive of the two secrets.
+	if path := viper.ConfigFileUsed(); path != "" {
+		if err := helpers.PrecreateSecureConfigFile(path); err != nil {
+			return err
+		}
+	}
 
 	// Write the updated configuration to file
 	err = viper.WriteConfig()
@@ -278,7 +290,8 @@ func setAsRWRSSHKey(keyPath string) error {
 		return fmt.Errorf("error writing updated configuration: %v", err)
 	}
 
-	// viper writes at 0644, and this file now contains the private key.
+	// Belt and braces: ConfigFileUsed is empty when no config was loaded, so
+	// WriteConfig may have created the file itself at 0644.
 	if err := helpers.SecureConfigFile(viper.ConfigFileUsed()); err != nil {
 		return fmt.Errorf("error restricting configuration permissions: %w", err)
 	}

--- a/internal/processors/ssh_key_store_test.go
+++ b/internal/processors/ssh_key_store_test.go
@@ -1,0 +1,95 @@
+package processors
+
+import (
+	"encoding/base64"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withConfigFile points viper at a throwaway config and returns its path.
+func withConfigFile(t *testing.T) string {
+	t.Helper()
+	viper.Reset()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	viper.SetConfigFile(path)
+	t.Cleanup(viper.Reset)
+	return path
+}
+
+// writeTestKey generates a real private key and returns its path.
+func writeTestKey(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("ssh-keygen"); err != nil {
+		t.Skip("ssh-keygen not available")
+	}
+	path := filepath.Join(t.TempDir(), "id_ed25519")
+	if out, err := exec.Command("ssh-keygen", "-t", "ed25519", "-N", "", "-C", "rwr-test", "-f", path).CombinedOutput(); err != nil {
+		t.Skipf("ssh-keygen failed: %v: %s", err, out)
+	}
+	return path
+}
+
+// The config file holds a private key when this is done, so it must never be
+// left readable by anyone else. viper writes at 0644 with no way to ask for
+// narrower, so the mode has to be established before the write rather than
+// repaired after it.
+func TestSetAsRWRSSHKeyLeavesConfigOwnerOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits")
+	}
+	configPath := withConfigFile(t)
+	keyPath := writeTestKey(t)
+
+	require.NoError(t, setAsRWRSSHKey(keyPath))
+
+	info, err := os.Stat(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, helpers.ConfigFilePerm, info.Mode().Perm(),
+		"config file holding a private key is not owner-only")
+}
+
+// The realistic starting state: a config file left at 0644 by an older rwr, or
+// by an operator's editor. It must be narrowed before the key lands in it, not
+// after.
+func TestSetAsRWRSSHKeyNarrowsAnExistingLooseConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits")
+	}
+	configPath := withConfigFile(t)
+	require.NoError(t, os.WriteFile(configPath, []byte("repository: {}\n"), 0o644))
+	keyPath := writeTestKey(t)
+
+	require.NoError(t, setAsRWRSSHKey(keyPath))
+
+	info, err := os.Stat(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, helpers.ConfigFilePerm, info.Mode().Perm())
+}
+
+// What gets stored has to be what the git auth path can read back. It stores
+// base64 of the PEM; for a long time nothing decoded that, so this recorded a
+// value no clone could ever use.
+func TestSetAsRWRSSHKeyStoresAValueGitAuthCanUse(t *testing.T) {
+	withConfigFile(t)
+	keyPath := writeTestKey(t)
+
+	require.NoError(t, setAsRWRSSHKey(keyPath))
+
+	stored := viper.GetString("repository.ssh_private_key")
+	require.NotEmpty(t, stored, "no key recorded")
+
+	decoded, err := base64.StdEncoding.DecodeString(stored)
+	require.NoError(t, err, "stored value is not the base64 form the reader expects")
+
+	original, err := os.ReadFile(keyPath)
+	require.NoError(t, err)
+	assert.Equal(t, original, decoded, "stored key does not round-trip to the file it came from")
+}


### PR DESCRIPTION
Two defects in the same path, found while auditing the config-file write.

## 1. `set_as_rwr_ssh_key` has never produced a usable key

`setAsRWRSSHKey` base64-encodes the private key into `repository.ssh_private_key`, and `--ssh-key` documents base64 as an accepted input. **Nothing ever decoded it.**

`getSSHAuthMethod` treated a value as key material only when it contained a newline or began with `ssh-`. Base64 has neither, so it fell through to the file-path branch and rwr tried to `open` the blob as a filename:

```
error creating SSH authentication from file:
open LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZ...: file name too long
```

Reproduced against a real `ssh-keygen` key: base64 fails, raw PEM works, path works. So `set_as_rwr_ssh_key: true` recorded a value no clone could use, and the base64 form described in `docs/blueprints/git.md`, `docs/cli/configuration.md` and `docs/blueprints/ssh-keys.md` never worked. The docs were right and the code was wrong, so this changes the code.

**Decode on read** rather than changing what is written: configs already hold base64 under that key, and `--ssh-key` has to accept it either way.

The decode proves itself before it is trusted. A bare filename can be valid base64 by accident (`config` round-trips), so the decoded bytes must look like a key or the value stays a path. There's a test for exactly that.

A stat failure now disqualifies a path for any reason rather than only `ENOENT` - the failing value above stats as `ENAMETOOLONG`, which is not `os.IsNotExist`, which is why it reached `NewPublicKeysFromFile` at all. The `PathError`'s own `Err` is wrapped, never the `PathError`: its message repeats the whole path, and when the value is key material that is a private key going into an error string.

## 2. The private key was briefly world-readable

The config file is written by viper at 0644 and tightened to 0600 afterwards, so a base64 private key sat on disk world-readable for the length of the write.

The GitHub token path has pre-created the file at 0600 since #234 (`helpers.PrecreateSecureConfigFile`). The private key, the more sensitive of the two secrets, still wrote first and repaired after. It now uses the same helper.

## Verification

Both fixes have regression tests that fail against the old code:

- with the decode removed, `TestSSHAuthAcceptsBase64EncodedKey` fails with the exact `file name too long` error above
- `TestSetAsRWRSSHKeyStoresAValueGitAuthCanUse` asserts the stored value round-trips to the file it came from
- `TestSetAsRWRSSHKeyNarrowsAnExistingLooseConfig` covers the realistic case: a config left at 0644 by an older rwr

`go test -race ./...` green on darwin, `golangci-lint` 0 issues, `go vet` clean, gosec and govulncheck clean via the pre-push hook.

## Not in scope

`ssh_private_key` still has no keyring path, unlike `gh_api_token` - `ResolveBuiltins` reads the keyring for the token but not for the key. Worth doing, but it needs both a read and a write side and is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SSH authentication now accepts raw private keys, base64-encoded keys, or file paths.
  - Key values are validated before use, with clearer errors that avoid exposing sensitive content.

- **Security**
  - SSH configuration files are created and maintained with owner-only permissions.
  - Existing configuration files have their permissions tightened when needed.

- **Bug Fixes**
  - Improved handling of file paths that resemble base64-encoded values.
  - Preserved useful filesystem error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->