### PR TITLE
fix(prompts): accept every GitHub token format GitHub issues

### DIFF
--- a/internal/prompts/github.go
+++ b/internal/prompts/github.go
@@ -55,7 +55,8 @@ func PromptGitHubAuthMethod() (GitHubAuthChoice, error) {
 }
 
 // PromptGitHubToken displays a secure input form for a GitHub personal access token.
-// It validates that the token starts with a recognized prefix (ghp_, gho_, ghu_).
+// It validates that the token starts with a prefix GitHub issues; see
+// gitHubTokenPrefixes.
 func PromptGitHubToken() (string, error) {
 	var token string
 
@@ -78,17 +79,37 @@ func PromptGitHubToken() (string, error) {
 	return token, nil
 }
 
-// validateGitHubToken checks that a pasted value looks like a GitHub personal
-// access token: non-empty and carrying a recognised prefix (ghp_ personal, gho_
-// OAuth, ghu_ user-to-server).
+// gitHubTokenPrefixes are the token forms GitHub issues today.
+//
+// github_pat_ is the one whose absence actually hurt: fine-grained personal
+// access tokens are what "Generate new token" offers first, so the common case
+// was an operator pasting a valid, correctly-scoped token and being told it was
+// invalid. ghs_ covers GitHub App installation tokens, which is what a CI job
+// hands to rwr.
+//
+// Order matters for the message only; HasPrefix is exact either way.
+var gitHubTokenPrefixes = []string{
+	"github_pat_", // fine-grained personal access token
+	"ghp_",        // classic personal access token
+	"gho_",        // OAuth token, what the device flow returns
+	"ghu_",        // user-to-server token
+	"ghs_",        // server-to-server (GitHub App installation) token
+}
+
+// validateGitHubToken checks that a pasted value looks like a GitHub token:
+// non-empty and carrying a prefix GitHub actually issues.
 func validateGitHubToken(s string) error {
 	if s == "" {
 		return fmt.Errorf("token cannot be empty")
 	}
-	if !strings.HasPrefix(s, "ghp_") && !strings.HasPrefix(s, "gho_") && !strings.HasPrefix(s, "ghu_") {
-		return fmt.Errorf("invalid GitHub token format")
+	for _, prefix := range gitHubTokenPrefixes {
+		if strings.HasPrefix(s, prefix) {
+			return nil
+		}
 	}
-	return nil
+	// Name the accepted prefixes. "invalid GitHub token format" told an
+	// operator holding a real token nothing about what was wrong with it.
+	return fmt.Errorf("does not look like a GitHub token; expected one starting with %s", strings.Join(gitHubTokenPrefixes, ", "))
 }
 
 // PromptAndSaveGitHubToken collects a GitHub token via interactive prompt

--- a/internal/prompts/github.go
+++ b/internal/prompts/github.go
@@ -64,7 +64,10 @@ func PromptGitHubToken() (string, error) {
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Enter your GitHub personal access token").
-				Description("Token needs 'write:public_key' scope").
+				// Both permission models, because the answer differs and the
+				// classic-only wording sent fine-grained users looking for a
+				// scope their token does not have.
+				Description("Classic token: 'write:public_key' scope. Fine-grained token: 'Git SSH keys' user permission, write.").
 				EchoMode(huh.EchoModePassword).
 				Value(&token).
 				Validate(validateGitHubToken),
@@ -79,25 +82,38 @@ func PromptGitHubToken() (string, error) {
 	return token, nil
 }
 
-// gitHubTokenPrefixes are the token forms GitHub issues today.
+// gitHubTokenPrefixes are the token forms that can do the one thing this
+// prompt collects a token for: POST /user/keys, which adds an SSH key to the
+// authenticated user's account.
 //
-// github_pat_ is the one whose absence actually hurt: fine-grained personal
+// github_pat_ is the one whose absence actually hurt. Fine-grained personal
 // access tokens are what "Generate new token" offers first, so the common case
 // was an operator pasting a valid, correctly-scoped token and being told it was
-// invalid. ghs_ covers GitHub App installation tokens, which is what a CI job
-// hands to rwr.
+// invalid.
+//
+// The list is what /user/keys accepts, not every prefix GitHub issues. See
+// gitHubTokenRejections for the ones deliberately left out.
 //
 // Order matters for the message only; HasPrefix is exact either way.
 var gitHubTokenPrefixes = []string{
-	"github_pat_", // fine-grained personal access token
-	"ghp_",        // classic personal access token
+	"github_pat_", // fine-grained PAT, with the "Git SSH keys" user permission
+	"ghp_",        // classic PAT, with the write:public_key scope
 	"gho_",        // OAuth token, what the device flow returns
-	"ghu_",        // user-to-server token
-	"ghs_",        // server-to-server (GitHub App installation) token
+	"ghu_",        // GitHub App user access token (user-to-server)
 }
 
-// validateGitHubToken checks that a pasted value looks like a GitHub token:
-// non-empty and carrying a prefix GitHub actually issues.
+// gitHubTokenRejections are real GitHub tokens that cannot do this job, mapped
+// to the reason. Passing one through validation only moves the failure to the
+// upload, where it surfaces as a bare 403 with nothing explaining it.
+var gitHubTokenRejections = map[string]string{
+	// An installation token acts as the app installation, not as a person, so
+	// there is no authenticated user for /user/keys to add a key to. The
+	// GitHub App token that does have a user is ghu_, which is accepted.
+	"ghs_": "that is a GitHub App installation token, which has no authenticated user to add a key to; use a user access token (ghu_) or a personal access token",
+}
+
+// validateGitHubToken checks that a pasted value is a GitHub token that can
+// upload an SSH key for the authenticated user.
 func validateGitHubToken(s string) error {
 	if s == "" {
 		return fmt.Errorf("token cannot be empty")
@@ -105,6 +121,13 @@ func validateGitHubToken(s string) error {
 	for _, prefix := range gitHubTokenPrefixes {
 		if strings.HasPrefix(s, prefix) {
 			return nil
+		}
+	}
+	// A real token of the wrong kind gets told which kind it is. "does not
+	// look like a GitHub token" would be untrue and unactionable.
+	for prefix, reason := range gitHubTokenRejections {
+		if strings.HasPrefix(s, prefix) {
+			return fmt.Errorf("%s", reason)
 		}
 	}
 	// Name the accepted prefixes. "invalid GitHub token format" told an

--- a/internal/prompts/github_test.go
+++ b/internal/prompts/github_test.go
@@ -19,11 +19,13 @@ func TestValidateGitHubToken(t *testing.T) {
 		{name: "fine-grained personal access token", token: "github_pat_11ABCDEFG0abcdef1234567890"},
 		{name: "classic personal access token", token: "ghp_abcdef1234567890"},
 		{name: "oauth token", token: "gho_abcdef1234567890"},
-		{name: "user-to-server token", token: "ghu_abcdef1234567890"},
-		// A GitHub App installation token, which is what a CI job hands to
-		// rwr. Previously refused; that was characterisation of the
-		// implementation rather than a decision about App tokens.
-		{name: "server-to-server token", token: "ghs_abcdef1234567890"},
+		{name: "github app user access token", token: "ghu_abcdef1234567890"},
+		// A GitHub App *installation* token acts as the installation, not as a
+		// person, so /user/keys has no authenticated user to add a key to.
+		// Accepting it would only move the failure to the upload, where it
+		// arrives as a bare 403.
+		{name: "installation token is the wrong kind", token: "ghs_abcdef1234567890",
+			wantErr: "has no authenticated user"},
 		{name: "empty", token: "", wantErr: "cannot be empty"},
 		{name: "no recognised prefix", token: "abcdef1234567890", wantErr: "does not look like a GitHub token"},
 		{name: "prefix must lead", token: "xghp_abcdef", wantErr: "does not look like a GitHub token"},
@@ -134,5 +136,32 @@ func TestValidateGitHubTokenErrorOmitsTheValue(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), pasted) {
 		t.Errorf("error repeats the pasted credential: %v", err)
+	}
+}
+
+// A real GitHub token of the wrong kind is told which kind it is, and pointed
+// at one that works. Falling back to "does not look like a GitHub token" would
+// be untrue, and leaves an operator staring at a token they can see is valid.
+func TestValidateGitHubTokenExplainsAWrongKindOfToken(t *testing.T) {
+	err := validateGitHubToken("ghs_abcdef1234567890")
+	if err == nil {
+		t.Fatal("an installation token was accepted for a /user/keys upload")
+	}
+	if strings.Contains(err.Error(), "does not look like a GitHub token") {
+		t.Errorf("a real token was called unrecognisable: %v", err)
+	}
+	// It has to name the alternative, or the operator has nothing to do next.
+	if !strings.Contains(err.Error(), "ghu_") {
+		t.Errorf("error does not point at a token type that works: %v", err)
+	}
+}
+
+// Nothing may appear in both lists: a prefix that is accepted and explained as
+// a rejection would resolve by list order rather than by intent.
+func TestGitHubTokenPrefixesAndRejectionsAreDisjoint(t *testing.T) {
+	for _, accepted := range gitHubTokenPrefixes {
+		if _, rejected := gitHubTokenRejections[accepted]; rejected {
+			t.Errorf("%q is both accepted and rejected", accepted)
+		}
 	}
 }

--- a/internal/prompts/github_test.go
+++ b/internal/prompts/github_test.go
@@ -13,13 +13,20 @@ func TestValidateGitHubToken(t *testing.T) {
 		token   string
 		wantErr string
 	}{
-		{name: "personal access token", token: "ghp_abcdef1234567890"},
+		// The one that mattered: fine-grained PATs are what GitHub's
+		// "Generate new token" offers first, so this was the common case
+		// being refused.
+		{name: "fine-grained personal access token", token: "github_pat_11ABCDEFG0abcdef1234567890"},
+		{name: "classic personal access token", token: "ghp_abcdef1234567890"},
 		{name: "oauth token", token: "gho_abcdef1234567890"},
 		{name: "user-to-server token", token: "ghu_abcdef1234567890"},
+		// A GitHub App installation token, which is what a CI job hands to
+		// rwr. Previously refused; that was characterisation of the
+		// implementation rather than a decision about App tokens.
+		{name: "server-to-server token", token: "ghs_abcdef1234567890"},
 		{name: "empty", token: "", wantErr: "cannot be empty"},
-		{name: "no recognised prefix", token: "abcdef1234567890", wantErr: "invalid GitHub token format"},
-		{name: "server-to-server tokens are not accepted", token: "ghs_abcdef", wantErr: "invalid GitHub token format"},
-		{name: "prefix must lead", token: "xghp_abcdef", wantErr: "invalid GitHub token format"},
+		{name: "no recognised prefix", token: "abcdef1234567890", wantErr: "does not look like a GitHub token"},
+		{name: "prefix must lead", token: "xghp_abcdef", wantErr: "does not look like a GitHub token"},
 	}
 
 	for _, tt := range tests {
@@ -99,4 +106,33 @@ func TestFormsBuildAgainstHuhV2(t *testing.T) {
 			t.Fatal("huh.NewForm returned nil for the confirm")
 		}
 	})
+}
+
+// The rejection has to name what would be accepted. "invalid GitHub token
+// format" left an operator holding a real, correctly-scoped token with
+// nothing to act on.
+func TestValidateGitHubTokenErrorNamesTheAcceptedPrefixes(t *testing.T) {
+	err := validateGitHubToken("not-a-token")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	for _, prefix := range gitHubTokenPrefixes {
+		if !strings.Contains(err.Error(), prefix) {
+			t.Errorf("error does not mention %q: %v", prefix, err)
+		}
+	}
+}
+
+// The message must not echo the value back: it is a credential, and the
+// operator already knows what they pasted.
+func TestValidateGitHubTokenErrorOmitsTheValue(t *testing.T) {
+	const pasted = "definitely-a-secret-value"
+
+	err := validateGitHubToken(pasted)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), pasted) {
+		t.Errorf("error repeats the pasted credential: %v", err)
+	}
 }


### PR DESCRIPTION
`validateGitHubToken` accepted `ghp_`, `gho_` and `ghu_` only.

`github_pat_` is what GitHub's "Generate new token" offers first now, so the common case was an operator pasting a valid, correctly-scoped fine-grained token and being told:

```
invalid GitHub token format
```

with no indication of what a valid one would look like.

## Was the exclusion deliberate?

No. The `ghs_` test case came in with #145, a huh v2 dependency bump that added the package's first tests. That commit describes its own coverage as *"accepted prefixes (ghp_, gho_, ghu_), empty input, an unrecognised prefix, and a prefix that appears but does not lead"* - so the exclusion was incidental, not a decision. Checked before changing it.

## Correction: `ghs_` stays rejected

My first version of this PR added `ghs_` on the grounds that it "covers GitHub App installation tokens, which is what a CI job hands to rwr". That is true about the token and **wrong about this prompt**, as CodeRabbit pointed out.

`validateGitHubToken` is reached from exactly one place: the SSH key upload in `copySSHKeyToGitHub`, which POSTs to `https://api.github.com/user/keys`. That endpoint adds a key to the *authenticated user*. An installation token acts as the app installation, not as a person, so there is no authenticated user for it to act on and GitHub answers 403. The GitHub App token that does carry a user is `ghu_`, which was already accepted.

So accepting `ghs_` enabled nothing. It moved the failure from the prompt - where the operator is holding the token and can go get a different one - to the upload, where it arrives as a bare 403. That is the exact failure this validator exists to prevent.

The `ghs_` exclusion was therefore right all along, for a reason nobody had written down. It is written down now.

## Final behaviour

| prefix | what it is | verdict |
|---|---|---|
| `github_pat_` | fine-grained PAT, "Git SSH keys" user permission | **now accepted** |
| `ghp_` | classic PAT, `write:public_key` scope | accepted |
| `gho_` | OAuth token, what the device flow returns | accepted |
| `ghu_` | GitHub App user access token | accepted |
| `ghs_` | GitHub App installation token | rejected, **with the reason and an alternative** |

`ghs_` does not fall into the generic rejection. It is a real GitHub token, and telling someone their valid token "does not look like a GitHub token" is both untrue and unactionable, so a rejection table names the kind and points at one that works. A test asserts the accepted and rejected lists cannot overlap.

The prompt's description now gives both permission models. `Token needs 'write:public_key' scope` is classic-only and sent fine-grained users looking for a scope their token does not have.

The generic rejection still names the accepted prefixes, and no message echoes the pasted value back - it is a credential. Both have tests.

## Scope

This is the **interactive manual-entry path only**. `--gh-api-key` and `GITHUB_TOKEN` never went through this validator, so a fine-grained token already worked through those; it was the prompt that refused it.

## Verification

`go test -race ./...` green on darwin, `golangci-lint` 0 issues, `go vet` clean, gosec and govulncheck clean via the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)