### PR TITLE
feat(scripts): args as a list, so an argument can contain a space

### DIFF
--- a/docs/blueprints/scripts.md
+++ b/docs/blueprints/scripts.md
@@ -137,16 +137,17 @@ The Scripts blueprint supports the following fields:
 
 `args` takes either a string or a list.
 
-A **string** is divided at each space, and each part is sent to the script as
-one argument. The value `--verbose --out /tmp` becomes three arguments.
+A **string** is divided at each run of whitespace - spaces, tabs, newlines -
+and each part is sent to the script as one argument. The value
+`--verbose --out /tmp` becomes three arguments.
 
 ```yaml
 args: "--verbose --out /tmp"
 ```
 
 A **list** sends each element exactly as written, spaces and all. This is the
-only way to pass an argument that contains a space, because RWR runs no shell
-and quoting inside the string form has no effect:
+only way to pass an argument that contains whitespace, because RWR runs no
+shell and quoting inside the string form has no effect:
 
 ```yaml
 args: ["--message", "hello world", "--out", "/tmp/my reports"]
@@ -165,6 +166,9 @@ args = ["--message", "hello world"]
 ```cue
 args: ["--message", "hello world"]
 ```
+
+Every element of a list must be a string. A value such as `args: [8080]` is
+refused in every format, so quote it: `args: ["8080"]`.
 
 RWR does not use a shell to run the script. The shell characters keep their
 literal value. These characters have no special function:

--- a/docs/blueprints/scripts.md
+++ b/docs/blueprints/scripts.md
@@ -124,7 +124,7 @@ The Scripts blueprint supports the following fields:
 | `exec` | No | The program that runs the script: `bash`, `python`, `ruby`, `perl`, `lua`, `powershell`, or `self`. The default is `bash` on Linux and macOS, and `powershell` on Windows. `self` runs the script file directly |
 | `source` | No | The path to the script file (relative to blueprint directory). |
 | `content` | No | The inline content of the script. |
-| `args` | No | Additional arguments to pass to the script. |
+| `args` | No | Arguments to pass to the script, as a string (split on whitespace) or a list (each element taken verbatim). |
 | `elevated` | No | Whether to run the script with elevated privileges (`sudo`). Default is `false`. |
 | `asUser` | No | Run the script as another account: `sudo -u <user>`. Ignored when `elevated: true`, since sudo cannot do both at once; RWR warns and runs elevated. |
 | `log` | No | Log name for script output. |
@@ -135,9 +135,36 @@ The Scripts blueprint supports the following fields:
 
 ### How RWR runs the arguments
 
-RWR divides the `args` string at each space. It then sends each part to the
-script as one argument. The value `--verbose --out /tmp` becomes three
-arguments.
+`args` takes either a string or a list.
+
+A **string** is divided at each space, and each part is sent to the script as
+one argument. The value `--verbose --out /tmp` becomes three arguments.
+
+```yaml
+args: "--verbose --out /tmp"
+```
+
+A **list** sends each element exactly as written, spaces and all. This is the
+only way to pass an argument that contains a space, because RWR runs no shell
+and quoting inside the string form has no effect:
+
+```yaml
+args: ["--message", "hello world", "--out", "/tmp/my reports"]
+```
+
+The list form works in every blueprint format:
+
+```json
+"args": ["--message", "hello world"]
+```
+
+```toml
+args = ["--message", "hello world"]
+```
+
+```cue
+args: ["--message", "hello world"]
+```
 
 RWR does not use a shell to run the script. The shell characters keep their
 literal value. These characters have no special function:

--- a/internal/processors/scripts.go
+++ b/internal/processors/scripts.go
@@ -70,14 +70,18 @@ func processScripts(scripts []types.Script, osInfo *types.OSInfo, initConfig *ty
 				track.item("", script.Name, script.Action, types.StatusFailed, err.Error(), time.Since(started))
 				// Scripts stop at the first failure, where packages, files and
 				// the rest record the failure and carry on. That difference is
-				// deliberate. A script is arbitrary code, the scripts in a file
+				// deliberate: a script is arbitrary code, the scripts in a file
 				// are usually ordered, and one that fails has very likely left
-				// the next one's prerequisites unmet. Returning also hands the
-				// error to All(), which is what offers the operator
-				// retry/skip/abort - and a retry re-runs the whole file, so
-				// stopping early is what keeps the already-succeeded scripts
-				// from running a second time. Nothing here can assume the
-				// idempotence that makes retry cheap for the other processors.
+				// the next one's prerequisites unmet. Stopping is what keeps
+				// the later scripts from running against that.
+				//
+				// Returning also hands the error to All(), which is what offers
+				// the operator retry/skip/abort. Note what retry costs here: it
+				// re-runs the whole file, so every script that already
+				// succeeded runs again. Nothing in this processor can assume
+				// the idempotence that makes that cheap for packages or files,
+				// which is a reason to keep the failed set small, not a reason
+				// to push on past a failure.
 				return fmt.Errorf("error running script %s: %w", script.Name, err)
 			}
 			log.Infof("Script %s executed successfully", script.Name)

--- a/internal/processors/scripts.go
+++ b/internal/processors/scripts.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/fynxlabs/rwr/internal/helpers"
@@ -69,6 +68,16 @@ func processScripts(scripts []types.Script, osInfo *types.OSInfo, initConfig *ty
 			if err != nil {
 				log.Errorf("Error running script %s: %v", script.Name, err)
 				track.item("", script.Name, script.Action, types.StatusFailed, err.Error(), time.Since(started))
+				// Scripts stop at the first failure, where packages, files and
+				// the rest record the failure and carry on. That difference is
+				// deliberate. A script is arbitrary code, the scripts in a file
+				// are usually ordered, and one that fails has very likely left
+				// the next one's prerequisites unmet. Returning also hands the
+				// error to All(), which is what offers the operator
+				// retry/skip/abort - and a retry re-runs the whole file, so
+				// stopping early is what keeps the already-succeeded scripts
+				// from running a second time. Nothing here can assume the
+				// idempotence that makes retry cheap for the other processors.
 				return fmt.Errorf("error running script %s: %w", script.Name, err)
 			}
 			log.Infof("Script %s executed successfully", script.Name)
@@ -178,13 +187,13 @@ func runScript(script types.Script, osInfo *types.OSInfo, initConfig *types.Init
 		return fmt.Errorf("unsupported script executor: %s", script.Exec)
 	}
 
-	// Append the script arguments. `args` is a single string in the blueprint, and
-	// the shell used to word-split it on the way to the script. Now that commands are
-	// argv, split it here - otherwise `args: "--verbose --out /tmp"` would arrive as
-	// one argument instead of three.
-	if script.Args != "" {
-		log.Debugf("Adding script arguments: %s", script.Args)
-		scriptCmd.Args = append(scriptCmd.Args, strings.Fields(script.Args)...)
+	// Append the script arguments. The blueprint writes `args` either as a
+	// string, which types.ScriptArgs splits on whitespace the way it always
+	// has, or as a list, whose elements are taken verbatim so an argument
+	// containing a space can be expressed at all.
+	if len(script.Args) > 0 {
+		log.Debugf("Adding script arguments: %v", []string(script.Args))
+		scriptCmd.Args = append(scriptCmd.Args, script.Args...)
 	}
 
 	// Set the log name

--- a/internal/processors/scripts_argv_test.go
+++ b/internal/processors/scripts_argv_test.go
@@ -301,3 +301,100 @@ scripts:
 		})
 	}
 }
+
+// scriptDecodeErr runs one blueprint and returns the error, if any.
+func scriptDecodeErr(t *testing.T, format, blueprint string) error {
+	t.Helper()
+
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	return ProcessScripts([]byte(blueprint), t.TempDir(), format, scriptOSInfo(), &types.InitConfig{})
+}
+
+// The formats have to agree about what args means, and this is the table that
+// says so.
+//
+// yaml.v3 coerces any scalar into a string on the way into a []string, so
+// `args: [1, true]` decoded happily as ["1", "true"] while JSON, TOML and CUE
+// all rejected the same blueprint - and YAML itself rejected the bare scalar
+// `args: 42`, so it did not agree with itself either. A blueprint has to mean
+// the same thing whichever format it is written in.
+//
+// The error text is deliberately not asserted: four different decoders produce
+// four different messages, and pinning them would test the libraries rather
+// than rwr's contract.
+func TestProcessScripts_InvalidArgsAreRejectedInEveryFormat(t *testing.T) {
+	cases := []struct {
+		name      string
+		format    string
+		blueprint string
+	}{
+		{"yaml list with numbers", "yaml", `
+scripts:
+  - name: "setup.sh"
+    action: "run"
+    source: "."
+    exec: "bash"
+    args: [1, true, 2.5]
+`},
+		{"json list with numbers", "json",
+			`{"scripts":[{"name":"setup.sh","action":"run","source":".","exec":"bash","args":[1,true]}]}`},
+		{"toml list with numbers", "toml", `
+[[scripts]]
+name = "setup.sh"
+action = "run"
+source = "."
+exec = "bash"
+args = [1, true]
+`},
+		{"cue list with numbers", "cue", `
+scripts: [{name: "setup.sh", action: "run", source: ".", exec: "bash", args: [1, true]}]
+`},
+		{"yaml list with a null", "yaml", `
+scripts:
+  - name: "setup.sh"
+    action: "run"
+    source: "."
+    exec: "bash"
+    args: ["--flag", null]
+`},
+		{"yaml list with a nested list", "yaml", `
+scripts:
+  - name: "setup.sh"
+    action: "run"
+    source: "."
+    exec: "bash"
+    args: ["--flag", ["nested"]]
+`},
+		{"yaml scalar number", "yaml", `
+scripts:
+  - name: "setup.sh"
+    action: "run"
+    source: "."
+    exec: "bash"
+    args: 42
+`},
+		{"json scalar number", "json",
+			`{"scripts":[{"name":"setup.sh","action":"run","source":".","exec":"bash","args":42}]}`},
+		{"toml scalar number", "toml", `
+[[scripts]]
+name = "setup.sh"
+action = "run"
+source = "."
+exec = "bash"
+args = 42
+`},
+		{"cue scalar number", "cue", `
+scripts: [{name: "setup.sh", action: "run", source: ".", exec: "bash", args: 42}]
+`},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := scriptDecodeErr(t, tt.format, tt.blueprint); err == nil {
+				t.Fatal("a non-string args value was accepted")
+			}
+		})
+	}
+}

--- a/internal/processors/scripts_argv_test.go
+++ b/internal/processors/scripts_argv_test.go
@@ -135,3 +135,169 @@ scripts:
 		t.Errorf("staged script = %q, want a .ps1 extension - powershell -File refuses anything else", got)
 	}
 }
+
+// runScriptArgs runs one script blueprint and returns the argv the executor
+// saw, minus the script path that always leads it.
+func runScriptArgs(t *testing.T, format, blueprint string) []string {
+	t.Helper()
+
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "setup.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/bash\necho hi\n"), 0o700); err != nil {
+		t.Fatalf("writing script: %v", err)
+	}
+
+	if err := ProcessScripts([]byte(blueprint), dir, format, scriptOSInfo(), &types.InitConfig{}); err != nil {
+		t.Fatalf("ProcessScripts: %v", err)
+	}
+	if len(rec.Calls) != 1 {
+		t.Fatalf("recorded %d calls, want 1: %v", len(rec.Calls), rec.Calls)
+	}
+	return rec.Calls[0].Args[1:]
+}
+
+func argsEqual(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// The reason the list form exists. Splitting on whitespace means an argument
+// that contains whitespace cannot be written at all: quoting inside the string
+// does not help, because no shell ever parses the value. A list element is
+// taken verbatim.
+func TestProcessScripts_ListArgsKeepArgumentsContainingSpaces(t *testing.T) {
+	got := runScriptArgs(t, "yaml", `
+scripts:
+  - name: "setup.sh"
+    action: "run"
+    source: "."
+    exec: "bash"
+    args: ["--message", "hello world", "--out", "/tmp/a b"]
+`)
+
+	want := []string{"--message", "hello world", "--out", "/tmp/a b"}
+	if !argsEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
+// The list form has to work in every blueprint format, not just the one it was
+// written against. CUE rides the JSON decode path.
+func TestProcessScripts_ListArgsInEveryFormat(t *testing.T) {
+	want := []string{"--message", "hello world"}
+
+	cases := map[string]string{
+		"yaml": `
+scripts:
+  - name: "setup.sh"
+    action: "run"
+    source: "."
+    exec: "bash"
+    args: ["--message", "hello world"]
+`,
+		"json": `{"scripts":[{"name":"setup.sh","action":"run","source":".","exec":"bash","args":["--message","hello world"]}]}`,
+		"toml": `
+[[scripts]]
+name = "setup.sh"
+action = "run"
+source = "."
+exec = "bash"
+args = ["--message", "hello world"]
+`,
+		"cue": `
+scripts: [{
+	name:   "setup.sh"
+	action: "run"
+	source: "."
+	exec:   "bash"
+	args: ["--message", "hello world"]
+}]
+`,
+	}
+
+	for format, blueprint := range cases {
+		t.Run(format, func(t *testing.T) {
+			if got := runScriptArgs(t, format, blueprint); !argsEqual(got, want) {
+				t.Fatalf("args = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+// The string form keeps splitting on whitespace in every format too: existing
+// blueprints depend on it, and nothing else does that splitting now that
+// commands are argv.
+func TestProcessScripts_StringArgsStillSplitInEveryFormat(t *testing.T) {
+	want := []string{"--verbose", "--out", "/tmp/out"}
+
+	cases := map[string]string{
+		"yaml": `
+scripts:
+  - name: "setup.sh"
+    action: "run"
+    source: "."
+    exec: "bash"
+    args: "--verbose --out /tmp/out"
+`,
+		"json": `{"scripts":[{"name":"setup.sh","action":"run","source":".","exec":"bash","args":"--verbose --out /tmp/out"}]}`,
+		"toml": `
+[[scripts]]
+name = "setup.sh"
+action = "run"
+source = "."
+exec = "bash"
+args = "--verbose --out /tmp/out"
+`,
+		"cue": `
+scripts: [{
+	name:   "setup.sh"
+	action: "run"
+	source: "."
+	exec:   "bash"
+	args:   "--verbose --out /tmp/out"
+}]
+`,
+	}
+
+	for format, blueprint := range cases {
+		t.Run(format, func(t *testing.T) {
+			if got := runScriptArgs(t, format, blueprint); !argsEqual(got, want) {
+				t.Fatalf("args = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+// An omitted or empty args field adds nothing, rather than an empty argument
+// that the script would see as a real (blank) parameter.
+func TestProcessScripts_EmptyArgsAddNothing(t *testing.T) {
+	for name, args := range map[string]string{
+		"omitted":      "",
+		"empty string": `    args: ""` + "\n",
+		"whitespace":   `    args: "   "` + "\n",
+		"empty list":   `    args: []` + "\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := runScriptArgs(t, "yaml", `
+scripts:
+  - name: "setup.sh"
+    action: "run"
+    source: "."
+    exec: "bash"
+`+args)
+			if len(got) != 0 {
+				t.Fatalf("args = %#v, want none", got)
+			}
+		})
+	}
+}

--- a/internal/types/script_args.go
+++ b/internal/types/script_args.go
@@ -39,9 +39,20 @@ func (a *ScriptArgs) UnmarshalYAML(node *yaml.Node) error {
 		*a = splitScriptArgs(node.Value)
 		return nil
 	case "!!seq":
-		var list []string
-		if err := node.Decode(&list); err != nil {
-			return fmt.Errorf("line %d: args list must contain only strings: %w", node.Line, err)
+		// Each element is checked rather than decoded straight into []string.
+		// yaml.v3 coerces any scalar to a string on the way in, so
+		// `args: [1, true]` decoded happily as ["1", "true"] while JSON, TOML
+		// and CUE all rejected the same blueprint - and YAML itself rejected
+		// the bare scalar `args: 42`, so it did not even agree with itself.
+		// The formats have to mean the same thing; the examples CI job exists
+		// to assert exactly that.
+		list := make([]string, 0, len(node.Content))
+		for i, element := range node.Content {
+			if element.Tag != "!!str" {
+				return fmt.Errorf("line %d: args[%d] must be a string; quote it if you meant the text %q",
+					element.Line, i, element.Value)
+			}
+			list = append(list, element.Value)
 		}
 		*a = list
 		return nil

--- a/internal/types/script_args.go
+++ b/internal/types/script_args.go
@@ -1,0 +1,115 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ScriptArgs is a script's argument list, written either as a list or as a
+// single string.
+//
+// The string form splits on whitespace, which is what `args` has always done
+// and what every existing blueprint relies on: `args: "--verbose --out /tmp"`
+// reaches the script as three arguments. Commands are argv now, so nothing
+// else does that splitting - without it the whole string would arrive as one
+// argument.
+//
+// That split is also the limitation the list form exists for. Splitting on
+// whitespace means an argument containing whitespace cannot be written at all:
+// no amount of quoting inside the string helps, because the value is never
+// parsed by a shell. A commit message, a path with a space, a --message flag -
+// none of them could be passed. The list form takes each element verbatim:
+//
+//	args: ["--message", "hello world"]
+//
+// Both forms stay supported. The string is the common case and reads better
+// for simple flags; the list is the one that can express everything.
+type ScriptArgs []string
+
+// UnmarshalYAML reads args from YAML as either a scalar or a sequence.
+func (a *ScriptArgs) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Tag {
+	case "!!null":
+		*a = nil
+		return nil
+	case "!!str":
+		*a = splitScriptArgs(node.Value)
+		return nil
+	case "!!seq":
+		var list []string
+		if err := node.Decode(&list); err != nil {
+			return fmt.Errorf("line %d: args list must contain only strings: %w", node.Line, err)
+		}
+		*a = list
+		return nil
+	default:
+		return fmt.Errorf("line %d: args must be a string or a list of strings, got %s", node.Line, node.Tag)
+	}
+}
+
+// UnmarshalJSON reads args from JSON as either a string or an array. CUE
+// blueprints arrive through here too, since CUE evaluates to JSON.
+func (a *ScriptArgs) UnmarshalJSON(data []byte) error {
+	raw := strings.TrimSpace(string(data))
+	switch {
+	case raw == "null":
+		*a = nil
+		return nil
+	case strings.HasPrefix(raw, "["):
+		var list []string
+		if err := json.Unmarshal(data, &list); err != nil {
+			return fmt.Errorf("args list must contain only strings: %w", err)
+		}
+		*a = list
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("args must be a string or a list of strings")
+	}
+	*a = splitScriptArgs(s)
+	return nil
+}
+
+// UnmarshalTOML reads args from TOML. BurntSushi hands over the decoded value,
+// so a list arrives as []interface{} whose elements have to be checked one by
+// one rather than asserted wholesale.
+func (a *ScriptArgs) UnmarshalTOML(data any) error {
+	switch v := data.(type) {
+	case nil:
+		*a = nil
+		return nil
+	case string:
+		*a = splitScriptArgs(v)
+		return nil
+	case []string:
+		*a = v
+		return nil
+	case []any:
+		list := make([]string, 0, len(v))
+		for i, element := range v {
+			s, ok := element.(string)
+			if !ok {
+				return fmt.Errorf("args[%d] must be a string, got %T", i, element)
+			}
+			list = append(list, s)
+		}
+		*a = list
+		return nil
+	default:
+		return fmt.Errorf("args must be a string or a list of strings, got %T", data)
+	}
+}
+
+// splitScriptArgs divides the string form on whitespace.
+func splitScriptArgs(s string) []string {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}

--- a/internal/types/scripts.go
+++ b/internal/types/scripts.go
@@ -7,8 +7,10 @@ type Script struct {
 	Exec     string   `mapstructure:"exec" yaml:"exec" json:"exec" toml:"exec"`
 	Source   string   `mapstructure:"source,omitempty" yaml:"source,omitempty" json:"source,omitempty" toml:"source,omitempty"`
 	Content  string   `mapstructure:"content,omitempty" yaml:"content,omitempty" json:"content,omitempty" toml:"content,omitempty"`
-	Args     string   `mapstructure:"args,omitempty" yaml:"args,omitempty" json:"args,omitempty" toml:"args,omitempty"`
-	Elevated bool     `mapstructure:"elevated,omitempty" yaml:"elevated,omitempty" json:"elevated,omitempty" toml:"elevated,omitempty"`
+	// Args is a string (split on whitespace) or a list (taken verbatim).
+	// See ScriptArgs.
+	Args     ScriptArgs `mapstructure:"args,omitempty" yaml:"args,omitempty" json:"args,omitempty" toml:"args,omitempty"`
+	Elevated bool       `mapstructure:"elevated,omitempty" yaml:"elevated,omitempty" json:"elevated,omitempty" toml:"elevated,omitempty"`
 	// AsUser runs the script as another account (sudo -u). Elevated takes
 	// precedence when both are set, since sudo cannot do both at once.
 	AsUser      string `mapstructure:"asUser,omitempty" yaml:"asUser,omitempty" json:"asUser,omitempty" toml:"asUser,omitempty"`


### PR DESCRIPTION
Plan item 5, first half. The second half turned out to be a bad finding on my part - see below.

## The gap

`args` was a single string, split on whitespace on the way to the script. That split is load-bearing: commands are argv now, so without it `args: "--verbose --out /tmp"` would arrive as **one** argument instead of three.

But it also meant an argument containing whitespace could not be written **at all**. Quoting inside the string does not help, because no shell ever parses the value. A commit message, a path with a space, any `--message` flag - none of them were expressible.

## The fix

`types.ScriptArgs` accepts either form:

```yaml
args: "--verbose --out /tmp"                                  # split on whitespace, as before
args: ["--message", "hello world", "--out", "/tmp/my reports"]  # each element verbatim
```

Every existing blueprint is unaffected - the string form behaves exactly as it did.

It decodes in all four blueprint formats, following the `UnmarshalYAML` / `UnmarshalJSON` / `UnmarshalTOML` shape `types.FileMode` already established for a field with more than one written form. CUE rides the JSON path, as it does everywhere else.

Tests cover both forms in all four formats, plus the empty cases: an omitted, blank, or empty-list `args` adds nothing, rather than an empty argument the script would see as a real blank parameter.

## What I did not do, and why

My review flagged a second thing: `processScripts` returns on the first failure, so script 2 of 10 failing means 3 through 10 never run, where every other processor records the failure and carries on. I planned to make it match.

Looking at it properly, **the inconsistency is correct and I was wrong to flag it.** The interactive halt fires on a processor-level error return, and `HaltRetry` re-runs the whole blueprint file. The comment justifying that says *"providers are idempotent, so completed items skip fast"* - which is exactly what a script is not. Scripts are arbitrary code, usually ordered, and a failed one has likely left the next one's prerequisites unmet. Continuing would run scripts that cannot succeed; and since retry re-runs the file, stopping early is what keeps already-succeeded scripts from executing twice.

So the behaviour stays, and now carries a comment saying why - which is the actual defect, since an unexplained inconsistency is what made it look like an oversight.

## Verification

`go test -race ./...` green on darwin, `golangci-lint` 0 issues, `go vet` clean, gosec and govulncheck clean via the pre-push hook. Every example tree still passes `rwr validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Script arguments support whitespace-separated strings and lists.
  - List entries preserve embedded spaces for paths and quoted values.
  - Argument handling is consistent across YAML, JSON, TOML, and CUE.
  - Empty or omitted arguments produce no command-line arguments.

- **Bug Fixes**
  - Invalid argument types are rejected with clear errors.
  - Script processing stops at the first failure and returns the error for retry, skip, or abort handling.

- **Documentation**
  - Updated script configuration documentation with supported formats and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->