### PR TITLE
fix(prompts): a bare prefix is not a token

### DIFF
--- a/internal/prompts/github.go
+++ b/internal/prompts/github.go
@@ -54,9 +54,11 @@ func PromptGitHubAuthMethod() (GitHubAuthChoice, error) {
 	return GitHubAuthChoice(authChoice), nil
 }
 
-// PromptGitHubToken displays a secure input form for a GitHub personal access token.
-// It validates that the token starts with a prefix GitHub issues; see
-// gitHubTokenPrefixes.
+// PromptGitHubToken displays a secure input form for a GitHub personal access
+// token. It validates that the token is one of the kinds that can upload an
+// SSH key for the authenticated user; see gitHubTokenPrefixes. Not every
+// GitHub-issued prefix qualifies - ghs_ is a real token this prompt correctly
+// refuses.
 func PromptGitHubToken() (string, error) {
 	var token string
 

--- a/internal/prompts/github.go
+++ b/internal/prompts/github.go
@@ -114,11 +114,32 @@ var gitHubTokenRejections = map[string]string{
 	"ghs_": "that is a GitHub App installation token, which has no authenticated user to add a key to; use a user access token (ghu_) or a personal access token",
 }
 
+// minGitHubTokenBody is the shortest run of characters that can follow a
+// prefix and still be a real token.
+//
+// The prefix check is HasPrefix, so without this a bare "ghp_" validated, and
+// so did "ghp_x". Neither can be a token, and accepting them puts the failure
+// back where this validator exists to stop it happening: a 401 from the upload,
+// long after the operator has stopped looking at what they pasted. A truncated
+// paste is the realistic way to produce one.
+//
+// The bound is deliberately far below every real format rather than exact.
+// Classic, OAuth and user tokens carry 36 characters after the prefix and
+// fine-grained ones carry about 82, but GitHub has changed token lengths
+// before and a validator that pins them would reject the next format. This
+// only has to be tight enough to catch a value that is obviously not a token.
+const minGitHubTokenBody = 20
+
 // validateGitHubToken checks that a pasted value is a GitHub token that can
 // upload an SSH key for the authenticated user.
 func validateGitHubToken(s string) error {
 	if s == "" {
 		return fmt.Errorf("token cannot be empty")
+	}
+	for _, prefix := range gitHubTokenPrefixes {
+		if strings.HasPrefix(s, prefix) && len(s)-len(prefix) < minGitHubTokenBody {
+			return fmt.Errorf("that is only the %s prefix, not a whole token; check for a truncated paste", prefix)
+		}
 	}
 	for _, prefix := range gitHubTokenPrefixes {
 		if strings.HasPrefix(s, prefix) {

--- a/internal/prompts/github_test.go
+++ b/internal/prompts/github_test.go
@@ -18,17 +18,26 @@ func TestValidateGitHubToken(t *testing.T) {
 		// The one that mattered: fine-grained PATs are what GitHub's
 		// "Generate new token" offers first, so this was the common case
 		// being refused.
-		{name: "fine-grained personal access token", token: "github_pat_11ABCDEFG0abcdef1234567890"},
-		{name: "classic personal access token", token: "ghp_abcdef1234567890"},
-		{name: "oauth token", token: "gho_abcdef1234567890"},
-		{name: "github app user access token", token: "ghu_abcdef1234567890"},
+		{name: "fine-grained personal access token", token: "github_pat_11ABCDEFG0" + strings.Repeat("b", 72)},
+		{name: "classic personal access token", token: "ghp_" + strings.Repeat("c", 36)},
+		{name: "oauth token", token: "gho_" + strings.Repeat("d", 36)},
+		{name: "github app user access token", token: "ghu_" + strings.Repeat("e", 36)},
 		// A GitHub App *installation* token acts as the installation, not as a
 		// person, so /user/keys has no authenticated user to add a key to.
 		// Accepting it would only move the failure to the upload, where it
 		// arrives as a bare 403.
-		{name: "installation token is the wrong kind", token: "ghs_abcdef1234567890",
+		{name: "installation token is the wrong kind", token: "ghs_" + strings.Repeat("f", 36),
 			wantErr: "has no authenticated user"},
 		{name: "empty", token: "", wantErr: "cannot be empty"},
+		// Boundaries. The prefix check is HasPrefix, so a bare prefix or a
+		// truncated paste reaches it and used to validate.
+		{name: "classic prefix with no body", token: "ghp_", wantErr: "not a whole token"},
+		{name: "fine-grained prefix with no body", token: "github_pat_", wantErr: "not a whole token"},
+		{name: "oauth prefix with no body", token: "gho_", wantErr: "not a whole token"},
+		{name: "user prefix with no body", token: "ghu_", wantErr: "not a whole token"},
+		{name: "body one short of the minimum", token: "ghp_" + strings.Repeat("a", 19), wantErr: "not a whole token"},
+		{name: "body exactly at the minimum", token: "ghp_" + strings.Repeat("a", 20)},
+		{name: "a real-length classic token", token: "ghp_" + strings.Repeat("a", 36)},
 		{name: "no recognised prefix", token: "abcdef1234567890", wantErr: "does not look like a GitHub token"},
 		{name: "prefix must lead", token: "xghp_abcdef", wantErr: "does not look like a GitHub token"},
 	}
@@ -153,7 +162,7 @@ func TestValidateGitHubTokenErrorOmitsTheValue(t *testing.T) {
 func TestValidateGitHubTokenExplainsAWrongKindOfToken(t *testing.T) {
 	t.Parallel()
 
-	err := validateGitHubToken("ghs_abcdef1234567890")
+	err := validateGitHubToken("ghs_" + strings.Repeat("f", 36))
 	if err == nil {
 		t.Fatal("an installation token was accepted for a /user/keys upload")
 	}

--- a/internal/prompts/github_test.go
+++ b/internal/prompts/github_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestValidateGitHubToken(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		token   string
@@ -33,6 +35,8 @@ func TestValidateGitHubToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			err := validateGitHubToken(tt.token)
 
 			if tt.wantErr == "" {
@@ -114,6 +118,8 @@ func TestFormsBuildAgainstHuhV2(t *testing.T) {
 // format" left an operator holding a real, correctly-scoped token with
 // nothing to act on.
 func TestValidateGitHubTokenErrorNamesTheAcceptedPrefixes(t *testing.T) {
+	t.Parallel()
+
 	err := validateGitHubToken("not-a-token")
 	if err == nil {
 		t.Fatal("expected an error")
@@ -128,6 +134,8 @@ func TestValidateGitHubTokenErrorNamesTheAcceptedPrefixes(t *testing.T) {
 // The message must not echo the value back: it is a credential, and the
 // operator already knows what they pasted.
 func TestValidateGitHubTokenErrorOmitsTheValue(t *testing.T) {
+	t.Parallel()
+
 	const pasted = "definitely-a-secret-value"
 
 	err := validateGitHubToken(pasted)
@@ -143,6 +151,8 @@ func TestValidateGitHubTokenErrorOmitsTheValue(t *testing.T) {
 // at one that works. Falling back to "does not look like a GitHub token" would
 // be untrue, and leaves an operator staring at a token they can see is valid.
 func TestValidateGitHubTokenExplainsAWrongKindOfToken(t *testing.T) {
+	t.Parallel()
+
 	err := validateGitHubToken("ghs_abcdef1234567890")
 	if err == nil {
 		t.Fatal("an installation token was accepted for a /user/keys upload")
@@ -159,6 +169,8 @@ func TestValidateGitHubTokenExplainsAWrongKindOfToken(t *testing.T) {
 // Nothing may appear in both lists: a prefix that is accepted and explained as
 // a rejection would resolve by list order rather than by intent.
 func TestGitHubTokenPrefixesAndRejectionsAreDisjoint(t *testing.T) {
+	t.Parallel()
+
 	for _, accepted := range gitHubTokenPrefixes {
 		if _, rejected := gitHubTokenRejections[accepted]; rejected {
 			t.Errorf("%q is both accepted and rejected", accepted)


### PR DESCRIPTION
**Follow-up to #261, which merged before this could be pushed to it.** The branch was auto-deleted on merge and my push recreated it instead of updating the closed PR, so this was stranded; same cause as #263.

Started as a doc-comment correction. Review then turned up an actual gap, so the title moved with it.

## The gap

`validateGitHubToken` checks with `HasPrefix`, so a bare prefix validated:

```
"ghp_"         -> <nil>
"gho_"         -> <nil>
"ghu_"         -> <nil>
"github_pat_"  -> <nil>
"ghp_x"        -> <nil>
```

None of those can be a token. Accepting them puts the failure back exactly where this validator exists to stop it happening: a 401 from the upload, long after the operator has stopped looking at what they pasted. A truncated paste is the realistic way to produce one.

A token now has to carry a body after its prefix. The bound is deliberately **far below** every real format rather than exact - classic, OAuth and user tokens carry 36 characters and fine-grained ones about 82, but GitHub has changed token lengths before and a validator that pinned them would reject the next format. This only has to catch a value that is obviously not a token.

## The fixtures were part of the problem

The existing "valid token" cases used a 16-character body (`ghp_abcdef1234567890`) - shorter than any real token - and had to grow to representative lengths for the table to keep passing. Test data that cannot occur in practice is how a boundary like this goes unnoticed.

Boundary cases added for each accepted prefix with no body, one character short of the minimum, exactly at it, and a real-length token.

## Also here

The original doc fix: `PromptGitHubToken`'s comment described validation as accepting "a prefix GitHub issues", which #261 made wrong in a way that matters - `ghs_` **is** GitHub-issued and correctly refused, because an installation token has no authenticated user for `POST /user/keys`. Plus `t.Parallel()` on the package's validation tests.

## Verification

`go test -race ./...` green on darwin, `golangci-lint` 0 issues, `go vet` clean, gosec and govulncheck clean via the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)