### PR TITLE
fix(uninstall): reverse services on macOS, and say why when we cannot

### DIFF
--- a/internal/status/query.go
+++ b/internal/status/query.go
@@ -4,6 +4,7 @@
 package status
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"regexp"
@@ -108,9 +109,19 @@ var validUnitName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.@:\\-]*$`)
 // ServiceState queries a service read-only on the current platform; other
 // platforms and query failures are Unknown.
 func ServiceState(name string) Presence {
-	if name == "" || runtime.GOOS != "linux" || !validUnitName.MatchString(name) {
+	if name == "" || !validUnitName.MatchString(name) {
 		return Unknown
 	}
+	switch runtime.GOOS {
+	case types.OSLinux:
+		return systemdState(name)
+	case types.OSDarwin:
+		return launchdState(name)
+	}
+	return Unknown
+}
+
+func systemdState(name string) Presence {
 	if _, err := exec.LookPath("systemctl"); err != nil {
 		return Unknown
 	}
@@ -126,4 +137,30 @@ func ServiceState(name string) Presence {
 		return Absent
 	}
 	return Unknown
+}
+
+// launchdState asks launchctl whether a label is loaded.
+//
+// `launchctl list <label>` prints the job's dictionary and exits zero when the
+// label is loaded, non-zero when it is not. That is the same verb the services
+// processor's own "status" action uses, so status and apply agree about what
+// "this service is here" means.
+//
+// Loaded, not enabled: launchd has no single is-enabled equivalent, and a job
+// that is loaded is the state `rwr services` produces with `launchctl load`.
+// Reporting Absent for a label launchctl does not know is honest; anything
+// less certain stays Unknown.
+func launchdState(name string) Presence {
+	if _, err := exec.LookPath("launchctl"); err != nil {
+		return Unknown
+	}
+	query := exec.Command("launchctl", "list", name) // #nosec G204 -- argv-exec'd read-only query; name validated against the unit-name pattern above
+	if err := query.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return Absent
+		}
+		return Unknown
+	}
+	return Present
 }

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -224,6 +224,24 @@ func reverseGit(entry state.Entry) (string, error) {
 	return "", os.RemoveAll(target)
 }
 
+// serviceState is the presence query reverseService consults, as a var so a
+// test can decide the answer.
+//
+// Without it a test can only assert "some skip reason", because the real
+// answer depends on which service manager the machine happens to run. The
+// three reasons being distinguishable is the whole point of the change, so
+// the test has to be able to reach each of them.
+var serviceState = status.ServiceState
+
+// SetServiceStateForTest installs a presence query for the duration of a test
+// and returns the restore func, in the same shape as
+// system.SetProvidersForTest and credentials.SetRingForTest.
+func SetServiceStateForTest(query func(string) status.Presence) (restore func()) {
+	previous := serviceState
+	serviceState = query
+	return func() { serviceState = previous }
+}
+
 // reverseService disables a recorded service on the platform it was enabled
 // on.
 //
@@ -245,7 +263,7 @@ func reverseService(entry state.Entry) (string, error) {
 		return fmt.Sprintf("no service reversal on %s", runtime.GOOS), nil
 	}
 
-	switch status.ServiceState(name) {
+	switch serviceState(name) {
 	case status.Absent:
 		return "already disabled", nil
 	case status.Unknown:

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"charm.land/log/v2"
@@ -223,15 +224,62 @@ func reverseGit(entry state.Entry) (string, error) {
 	return "", os.RemoveAll(target)
 }
 
+// reverseService disables a recorded service on the platform it was enabled
+// on.
+//
+// Every skip used to read "not enabled or not queryable", which folded three
+// different situations into one sentence: the service really is already
+// disabled, the query could not answer, and the platform had no reversal at
+// all. On macOS it was always the third - ServiceState answered Unknown for
+// anything non-Linux, so uninstall skipped every service and told the operator
+// nothing about why, even though the services processor has had a full launchd
+// backend the whole time. Each case now says which one it is.
 func reverseService(entry state.Entry) (string, error) {
 	name := entry.Identity["name"]
-	if status.ServiceState(name) != status.Present {
-		return "not enabled or not queryable", nil
+	if name == "" {
+		return "no recorded service name", nil
 	}
-	cmd := types.Command{
-		Exec:     "systemctl",
-		Args:     []string{"disable", "--now", name},
-		Elevated: true,
+
+	cmd, ok := disableServiceCommand(name, entry)
+	if !ok {
+		return fmt.Sprintf("no service reversal on %s", runtime.GOOS), nil
 	}
+
+	switch status.ServiceState(name) {
+	case status.Absent:
+		return "already disabled", nil
+	case status.Unknown:
+		return "cannot query the service; not disabling it blind", nil
+	}
+
 	return "", system.RunCommand(cmd, false)
+}
+
+// disableServiceCommand is the platform's "stop it and keep it stopped" verb,
+// taken from the same tools the services processor applies with, so uninstall
+// undoes what apply did rather than guessing at an equivalent.
+func disableServiceCommand(name string, entry state.Entry) (types.Command, bool) {
+	switch runtime.GOOS {
+	case types.OSLinux:
+		return types.Command{
+			Exec:     "systemctl",
+			Args:     []string{"disable", "--now", name},
+			Elevated: true,
+		}, true
+	case types.OSDarwin:
+		// The inverse of the processor's enable action, which is
+		// `launchctl load /Library/LaunchDaemons/<name>.plist`. The recorded
+		// target is preferred when the apply captured one, because a daemon
+		// can be installed somewhere else entirely.
+		plist := entry.Identity["target"]
+		if plist == "" {
+			plist = fmt.Sprintf("/Library/LaunchDaemons/%s.plist", name)
+		}
+		return types.Command{
+			Exec:     "launchctl",
+			Args:     []string{"unload", "-w", plist},
+			Elevated: entry.Elevated,
+		}, true
+	}
+	return types.Command{}, false
 }

--- a/internal/uninstall/uninstall_service_test.go
+++ b/internal/uninstall/uninstall_service_test.go
@@ -1,0 +1,115 @@
+package uninstall
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/state"
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+func serviceEntry(name string, identity map[string]string) state.Entry {
+	merged := map[string]string{"name": name}
+	for k, v := range identity {
+		merged[k] = v
+	}
+	return state.Entry{
+		Processor: types.BlueprintTypeServices,
+		Action:    "enable", OK: true, Outcome: "ok",
+		Identity: merged,
+	}
+}
+
+// Every platform rwr provisions services on has a reversal, taken from the
+// same tool the services processor applies with. macOS had none: uninstall
+// skipped every service and said "not enabled or not queryable", even though
+// the processor has had a full launchd backend the whole time.
+func TestDisableServiceCommandPerPlatform(t *testing.T) {
+	cmd, ok := disableServiceCommand("nginx", serviceEntry("nginx", nil))
+
+	switch runtime.GOOS {
+	case types.OSLinux:
+		if !ok {
+			t.Fatal("linux has no service reversal")
+		}
+		if cmd.Exec != "systemctl" {
+			t.Errorf("exec = %q, want systemctl", cmd.Exec)
+		}
+		if strings.Join(cmd.Args, " ") != "disable --now nginx" {
+			t.Errorf("args = %v", cmd.Args)
+		}
+	case types.OSDarwin:
+		if !ok {
+			t.Fatal("darwin has no service reversal")
+		}
+		if cmd.Exec != "launchctl" {
+			t.Errorf("exec = %q, want launchctl", cmd.Exec)
+		}
+		// The inverse of the processor's enable action, which loads the
+		// daemon from /Library/LaunchDaemons.
+		if strings.Join(cmd.Args, " ") != "unload -w /Library/LaunchDaemons/nginx.plist" {
+			t.Errorf("args = %v", cmd.Args)
+		}
+	default:
+		if ok {
+			t.Errorf("%s claims a service reversal it does not have", runtime.GOOS)
+		}
+	}
+}
+
+// A daemon can be installed somewhere other than /Library/LaunchDaemons, and
+// the apply records where it put it. The recorded target wins over the
+// convention.
+func TestDisableServiceCommandPrefersTheRecordedTarget(t *testing.T) {
+	if runtime.GOOS != types.OSDarwin {
+		t.Skip("launchd only")
+	}
+	entry := serviceEntry("nginx", map[string]string{"target": "/Users/me/Library/LaunchAgents/nginx.plist"})
+
+	cmd, ok := disableServiceCommand("nginx", entry)
+	if !ok {
+		t.Fatal("darwin has no service reversal")
+	}
+	if got := cmd.Args[len(cmd.Args)-1]; got != "/Users/me/Library/LaunchAgents/nginx.plist" {
+		t.Errorf("plist = %q, want the recorded target", got)
+	}
+}
+
+// The three reasons a service is left alone are different situations and the
+// operator has to be able to tell them apart. They were one sentence -
+// "not enabled or not queryable" - which on macOS always meant the third and
+// never said so.
+func TestReverseServiceSkipReasonsAreDistinct(t *testing.T) {
+	if _, err := reverseService(serviceEntry("", nil)); err != nil {
+		t.Fatal(err)
+	}
+	reason, err := reverseService(serviceEntry("", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != "no recorded service name" {
+		t.Errorf("missing name reason = %q", reason)
+	}
+
+	// A name no service manager knows: on a platform with a reversal that is
+	// "already disabled" or an honest "cannot query"; on one without, it must
+	// name the platform rather than blaming the service.
+	reason, err = reverseService(serviceEntry("rwr-test-definitely-not-a-real-service", nil))
+	if err != nil {
+		t.Fatalf("reversing an absent service should skip, not fail: %v", err)
+	}
+	if reason == "" {
+		t.Fatal("an unknown service was not skipped")
+	}
+	switch runtime.GOOS {
+	case types.OSLinux, types.OSDarwin:
+		if strings.Contains(reason, "no service reversal on") {
+			t.Errorf("%s does have a service reversal, but reported %q", runtime.GOOS, reason)
+		}
+	default:
+		if !strings.Contains(reason, "no service reversal on "+runtime.GOOS) {
+			t.Errorf("reason = %q, want it to name the platform", reason)
+		}
+	}
+}

--- a/internal/uninstall/uninstall_service_test.go
+++ b/internal/uninstall/uninstall_service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/fynxlabs/rwr/internal/state"
+	"github.com/fynxlabs/rwr/internal/status"
 	"github.com/fynxlabs/rwr/internal/types"
 )
 
@@ -26,6 +27,8 @@ func serviceEntry(name string, identity map[string]string) state.Entry {
 // skipped every service and said "not enabled or not queryable", even though
 // the processor has had a full launchd backend the whole time.
 func TestDisableServiceCommandPerPlatform(t *testing.T) {
+	t.Parallel()
+
 	cmd, ok := disableServiceCommand("nginx", serviceEntry("nginx", nil))
 
 	switch runtime.GOOS {
@@ -65,6 +68,8 @@ func TestDisableServiceCommandPrefersTheRecordedTarget(t *testing.T) {
 	if runtime.GOOS != types.OSDarwin {
 		t.Skip("launchd only")
 	}
+	t.Parallel()
+
 	entry := serviceEntry("nginx", map[string]string{"target": "/Users/me/Library/LaunchAgents/nginx.plist"})
 
 	cmd, ok := disableServiceCommand("nginx", entry)
@@ -80,36 +85,75 @@ func TestDisableServiceCommandPrefersTheRecordedTarget(t *testing.T) {
 // operator has to be able to tell them apart. They were one sentence -
 // "not enabled or not queryable" - which on macOS always meant the third and
 // never said so.
+//
+// The presence query is injected rather than asked of the host, or the test
+// could only assert "some reason": which one comes back depends on the
+// service manager the machine happens to run, and being able to reach each of
+// them is the point.
 func TestReverseServiceSkipReasonsAreDistinct(t *testing.T) {
-	if _, err := reverseService(serviceEntry("", nil)); err != nil {
-		t.Fatal(err)
+	if runtime.GOOS != types.OSLinux && runtime.GOOS != types.OSDarwin {
+		t.Skipf("%s has no service reversal; covered by the platform test", runtime.GOOS)
 	}
+
+	tests := []struct {
+		name  string
+		state status.Presence
+		want  string
+	}{
+		{name: "already disabled", state: status.Absent, want: "already disabled"},
+		{name: "unqueryable", state: status.Unknown, want: "cannot query the service; not disabling it blind"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer SetServiceStateForTest(func(string) status.Presence { return tt.state })()
+
+			reason, err := reverseService(serviceEntry("nginx", nil))
+			if err != nil {
+				t.Fatalf("a skip must not be an error: %v", err)
+			}
+			if reason != tt.want {
+				t.Errorf("reason = %q, want %q", reason, tt.want)
+			}
+		})
+	}
+}
+
+// A recorded entry with no name at all is its own case, and it must not reach
+// the service manager.
+func TestReverseServiceWithoutANameSkips(t *testing.T) {
+	defer SetServiceStateForTest(func(string) status.Presence {
+		t.Error("queried the service manager for an entry with no name")
+		return status.Unknown
+	})()
+
 	reason, err := reverseService(serviceEntry("", nil))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if reason != "no recorded service name" {
-		t.Errorf("missing name reason = %q", reason)
+		t.Errorf("reason = %q, want the missing-name reason", reason)
 	}
+}
 
-	// A name no service manager knows: on a platform with a reversal that is
-	// "already disabled" or an honest "cannot query"; on one without, it must
-	// name the platform rather than blaming the service.
-	reason, err = reverseService(serviceEntry("rwr-test-definitely-not-a-real-service", nil))
+// A platform with no reversal says so, and says which platform, rather than
+// implying the service was already disabled. It must decide that before it
+// consults the service manager, since there is nothing it could do with the
+// answer.
+func TestReverseServiceNamesAPlatformWithNoReversal(t *testing.T) {
+	if runtime.GOOS == types.OSLinux || runtime.GOOS == types.OSDarwin {
+		t.Skipf("%s has a service reversal", runtime.GOOS)
+	}
+	defer SetServiceStateForTest(func(string) status.Presence {
+		t.Error("queried the service manager on a platform with no reversal")
+		return status.Unknown
+	})()
+
+	reason, err := reverseService(serviceEntry("nginx", nil))
 	if err != nil {
-		t.Fatalf("reversing an absent service should skip, not fail: %v", err)
+		t.Fatal(err)
 	}
-	if reason == "" {
-		t.Fatal("an unknown service was not skipped")
-	}
-	switch runtime.GOOS {
-	case types.OSLinux, types.OSDarwin:
-		if strings.Contains(reason, "no service reversal on") {
-			t.Errorf("%s does have a service reversal, but reported %q", runtime.GOOS, reason)
-		}
-	default:
-		if !strings.Contains(reason, "no service reversal on "+runtime.GOOS) {
-			t.Errorf("reason = %q, want it to name the platform", reason)
-		}
+	if !strings.Contains(reason, "no service reversal on "+runtime.GOOS) {
+		t.Errorf("reason = %q, want it to name the platform", reason)
 	}
 }


### PR DESCRIPTION
`rwr uninstall` could not disable a service on anything but Linux, and never said so.

`status.ServiceState` answered `Unknown` for any non-Linux platform, so `reverseService` took its skip branch **before** it built a command, and every macOS service came back as:

```
skipped: disable service nginx - not enabled or not queryable
```

That one sentence folds three different situations together: the service really is already disabled, the query could not answer, and this platform has no reversal at all. On macOS it was always the third, and the operator was left to guess - while `internal/processors/services.go` has had a full launchd backend the whole time.

(To be precise about the failure mode: it never shelled out to a missing `systemctl`. The `ServiceState != Present` guard short-circuited first. The defect is a silent structural gap plus a misleading message, not a crash.)

## Changes

**`status.ServiceState` answers on darwin** through `launchctl list <label>` - the same verb the processor's own `status` action uses, so status and apply agree about what "this service is here" means. Verified behaviour:

```
$ launchctl list rwr-test-definitely-not-a-real-service ; echo $?
Could not find service ... in domain for port
113
$ launchctl list com.apple.Finder >/dev/null 2>&1 ; echo $?
0
```

Clean exit zero is `Present`, a non-zero exit status is `Absent`, and anything that is not an `ExitError` (launchctl missing, spawn failure) stays `Unknown` rather than guessing.

**`reverseService` dispatches per platform**, taking each verb from the tool the processor applies with, so uninstall undoes what apply did instead of guessing at an equivalent:

| platform | reversal |
|---|---|
| linux | `systemctl disable --now <name>` |
| darwin | `launchctl unload -w <plist>` - the inverse of the enable action's `launchctl load` |
| other | no reversal, and it says so |

A daemon can live outside `/Library/LaunchDaemons`, so a recorded `target` in the journal identity wins over the convention.

**Three skip reasons instead of one**, including one that names the platform when there is genuinely no reversal for it.

Windows is still unreversed, but it now says so rather than implying the service was already disabled.

## Verification

`go test -race ./...` green on darwin, `golangci-lint` 0 issues, `go vet` clean, gosec and govulncheck clean via the pre-push hook.

The new tests are platform-branching by design: they assert the Linux verb on Linux, the launchd verb on darwin, and the honest refusal elsewhere, so the macOS leg of CI actually exercises the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform-specific service status checks for Linux and macOS.
  * Added macOS service removal using launchd targets when available.
  * Improved handling and reporting of missing, unsupported, disabled, or unqueryable services.

* **Bug Fixes**
  * Service reversal now uses the appropriate platform command instead of a generic process.
  * Prevented incorrect service status reporting when checks or tools fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->