### PR TITLE
fix(state): a file's identity is its destination, not its content

### DIFF
--- a/internal/state/read.go
+++ b/internal/state/read.go
@@ -15,13 +15,28 @@ import (
 // history recorded before the event log survives it.
 func Applies(configDir string) ([]Entry, error) {
 	var entries []Entry
-	reversed := map[string]bool{}
+	// applyPos[i] is the journal position of entries[i]. The log is append
+	// only, so position is time: it is what lets a reversal be compared
+	// against the apply it is meant to undo.
+	var applyPos []int
+	// reversedAt holds the position of the most recent reverse per identity,
+	// not merely the fact that one exists. A reversal only cancels an apply
+	// that came before it: apply, uninstall, re-apply leaves the file on disk
+	// and the record has to say so.
+	reversedAt := map[string]int{}
+	position := 0
 
 	legacy, err := legacyEntries(configDir)
 	if err != nil {
 		return nil, err
 	}
-	entries = append(entries, legacy...)
+	// v1 records predate the event log, so every one of them sorts before
+	// every journal event.
+	for _, entry := range legacy {
+		entries = append(entries, entry)
+		applyPos = append(applyPos, position)
+		position++
+	}
 
 	file, err := os.Open(JournalPath(configDir)) // #nosec G304 -- rwr's own state directory
 	if err == nil {
@@ -35,6 +50,9 @@ func Applies(configDir string) ([]Entry, error) {
 			if json.Unmarshal(scanner.Bytes(), &event) != nil {
 				continue
 			}
+			// Every parsed event advances position, including the run and
+			// finish events, so positions stay strictly ordered.
+			position++
 			switch event.Kind {
 			case "apply":
 				if event.OK {
@@ -43,19 +61,20 @@ func Applies(configDir string) ([]Entry, error) {
 						Identity: event.Identity, Detail: event.Detail,
 						Outcome: event.Outcome, OK: event.OK, Elevated: event.Elevated,
 					})
+					applyPos = append(applyPos, position)
 				}
 			case "reverse":
-				reversed[Key(event.Processor, event.Identity)] = true
+				reversedAt[Key(event.Processor, event.Identity)] = position
 			}
 		}
 	} else if !os.IsNotExist(err) {
 		return nil, err
 	}
 
-	// Latest apply per identity wins; reversal marks apply to the identity.
-	// The latest entry is the one kept, so its guard values (a file's sha256)
-	// are the ones consumers see - the hash of the content actually on disk
-	// after the most recent apply, which is what a hash-guarded delete needs.
+	// Latest apply per identity wins. The latest entry is the one kept, so
+	// its guard values (a file's sha256) are the ones consumers see - the
+	// hash of the content actually on disk after the most recent apply,
+	// which is what a hash-guarded delete needs.
 	latest := map[string]int{}
 	var order []string
 	for i, entry := range entries {
@@ -67,8 +86,16 @@ func Applies(configDir string) ([]Entry, error) {
 	}
 	folded := make([]Entry, 0, len(order))
 	for _, key := range order {
-		entry := entries[latest[key]]
-		entry.Reversed = entry.Reversed || reversed[Key(entry.Processor, entry.Identity)]
+		index := latest[key]
+		entry := entries[index]
+		// Reversed only when the reversal came after the apply being kept.
+		// Treating any reversal as cancelling the identity forever meant
+		// `rwr all`, `rwr uninstall`, `rwr all` left every re-applied unit
+		// looking reversed: uninstall would not offer to remove it again and
+		// status did not count it, while the thing was sitting on disk.
+		if pos, ok := reversedAt[key]; ok && pos > applyPos[index] {
+			entry.Reversed = true
+		}
 		folded = append(folded, entry)
 	}
 	return folded, nil

--- a/internal/state/read.go
+++ b/internal/state/read.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // Applies folds the journal into applied entries: OK applies only, the
@@ -44,7 +45,7 @@ func Applies(configDir string) ([]Entry, error) {
 					})
 				}
 			case "reverse":
-				reversed[event.Processor+"\x00"+identityString(event.Identity)] = true
+				reversed[Key(event.Processor, event.Identity)] = true
 			}
 		}
 	} else if !os.IsNotExist(err) {
@@ -52,10 +53,13 @@ func Applies(configDir string) ([]Entry, error) {
 	}
 
 	// Latest apply per identity wins; reversal marks apply to the identity.
+	// The latest entry is the one kept, so its guard values (a file's sha256)
+	// are the ones consumers see - the hash of the content actually on disk
+	// after the most recent apply, which is what a hash-guarded delete needs.
 	latest := map[string]int{}
 	var order []string
 	for i, entry := range entries {
-		key := entry.Processor + "\x00" + identityString(entry.Identity)
+		key := Key(entry.Processor, entry.Identity)
 		if _, seen := latest[key]; !seen {
 			order = append(order, key)
 		}
@@ -64,7 +68,7 @@ func Applies(configDir string) ([]Entry, error) {
 	folded := make([]Entry, 0, len(order))
 	for _, key := range order {
 		entry := entries[latest[key]]
-		entry.Reversed = entry.Reversed || reversed[entry.Processor+"\x00"+identityString(entry.Identity)]
+		entry.Reversed = entry.Reversed || reversed[Key(entry.Processor, entry.Identity)]
 		folded = append(folded, entry)
 	}
 	return folded, nil
@@ -85,18 +89,44 @@ func Unreversed(configDir string) ([]Entry, error) {
 	return kept, nil
 }
 
-// identityString renders an identity deterministically for keying.
-func identityString(identity map[string]string) string {
+// guardKeys are identity entries that describe the state a unit was left in
+// rather than which unit it is.
+//
+// They travel inside Identity because consumers need them next to the thing
+// they guard: uninstall refuses to delete a file whose content no longer
+// matches the recorded sha256. But two applies that differ only in a guard are
+// the same unit, and folding has to say so.
+//
+// Including sha256 in the fold key meant re-applying a file with changed
+// content produced a brand new identity. The previous entry never folded away
+// and stayed unreversed forever, so the journal accreted one permanent entry
+// per content version, `rwr uninstall` planned N deletes for one path (N-1
+// reporting "already absent"), and `rwr status` could report a live file as
+// stale.
+var guardKeys = map[string]bool{"sha256": true}
+
+// Key renders the identifying part of an identity deterministically, so the
+// same unit keys the same way across runs and across a reversal.
+func Key(processor string, identity map[string]string) string {
 	keys := make([]string, 0, len(identity))
 	for k := range identity {
+		if guardKeys[k] {
+			continue
+		}
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	s := ""
+
+	var b strings.Builder
+	b.WriteString(processor)
+	b.WriteString("\x00")
 	for _, k := range keys {
-		s += k + "=" + identity[k] + ";"
+		b.WriteString(k)
+		b.WriteString("=")
+		b.WriteString(identity[k])
+		b.WriteString(";")
 	}
-	return s
+	return b.String()
 }
 
 // legacyEntries reads the v1 per-run record files this format replaced.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -88,12 +88,14 @@ func TestJournal_ReversalIsAnEvent(t *testing.T) {
 	}
 }
 
-// The latest apply per identity wins: re-applying after a reversal makes
-// the entry live again only if the reversal preceded the re-apply... a
-// reversal event marks the identity, so a later apply of the same identity
-// still shows reversed. That is the simple rule; a re-provisioned machine
-// writes new identities in practice (new run, same identity) and status
-// reads disk anyway. Documented by this test.
+// The latest apply per identity wins.
+//
+// This used to carry a caveat: a reversal marked the identity whatever the
+// order, so a later apply of the same identity still showed reversed, on the
+// reasoning that a re-provisioned machine writes new identities anyway. It
+// does not - a re-run writes the same identity - so that rule hid every
+// re-applied unit after an uninstall. Reversal is now ordered against the
+// apply it cancels; see TestJournal_ReapplyAfterReversalIsLiveAgain.
 func TestJournal_LatestApplyWins(t *testing.T) {
 	dir := t.TempDir()
 	w, _ := NewWriter(dir, "tree", false)
@@ -213,5 +215,97 @@ func TestJournal_DistinctDestinationsStayDistinct(t *testing.T) {
 	}
 	if len(applies) != 2 {
 		t.Fatalf("applies = %d, want 2 distinct destinations: %+v", len(applies), applies)
+	}
+}
+
+// apply, uninstall, apply again: the file is on disk, and the record has to
+// say so.
+//
+// A reversal used to cancel an identity forever, whatever order the events
+// arrived in. Re-provisioning after an uninstall therefore left every
+// re-applied unit looking reversed: `rwr uninstall` would not offer to remove
+// it a second time and `rwr status` did not count it, while the thing was
+// sitting right there. Files escaped this by accident, because their identity
+// carried a content hash that made each apply a different key; folding on the
+// destination removed that accident, so the ordering has to be real.
+func TestJournal_ReapplyAfterReversalIsLiveAgain(t *testing.T) {
+	dir := t.TempDir()
+	identity := map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "aaa"}
+
+	w, _ := NewWriter(dir, "tree", false)
+	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok", Identity: identity})
+	_ = w.Finalize()
+
+	u, _ := NewWriter(dir, "", false)
+	u.Reverse("files", identity)
+	_ = u.Finalize()
+
+	again, _ := NewWriter(dir, "tree", false)
+	again.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
+		Identity: map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "bbb"}})
+	_ = again.Finalize()
+
+	live, err := Unreversed(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(live) != 1 {
+		t.Fatalf("the re-applied file is hidden by the earlier reversal: %+v", live)
+	}
+	if got := live[0].Identity["sha256"]; got != "bbb" {
+		t.Errorf("sha256 = %q, want the re-applied content", got)
+	}
+}
+
+// The same ordering rule for an identity that carries no guard at all, which
+// is every processor other than files. This case was wrong before the fold
+// keyed on identifying fields too, so it is not a files-only concern.
+func TestJournal_ReapplyAfterReversalIsLiveAgainForPackages(t *testing.T) {
+	dir := t.TempDir()
+	identity := map[string]string{"name": "git", "provider": "pacman"}
+
+	w, _ := NewWriter(dir, "tree", false)
+	w.Append(Entry{Processor: "packages", Action: "install", OK: true, Outcome: "ok", Identity: identity})
+	_ = w.Finalize()
+
+	u, _ := NewWriter(dir, "", false)
+	u.Reverse("packages", identity)
+	_ = u.Finalize()
+
+	again, _ := NewWriter(dir, "tree", false)
+	again.Append(Entry{Processor: "packages", Action: "install", OK: true, Outcome: "ok", Identity: identity})
+	_ = again.Finalize()
+
+	live, err := Unreversed(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(live) != 1 {
+		t.Fatalf("the reinstalled package is hidden by the earlier reversal: %+v", live)
+	}
+}
+
+// The other direction still holds: a reversal that comes after the last apply
+// really does cancel it, or uninstall would keep offering to remove things it
+// already removed.
+func TestJournal_ReversalAfterTheLastApplyStillCancelsIt(t *testing.T) {
+	dir := t.TempDir()
+	identity := map[string]string{"name": "git", "provider": "pacman"}
+
+	w, _ := NewWriter(dir, "tree", false)
+	w.Append(Entry{Processor: "packages", Action: "install", OK: true, Outcome: "ok", Identity: identity})
+	w.Append(Entry{Processor: "packages", Action: "install", OK: true, Outcome: "ok", Identity: identity})
+	_ = w.Finalize()
+
+	u, _ := NewWriter(dir, "", false)
+	u.Reverse("packages", identity)
+	_ = u.Finalize()
+
+	live, err := Unreversed(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("a reversal after the last apply did not cancel it: %+v", live)
 	}
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -136,3 +136,82 @@ func TestLegacyV1RecordsFoldIn(t *testing.T) {
 		t.Fatalf("unreversed = %+v", unreversed)
 	}
 }
+
+// A file re-applied with changed content is the same file, not a second one.
+//
+// The identity a files apply records is {name, dest, sha256}. Folding on the
+// whole map meant a content change produced a brand new key: the previous
+// entry never folded away and stayed unreversed forever. The journal accreted
+// one permanent entry per content version, `rwr uninstall` planned a delete
+// for each of them, and `rwr status` could call a live file stale.
+func TestJournal_FileReapplyWithNewContentFoldsToOneEntry(t *testing.T) {
+	dir := t.TempDir()
+	w, _ := NewWriter(dir, "tree", false)
+	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
+		Identity: map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "aaa"}, Detail: "first"})
+	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
+		Identity: map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "bbb"}, Detail: "second"})
+	_ = w.Finalize()
+
+	applies, err := Applies(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(applies) != 1 {
+		t.Fatalf("applies = %d entries, want 1 folded entry: %+v", len(applies), applies)
+	}
+	if applies[0].Detail != "second" {
+		t.Errorf("kept the wrong apply: %+v", applies[0])
+	}
+	// The surviving entry carries the latest guard, which is what a
+	// hash-guarded delete has to compare against.
+	if got := applies[0].Identity["sha256"]; got != "bbb" {
+		t.Errorf("sha256 = %q, want the most recent apply's hash", got)
+	}
+}
+
+// Reversal has to match across a content change too: uninstall records the
+// identity it saw, and a re-apply before that reversal must not leave a
+// stale-hashed twin behind that looks unreversed.
+func TestJournal_ReversalMatchesAcrossAContentChange(t *testing.T) {
+	dir := t.TempDir()
+	w, _ := NewWriter(dir, "tree", false)
+	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
+		Identity: map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "aaa"}})
+	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
+		Identity: map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "bbb"}})
+	_ = w.Finalize()
+
+	u, _ := NewWriter(dir, "", false)
+	// uninstall reverses what it read: the latest identity, hash included.
+	u.Reverse("files", map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "bbb"})
+	_ = u.Finalize()
+
+	unreversed, err := Unreversed(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unreversed) != 0 {
+		t.Fatalf("unreversed = %+v, want nothing left to reverse", unreversed)
+	}
+}
+
+// Two genuinely different files stay two units: dropping the guard from the
+// key must not collapse anything that is actually distinct.
+func TestJournal_DistinctDestinationsStayDistinct(t *testing.T) {
+	dir := t.TempDir()
+	w, _ := NewWriter(dir, "tree", false)
+	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
+		Identity: map[string]string{"name": "rc", "dest": "/tmp/one", "sha256": "aaa"}})
+	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
+		Identity: map[string]string{"name": "rc", "dest": "/tmp/two", "sha256": "aaa"}})
+	_ = w.Finalize()
+
+	applies, err := Applies(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(applies) != 2 {
+		t.Fatalf("applies = %d, want 2 distinct destinations: %+v", len(applies), applies)
+	}
+}


### PR DESCRIPTION
The identity a files apply records is `{name, dest, sha256}`, and `Applies` folded the journal on the whole map. A file re-applied with **changed content** therefore produced a brand new key, so the previous entry never folded away and stayed unreversed forever.

Three consequences, all growing with every run:

- the journal accretes one permanent live entry per content version of every file rwr manages
- `rwr uninstall` plans a delete for each of them: N attempts at one path, of which N-1 report `already absent`
- `rwr status` can report a file that is present and current as `stale`, because an older content version's entry is still unreversed and no longer matches anything in the tree

Reversal had the same fault from the other side. uninstall records the identity it read, hash included, so reversing a file left every earlier content version's entry unmatched and still live.

## The fix

`sha256` is a **guard**, not an identifier. It travels inside `Identity` because consumers need it next to the thing it guards (uninstall refuses to delete a file whose content no longer matches), but two applies that differ only in a guard are the same unit, and folding has to say so.

`state.Key` drops known guard keys when it renders a fold key, and both the apply fold and the reversal match go through it. The latest apply still wins, so the surviving entry carries the most recent hash, which is the one a hash-guarded delete has to compare against.

**Journals already on disk read correctly** - the change is in how keys are computed, not in what is written. No format version bump needed.

`Key` is exported because `status` and `diff` each open-code their own variant of this keying (on `name` alone, which is a different bug), and unifying them wants one function to unify on. That cleanup is not in this PR.

## Verification

Three new tests. Against the old code, two of them fail with exactly the described symptoms:

```
--- FAIL: TestJournal_FileReapplyWithNewContentFoldsToOneEntry
    applies = 2 entries, want 1 folded entry:
    [{... Identity:map[dest:/tmp/rc name:rc sha256:aaa] Detail:first}
     {... Identity:map[dest:/tmp/rc name:rc sha256:bbb] Detail:second}]

--- FAIL: TestJournal_ReversalMatchesAcrossAContentChange
    unreversed = [{... sha256:aaa}], want nothing left to reverse
```

The third, `TestJournal_DistinctDestinationsStayDistinct`, passes both before and after on purpose: it guards against over-collapsing, so that dropping the guard from the key cannot merge two genuinely different files.

`go test -race ./...` green on darwin, `golangci-lint` 0 issues, `go vet` clean, gosec and govulncheck clean via the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reapplying a file change with updated content now replaces the previous entry while retaining the latest content information.
  * Reversals now correctly match earlier file changes even when content has changed.
  * Files at different destinations continue to be tracked as separate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->