### PR TITLE
fix(state): identity keys are length-prefixed, not delimiter-joined

### DIFF
--- a/internal/state/read.go
+++ b/internal/state/read.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -134,6 +135,21 @@ var guardKeys = map[string]bool{"sha256": true}
 
 // Key renders the identifying part of an identity deterministically, so the
 // same unit keys the same way across runs and across a reversal.
+//
+// Fields are length-prefixed rather than delimited, because identity values
+// are arbitrary strings and one of them is a filesystem path. Joining them
+// with "=" and ";" was ambiguous: both of these render identically, and would
+// fold two different managed files into one entry, so one of them would never
+// be reversed and the other could be matched against the wrong content hash.
+//
+//	{"dest": "/tmp/a;name=x", "name": "y"}
+//	{"dest": "/tmp/a",        "name": "x;name=y"}
+//
+// Length prefixes make the encoding injective: no value can imitate the
+// structure around it, whatever characters it contains.
+//
+// The format is never written to disk. Keys are computed while folding and
+// discarded, so changing it does not affect journals already recorded.
 func Key(processor string, identity map[string]string) string {
 	keys := make([]string, 0, len(identity))
 	for k := range identity {
@@ -145,15 +161,19 @@ func Key(processor string, identity map[string]string) string {
 	sort.Strings(keys)
 
 	var b strings.Builder
-	b.WriteString(processor)
-	b.WriteString("\x00")
+	writeKeyField(&b, processor)
 	for _, k := range keys {
-		b.WriteString(k)
-		b.WriteString("=")
-		b.WriteString(identity[k])
-		b.WriteString(";")
+		writeKeyField(&b, k)
+		writeKeyField(&b, identity[k])
 	}
 	return b.String()
+}
+
+// writeKeyField appends one length-prefixed field: "<len>:<value>".
+func writeKeyField(b *strings.Builder, value string) {
+	b.WriteString(strconv.Itoa(len(value)))
+	b.WriteByte(':')
+	b.WriteString(value)
 }
 
 // legacyEntries reads the v1 per-run record files this format replaced.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -6,6 +6,33 @@ import (
 	"testing"
 )
 
+// newWriter opens a journal for a test and fails loudly when it cannot.
+//
+// The tests used to discard the error from NewWriter and from Finalize. A
+// setup failure then produced an empty journal, Applies returned nothing, and
+// an assertion like "want nothing left to reverse" passed without any
+// reversal having been tested.
+func newWriter(t *testing.T, dir, location string) *Writer {
+	t.Helper()
+	w, err := NewWriter(dir, location, false)
+	if err != nil {
+		t.Fatalf("opening the journal: %v", err)
+	}
+	if w == nil {
+		t.Fatal("opening the journal returned no writer")
+	}
+	return w
+}
+
+// finalize closes a journal and fails when the close does not land, so a
+// half-written log cannot masquerade as an empty one.
+func finalize(t *testing.T, w *Writer) {
+	t.Helper()
+	if err := w.Finalize(); err != nil {
+		t.Fatalf("finalizing the journal: %v", err)
+	}
+}
+
 func TestJournal_Lifecycle(t *testing.T) {
 	dir := t.TempDir()
 	w, err := NewWriter(dir, "tree", false)
@@ -63,14 +90,14 @@ func TestJournal_DryRunWritesNothing(t *testing.T) {
 // Unreversed and stays visible in Applies.
 func TestJournal_ReversalIsAnEvent(t *testing.T) {
 	dir := t.TempDir()
-	w, _ := NewWriter(dir, "tree", false)
+	w := newWriter(t, dir, "tree")
 	identity := map[string]string{"name": "rc", "dest": "/tmp/rc"}
 	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok", Identity: identity})
-	_ = w.Finalize()
+	finalize(t, w)
 
-	u, _ := NewWriter(dir, "", false)
+	u := newWriter(t, dir, "")
 	u.Reverse("files", identity)
-	_ = u.Finalize()
+	finalize(t, u)
 
 	unreversed, err := Unreversed(dir)
 	if err != nil {
@@ -98,14 +125,17 @@ func TestJournal_ReversalIsAnEvent(t *testing.T) {
 // apply it cancels; see TestJournal_ReapplyAfterReversalIsLiveAgain.
 func TestJournal_LatestApplyWins(t *testing.T) {
 	dir := t.TempDir()
-	w, _ := NewWriter(dir, "tree", false)
+	w := newWriter(t, dir, "tree")
 	w.Append(Entry{Processor: "packages", Action: "install", OK: true, Outcome: "ok",
 		Identity: map[string]string{"name": "git"}, Detail: "first"})
 	w.Append(Entry{Processor: "packages", Action: "install", OK: true, Outcome: "ok",
 		Identity: map[string]string{"name": "git"}, Detail: "second"})
-	_ = w.Finalize()
+	finalize(t, w)
 
-	applies, _ := Applies(dir)
+	applies, err := Applies(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(applies) != 1 || applies[0].Detail != "second" {
 		t.Fatalf("applies = %+v", applies)
 	}
@@ -133,7 +163,10 @@ func TestLegacyV1RecordsFoldIn(t *testing.T) {
 	if len(applies) != 2 {
 		t.Fatalf("applies = %+v", applies)
 	}
-	unreversed, _ := Unreversed(dir)
+	unreversed, err := Unreversed(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(unreversed) != 1 || unreversed[0].Identity["name"] != "git" {
 		t.Fatalf("unreversed = %+v", unreversed)
 	}
@@ -148,12 +181,12 @@ func TestLegacyV1RecordsFoldIn(t *testing.T) {
 // for each of them, and `rwr status` could call a live file stale.
 func TestJournal_FileReapplyWithNewContentFoldsToOneEntry(t *testing.T) {
 	dir := t.TempDir()
-	w, _ := NewWriter(dir, "tree", false)
+	w := newWriter(t, dir, "tree")
 	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
 		Identity: map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "aaa"}, Detail: "first"})
 	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
 		Identity: map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "bbb"}, Detail: "second"})
-	_ = w.Finalize()
+	finalize(t, w)
 
 	applies, err := Applies(dir)
 	if err != nil {
@@ -177,17 +210,17 @@ func TestJournal_FileReapplyWithNewContentFoldsToOneEntry(t *testing.T) {
 // stale-hashed twin behind that looks unreversed.
 func TestJournal_ReversalMatchesAcrossAContentChange(t *testing.T) {
 	dir := t.TempDir()
-	w, _ := NewWriter(dir, "tree", false)
+	w := newWriter(t, dir, "tree")
 	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
 		Identity: map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "aaa"}})
 	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
 		Identity: map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "bbb"}})
-	_ = w.Finalize()
+	finalize(t, w)
 
-	u, _ := NewWriter(dir, "", false)
+	u := newWriter(t, dir, "")
 	// uninstall reverses what it read: the latest identity, hash included.
 	u.Reverse("files", map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "bbb"})
-	_ = u.Finalize()
+	finalize(t, u)
 
 	unreversed, err := Unreversed(dir)
 	if err != nil {
@@ -202,12 +235,12 @@ func TestJournal_ReversalMatchesAcrossAContentChange(t *testing.T) {
 // key must not collapse anything that is actually distinct.
 func TestJournal_DistinctDestinationsStayDistinct(t *testing.T) {
 	dir := t.TempDir()
-	w, _ := NewWriter(dir, "tree", false)
+	w := newWriter(t, dir, "tree")
 	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
 		Identity: map[string]string{"name": "rc", "dest": "/tmp/one", "sha256": "aaa"}})
 	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
 		Identity: map[string]string{"name": "rc", "dest": "/tmp/two", "sha256": "aaa"}})
-	_ = w.Finalize()
+	finalize(t, w)
 
 	applies, err := Applies(dir)
 	if err != nil {
@@ -232,18 +265,18 @@ func TestJournal_ReapplyAfterReversalIsLiveAgain(t *testing.T) {
 	dir := t.TempDir()
 	identity := map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "aaa"}
 
-	w, _ := NewWriter(dir, "tree", false)
+	w := newWriter(t, dir, "tree")
 	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok", Identity: identity})
-	_ = w.Finalize()
+	finalize(t, w)
 
-	u, _ := NewWriter(dir, "", false)
+	u := newWriter(t, dir, "")
 	u.Reverse("files", identity)
-	_ = u.Finalize()
+	finalize(t, u)
 
-	again, _ := NewWriter(dir, "tree", false)
+	again := newWriter(t, dir, "tree")
 	again.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
 		Identity: map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "bbb"}})
-	_ = again.Finalize()
+	finalize(t, again)
 
 	live, err := Unreversed(dir)
 	if err != nil {
@@ -264,17 +297,17 @@ func TestJournal_ReapplyAfterReversalIsLiveAgainForPackages(t *testing.T) {
 	dir := t.TempDir()
 	identity := map[string]string{"name": "git", "provider": "pacman"}
 
-	w, _ := NewWriter(dir, "tree", false)
+	w := newWriter(t, dir, "tree")
 	w.Append(Entry{Processor: "packages", Action: "install", OK: true, Outcome: "ok", Identity: identity})
-	_ = w.Finalize()
+	finalize(t, w)
 
-	u, _ := NewWriter(dir, "", false)
+	u := newWriter(t, dir, "")
 	u.Reverse("packages", identity)
-	_ = u.Finalize()
+	finalize(t, u)
 
-	again, _ := NewWriter(dir, "tree", false)
+	again := newWriter(t, dir, "tree")
 	again.Append(Entry{Processor: "packages", Action: "install", OK: true, Outcome: "ok", Identity: identity})
-	_ = again.Finalize()
+	finalize(t, again)
 
 	live, err := Unreversed(dir)
 	if err != nil {
@@ -292,14 +325,14 @@ func TestJournal_ReversalAfterTheLastApplyStillCancelsIt(t *testing.T) {
 	dir := t.TempDir()
 	identity := map[string]string{"name": "git", "provider": "pacman"}
 
-	w, _ := NewWriter(dir, "tree", false)
+	w := newWriter(t, dir, "tree")
 	w.Append(Entry{Processor: "packages", Action: "install", OK: true, Outcome: "ok", Identity: identity})
 	w.Append(Entry{Processor: "packages", Action: "install", OK: true, Outcome: "ok", Identity: identity})
-	_ = w.Finalize()
+	finalize(t, w)
 
-	u, _ := NewWriter(dir, "", false)
+	u := newWriter(t, dir, "")
 	u.Reverse("packages", identity)
-	_ = u.Finalize()
+	finalize(t, u)
 
 	live, err := Unreversed(dir)
 	if err != nil {
@@ -307,5 +340,70 @@ func TestJournal_ReversalAfterTheLastApplyStillCancelsIt(t *testing.T) {
 	}
 	if len(live) != 0 {
 		t.Fatalf("a reversal after the last apply did not cancel it: %+v", live)
+	}
+}
+
+// Identity values are arbitrary strings, and one of them is a filesystem path.
+// Joining fields with "=" and ";" was ambiguous: these two identities rendered
+// identically, which would fold two different managed files into one entry -
+// so one of them would never be reversed, and the other could be matched
+// against the wrong content hash on the way to a delete.
+func TestKey_DelimiterValuesDoNotCollide(t *testing.T) {
+	t.Parallel()
+
+	a := Key("files", map[string]string{"dest": "/tmp/a;name=x", "name": "y"})
+	b := Key("files", map[string]string{"dest": "/tmp/a", "name": "x;name=y"})
+
+	if a == b {
+		t.Fatalf("two distinct files collide onto one key: %q", a)
+	}
+}
+
+// The same ambiguity through the processor, and through a value that imitates
+// a length prefix rather than a delimiter.
+func TestKey_StructuralImitationDoesNotCollide(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a, b string
+	}{
+		{
+			name: "processor absorbs a field",
+			a:    Key("files", map[string]string{"name": "x"}),
+			b:    Key("files\x004:name", map[string]string{}),
+		},
+		{
+			name: "value imitates a length prefix",
+			a:    Key("files", map[string]string{"name": "4:dest"}),
+			b:    Key("files", map[string]string{"name": "", "4": "dest"}),
+		},
+	}
+
+	for _, tt := range cases {
+		if tt.a == tt.b {
+			t.Errorf("%s: distinct identities collide onto %q", tt.name, tt.a)
+		}
+	}
+}
+
+// Keying has to be stable across calls, or the fold would scatter one unit
+// across several entries.
+func TestKey_IsStableAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	identity := map[string]string{"name": "rc", "dest": "/tmp/rc", "provider": "", "sha256": "aaa"}
+	first := Key("files", identity)
+
+	for range 10 {
+		if got := Key("files", identity); got != first {
+			t.Fatalf("Key is not deterministic: %q then %q", first, got)
+		}
+	}
+
+	// The guard is excluded, so a content change keys the same.
+	changed := map[string]string{"name": "rc", "dest": "/tmp/rc", "provider": "", "sha256": "bbb"}
+	if Key("files", changed) != first {
+		t.Error("a content change altered the identity key")
 	}
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -34,6 +34,8 @@ func finalize(t *testing.T, w *Writer) {
 }
 
 func TestJournal_Lifecycle(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	w, err := NewWriter(dir, "tree", false)
 	if err != nil {
@@ -71,6 +73,8 @@ func TestJournal_Lifecycle(t *testing.T) {
 }
 
 func TestJournal_DryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	w, err := NewWriter(dir, "tree", true)
 	if err != nil || w != nil {
@@ -89,6 +93,8 @@ func TestJournal_DryRunWritesNothing(t *testing.T) {
 // A reversal is an appended event; the reversed apply folds out of
 // Unreversed and stays visible in Applies.
 func TestJournal_ReversalIsAnEvent(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	w := newWriter(t, dir, "tree")
 	identity := map[string]string{"name": "rc", "dest": "/tmp/rc"}
@@ -124,6 +130,8 @@ func TestJournal_ReversalIsAnEvent(t *testing.T) {
 // re-applied unit after an uninstall. Reversal is now ordered against the
 // apply it cancels; see TestJournal_ReapplyAfterReversalIsLiveAgain.
 func TestJournal_LatestApplyWins(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	w := newWriter(t, dir, "tree")
 	w.Append(Entry{Processor: "packages", Action: "install", OK: true, Outcome: "ok",
@@ -143,6 +151,8 @@ func TestJournal_LatestApplyWins(t *testing.T) {
 
 // v1 per-run record files still read; their reversed marks are honored.
 func TestLegacyV1RecordsFoldIn(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	runs := filepath.Join(dir, "state", "runs")
 	if err := os.MkdirAll(runs, 0o700); err != nil {
@@ -180,6 +190,8 @@ func TestLegacyV1RecordsFoldIn(t *testing.T) {
 // one permanent entry per content version, `rwr uninstall` planned a delete
 // for each of them, and `rwr status` could call a live file stale.
 func TestJournal_FileReapplyWithNewContentFoldsToOneEntry(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	w := newWriter(t, dir, "tree")
 	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
@@ -209,6 +221,8 @@ func TestJournal_FileReapplyWithNewContentFoldsToOneEntry(t *testing.T) {
 // identity it saw, and a re-apply before that reversal must not leave a
 // stale-hashed twin behind that looks unreversed.
 func TestJournal_ReversalMatchesAcrossAContentChange(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	w := newWriter(t, dir, "tree")
 	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
@@ -234,6 +248,8 @@ func TestJournal_ReversalMatchesAcrossAContentChange(t *testing.T) {
 // Two genuinely different files stay two units: dropping the guard from the
 // key must not collapse anything that is actually distinct.
 func TestJournal_DistinctDestinationsStayDistinct(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	w := newWriter(t, dir, "tree")
 	w.Append(Entry{Processor: "files", Action: "create", OK: true, Outcome: "ok",
@@ -262,6 +278,8 @@ func TestJournal_DistinctDestinationsStayDistinct(t *testing.T) {
 // carried a content hash that made each apply a different key; folding on the
 // destination removed that accident, so the ordering has to be real.
 func TestJournal_ReapplyAfterReversalIsLiveAgain(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	identity := map[string]string{"name": "rc", "dest": "/tmp/rc", "sha256": "aaa"}
 
@@ -294,6 +312,8 @@ func TestJournal_ReapplyAfterReversalIsLiveAgain(t *testing.T) {
 // is every processor other than files. This case was wrong before the fold
 // keyed on identifying fields too, so it is not a files-only concern.
 func TestJournal_ReapplyAfterReversalIsLiveAgainForPackages(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	identity := map[string]string{"name": "git", "provider": "pacman"}
 
@@ -322,6 +342,8 @@ func TestJournal_ReapplyAfterReversalIsLiveAgainForPackages(t *testing.T) {
 // really does cancel it, or uninstall would keep offering to remove things it
 // already removed.
 func TestJournal_ReversalAfterTheLastApplyStillCancelsIt(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	identity := map[string]string{"name": "git", "provider": "pacman"}
 


### PR DESCRIPTION
**Follow-up to #259, which merged before this fix could be pushed to it.** The bug below is currently on master.

CodeRabbit found a collision in the keying #259 introduced, three minutes after that PR merged. My push to the branch silently recreated it (the branch had been auto-deleted on merge) rather than updating the closed PR, so the fix never landed. Recovered here onto current master.

## The bug

`Key` joined fields with `=` and `;`. Identity values are arbitrary strings, and one of them is a filesystem path, where both characters are legal. These two identities render identically:

```go
{"dest": "/tmp/a;name=x", "name": "y"}
{"dest": "/tmp/a",        "name": "x;name=y"}
```

```
files\x00dest=/tmp/a;name=x;name=y;
```

Reproduced against master before fixing.

Folding two different managed files into one entry means one of them is never reversed, and the survivor can be matched against the other's content hash on the way to a **delete**. That is the worst place in the codebase for an ambiguous key.

## The fix

Fields are length-prefixed (`<len>:<value>`), which is injective: no value can imitate the structure around it, whatever characters it contains.

The format is never written to disk - keys are computed while folding and discarded - so this does not affect journals already recorded, and needs no version bump.

Tests cover the reported pair, a processor absorbing a field, and a value imitating a length prefix.

## Second finding in the same review

The state tests discarded the errors from `NewWriter` and `Finalize`. A setup failure produced an empty journal, from which `Applies` returns nothing, so an assertion like "want nothing left to reverse" passed **without any reversal having been tested**. Both now go through helpers that fail loudly, applied across the file rather than only to the two cases that prompted it.

## Verification

`go test -race ./...` green on darwin, `golangci-lint` 0 issues, `go vet` clean, gosec and govulncheck clean via the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal identity handling to prevent collisions when values contain delimiter characters.
  * Ensured identity keys remain deterministic and exclude file content hashes.

* **Tests**
  * Expanded coverage for collision scenarios, deterministic key generation, and journal creation and finalization error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->