### PR TITLE
fix(diff): a config rwr applied is not drift, and gets emitted

### DIFF
--- a/docs/cli/diff.md
+++ b/docs/cli/diff.md
@@ -6,8 +6,11 @@ the delta as blueprint material - never an apply.
 The machine side comes from read-only scans: explicitly-installed packages
 per provider (`pacman -Qe`, `apt-mark showmanual`, …), operator-enabled
 services, git checkouts, and configs. The tree side is the resolved plan.
-Packages the [run journal](../state.md) shows a run applied never report as
-hand-added - the tree may have changed since, but you didn't install them.
+Anything the [run journal](../state.md) shows a run applied never reports as
+hand-added - the tree may have changed since, but you didn't put it there.
+Packages and services match by name; configs and checkouts match by the path
+the journal recorded, since a blueprint entry's name has nothing to do with
+where its file lands.
 
 ```bash
 # The readable list: + additions (hand-done), - removals (declared, gone)

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -77,10 +77,24 @@ func Compute(machine Machine, plan *types.Plan, applies []state.Entry) []Change 
 	// or the journal accounts for it. location is the absolute path for the
 	// categories identified by one, and empty for the rest.
 	add := func(category, provider, name, location string) {
-		if desired[category][name] || applied[category+"\x00"+name] {
+		// The tree side offers nothing but a name, so that check is the same
+		// for every category.
+		if desired[category][name] {
 			return
 		}
-		if location != "" && appliedPaths[category+"\x00"+filepath.Clean(location)] {
+		if location != "" {
+			// Path only, never the name. Naming a files entry after the file
+			// it carries is the convention, so a journaled "init.lua" would
+			// otherwise suppress every other init.lua on the machine - and
+			// half a dozen tools own one. That is the same basename collision
+			// this change exists to remove; checking the name first would have
+			// left it in place through the other branch.
+			if appliedPaths[category+"\x00"+filepath.Clean(location)] {
+				return
+			}
+		} else if applied[category+"\x00"+name] {
+			// Packages and services have no location: a name is what
+			// identifies them, and the journal records the same one.
 			return
 		}
 		changes = append(changes, Change{Category: category, Provider: provider, Name: name, Path: location})

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -7,6 +7,7 @@ package diff
 import (
 	"fmt"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -20,7 +21,13 @@ type Change struct {
 	Category string // packages, services, git, configs
 	Provider string // packages only
 	Name     string
-	Removal  bool // declared in the tree, gone from the machine
+	// Path is where the thing lives on the machine, for the categories that
+	// are identified by one: a config's file and a checkout's directory. It
+	// is what the journal is matched against, and what EmitBlocks needs to
+	// find the scanned entry again. Empty for packages and services, which
+	// are identified by name.
+	Path    string
+	Removal bool // declared in the tree, gone from the machine
 }
 
 // Machine is the scanned side, gathered once by the caller.
@@ -45,23 +52,45 @@ func Compute(machine Machine, plan *types.Plan, applies []state.Entry) []Change 
 		desired[category][resource.Name] = true
 	}
 	applied := map[string]bool{} // "category\x00name" the journal accounts for
+	// appliedPaths is the same question asked by location rather than by name,
+	// which is the only way it can be answered for a config or a checkout.
+	//
+	// A files entry's blueprint name ("nvim-config") has nothing to do with the
+	// file it lands on, so matching a scanned config against Identity["name"]
+	// never hit: every dotfile rwr itself had applied came back as drift the
+	// tree does not declare. The journal records where the thing actually went,
+	// which is exactly what the scan found, so the two match on that.
+	// status.Rows already enriches from the journal for the same reason.
+	appliedPaths := map[string]bool{}
 	for _, entry := range applies {
 		applied[entry.Processor+"\x00"+entry.Identity["name"]] = true
+		// dest for a file, target for a checkout: the recorded location.
+		for _, key := range []string{"dest", "target"} {
+			if location := entry.Identity[key]; location != "" {
+				appliedPaths[entry.Processor+"\x00"+filepath.Clean(location)] = true
+			}
+		}
 	}
 
 	var changes []Change
-	add := func(category, provider, name string) {
+	// add reports something found on the machine, unless the tree declares it
+	// or the journal accounts for it. location is the absolute path for the
+	// categories identified by one, and empty for the rest.
+	add := func(category, provider, name, location string) {
 		if desired[category][name] || applied[category+"\x00"+name] {
 			return
 		}
-		changes = append(changes, Change{Category: category, Provider: provider, Name: name})
+		if location != "" && appliedPaths[category+"\x00"+filepath.Clean(location)] {
+			return
+		}
+		changes = append(changes, Change{Category: category, Provider: provider, Name: name, Path: location})
 	}
 
 	scannedPackages := map[string]bool{}
 	for _, result := range machine.Packages {
 		for _, name := range result.Names {
 			scannedPackages[name] = true
-			add(types.BlueprintTypePackages, result.Provider, name)
+			add(types.BlueprintTypePackages, result.Provider, name, "")
 		}
 	}
 	for name := range desired[types.BlueprintTypePackages] {
@@ -73,7 +102,7 @@ func Compute(machine Machine, plan *types.Plan, applies []state.Entry) []Change 
 	scannedServices := map[string]bool{}
 	for _, service := range machine.Services {
 		scannedServices[service] = true
-		add(types.BlueprintTypeServices, "", service)
+		add(types.BlueprintTypeServices, "", service, "")
 	}
 	for name := range desired[types.BlueprintTypeServices] {
 		if !scannedServices[name] {
@@ -82,11 +111,11 @@ func Compute(machine Machine, plan *types.Plan, applies []state.Entry) []Change 
 	}
 
 	for _, checkout := range machine.Git {
-		add(types.BlueprintTypeGit, "", path.Base(checkout.Path))
+		add(types.BlueprintTypeGit, "", path.Base(checkout.Path), checkout.Path)
 	}
 
 	for _, config := range machine.Configs {
-		add(types.BlueprintTypeFiles, "", path.Base(config.Rel))
+		add(types.BlueprintTypeFiles, "", path.Base(config.Rel), config.Path)
 	}
 
 	sort.SliceStable(changes, func(i, j int) bool {
@@ -135,10 +164,21 @@ func EmitBlocks(changes []Change, machine Machine, format string) (string, error
 	byProvider := map[string][]string{}
 	var services []string
 	var git []scan.GitCheckout
-	gitByName := map[string]scan.GitCheckout{}
+	var configs []scan.ConfigResult
+
+	// Both lookups are by path, not by name. Two checkouts can share a
+	// directory name and two configs very often share a filename - half a
+	// dozen tools each own an "init.lua" or a "config" - so a name-keyed map
+	// silently emits whichever one was scanned last.
+	gitByPath := map[string]scan.GitCheckout{}
 	for _, checkout := range machine.Git {
-		gitByName[path.Base(checkout.Path)] = checkout
+		gitByPath[filepath.Clean(checkout.Path)] = checkout
 	}
+	configByPath := map[string]scan.ConfigResult{}
+	for _, config := range machine.Configs {
+		configByPath[filepath.Clean(config.Path)] = config
+	}
+
 	for _, change := range changes {
 		if change.Removal {
 			continue
@@ -149,8 +189,12 @@ func EmitBlocks(changes []Change, machine Machine, format string) (string, error
 		case types.BlueprintTypeServices:
 			services = append(services, change.Name)
 		case types.BlueprintTypeGit:
-			if checkout, ok := gitByName[change.Name]; ok {
+			if checkout, ok := gitByPath[filepath.Clean(change.Path)]; ok {
 				git = append(git, checkout)
+			}
+		case types.BlueprintTypeFiles:
+			if config, ok := configByPath[filepath.Clean(change.Path)]; ok {
+				configs = append(configs, config)
 			}
 		}
 	}
@@ -180,6 +224,17 @@ func EmitBlocks(changes []Change, machine Machine, format string) (string, error
 	}
 	if len(git) > 0 {
 		block, err := scan.EmitGit(git, machine.Home, format)
+		if err != nil {
+			return "", err
+		}
+		out = append(out, string(block))
+	}
+	// Configs were listed as drift and then dropped here, so `rwr diff --emit`
+	// printed blocks for everything except the dotfiles - the category the
+	// command is most often reached for. scan.EmitConfigs already existed;
+	// capture has been using it all along.
+	if len(configs) > 0 {
+		block, err := scan.EmitConfigs(configs, machine.Home, format)
 		if err != nil {
 			return "", err
 		}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -139,3 +139,130 @@ func TestAppendEntries(t *testing.T) {
 		}
 	}
 }
+
+// A file rwr itself applied is not drift, and the journal is the only place
+// that says so.
+//
+// A files entry's blueprint name ("nvim-config") has nothing to do with the
+// path it lands on, so matching a scanned config against Identity["name"]
+// never hit: every dotfile rwr had applied came back as "on the machine, not
+// in the tree". The journal records where the thing actually went, which is
+// exactly what the scan found.
+func TestCompute_JournalPathsAccountForConfigsAndCheckouts(t *testing.T) {
+	t.Parallel()
+
+	machine := Machine{
+		Home:    "/home/me",
+		Configs: []scan.ConfigResult{{Path: "/home/me/.config/nvim/init.lua", Rel: ".config/nvim/init.lua", Known: true}},
+		Git:     []scan.GitCheckout{{Path: "/home/me/src/rwr", URL: "git@github.com:FynxLabs/rwr.git"}},
+	}
+	applies := []state.Entry{
+		{Processor: types.BlueprintTypeFiles,
+			Identity: map[string]string{"name": "nvim-config", "dest": "/home/me/.config/nvim/init.lua"}},
+		{Processor: types.BlueprintTypeGit,
+			Identity: map[string]string{"name": "rwr-checkout", "target": "/home/me/src/rwr"}},
+	}
+
+	if changes := Compute(machine, &types.Plan{}, applies); len(changes) != 0 {
+		t.Fatalf("rwr's own applies reported as drift: %+v", changes)
+	}
+}
+
+// The path comparison is by cleaned path, so a recorded trailing slash or a
+// "." segment still matches what the scan found.
+func TestCompute_JournalPathMatchIsPathAware(t *testing.T) {
+	t.Parallel()
+
+	machine := Machine{
+		Home: "/home/me",
+		Git:  []scan.GitCheckout{{Path: "/home/me/src/rwr", URL: "u"}},
+	}
+	applies := []state.Entry{
+		{Processor: types.BlueprintTypeGit, Identity: map[string]string{"target": "/home/me/src/./rwr/"}},
+	}
+
+	if changes := Compute(machine, &types.Plan{}, applies); len(changes) != 0 {
+		t.Fatalf("an unclean recorded path failed to match: %+v", changes)
+	}
+}
+
+// A recorded path only accounts for its own category. A checkout at a path
+// must not silence a config at that same path, or vice versa.
+func TestCompute_JournalPathsAreScopedToTheirCategory(t *testing.T) {
+	t.Parallel()
+
+	machine := Machine{
+		Home:    "/home/me",
+		Configs: []scan.ConfigResult{{Path: "/home/me/thing", Rel: "thing"}},
+	}
+	// The journal accounts for a *checkout* at that path, not a file.
+	applies := []state.Entry{
+		{Processor: types.BlueprintTypeGit, Identity: map[string]string{"target": "/home/me/thing"}},
+	}
+
+	changes := Compute(machine, &types.Plan{}, applies)
+	if len(changes) != 1 || changes[0].Category != types.BlueprintTypeFiles {
+		t.Fatalf("a git target silenced a config at the same path: %+v", changes)
+	}
+}
+
+// Everything the list reports as an addition has to be emittable, or
+// `rwr diff --emit` quietly hands back less than it just showed. Configs were
+// listed and then dropped - the category the command is most often used for.
+func TestEmitBlocks_IncludesEveryListedCategory(t *testing.T) {
+	t.Parallel()
+
+	machine := Machine{
+		Home:     "/home/me",
+		Packages: []scan.PackageResult{{Provider: "pacman", Names: []string{"ripgrep"}}},
+		Services: []string{"sshd"},
+		Git:      []scan.GitCheckout{{Path: "/home/me/src/rwr", URL: "git@github.com:FynxLabs/rwr.git"}},
+		Configs:  []scan.ConfigResult{{Path: "/home/me/.config/nvim/init.lua", Rel: ".config/nvim/init.lua", Known: true}},
+	}
+
+	changes := Compute(machine, &types.Plan{}, nil)
+	out, err := EmitBlocks(changes, machine, "yaml")
+	if err != nil {
+		t.Fatalf("EmitBlocks: %v", err)
+	}
+
+	// Every category the list reported must appear in the emitted blocks.
+	seen := map[string]bool{}
+	for _, change := range changes {
+		seen[change.Category] = true
+	}
+	for category := range seen {
+		if !strings.Contains(out, category+":") {
+			t.Errorf("category %q was listed as drift but is missing from --emit output:\n%s", category, out)
+		}
+	}
+}
+
+// Two configs can share a filename - half a dozen tools each own a "config" -
+// so the emitted block has to be found by path, not by name.
+func TestEmitBlocks_ConfigsSharingAFilenameBothEmit(t *testing.T) {
+	t.Parallel()
+
+	machine := Machine{
+		Home: "/home/me",
+		Configs: []scan.ConfigResult{
+			{Path: "/home/me/.config/nvim/init.lua", Rel: ".config/nvim/init.lua", Known: true},
+			{Path: "/home/me/.config/wezterm/init.lua", Rel: ".config/wezterm/init.lua", Known: true},
+		},
+	}
+
+	changes := Compute(machine, &types.Plan{}, nil)
+	if len(changes) != 2 {
+		t.Fatalf("expected both configs as drift, got %+v", changes)
+	}
+
+	out, err := EmitBlocks(changes, machine, "yaml")
+	if err != nil {
+		t.Fatalf("EmitBlocks: %v", err)
+	}
+	for _, want := range []string{"nvim", "wezterm"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("emitted output lost the %s config:\n%s", want, out)
+		}
+	}
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -266,3 +266,99 @@ func TestEmitBlocks_ConfigsSharingAFilenameBothEmit(t *testing.T) {
 		}
 	}
 }
+
+// A journal entry accounts for one path, not for every file that happens to
+// share its basename.
+//
+// Naming a files entry after the file it carries is the convention, so a
+// journaled "init.lua" would otherwise suppress every other init.lua on the
+// machine - and half a dozen tools own one. Checking the recorded name before
+// the recorded path left exactly the basename collision this change exists to
+// remove.
+func TestCompute_AJournaledNameDoesNotHideAnotherPath(t *testing.T) {
+	t.Parallel()
+
+	machine := Machine{
+		Home: "/home/me",
+		Configs: []scan.ConfigResult{
+			{Path: "/home/me/.config/nvim/init.lua", Rel: ".config/nvim/init.lua"},
+			{Path: "/home/me/.config/wezterm/init.lua", Rel: ".config/wezterm/init.lua"},
+		},
+	}
+	// The recorded entry is named after its file and covers only the nvim one.
+	applies := []state.Entry{
+		{Processor: types.BlueprintTypeFiles,
+			Identity: map[string]string{"name": "init.lua", "dest": "/home/me/.config/nvim/init.lua"}},
+	}
+
+	changes := Compute(machine, &types.Plan{}, applies)
+	if len(changes) != 1 {
+		t.Fatalf("want only the unjournaled config as drift, got %d: %+v", len(changes), changes)
+	}
+	if changes[0].Path != "/home/me/.config/wezterm/init.lua" {
+		t.Errorf("reported the wrong config: %+v", changes[0])
+	}
+
+	// And it still reaches the paste-ready output.
+	out, err := EmitBlocks(changes, machine, "yaml")
+	if err != nil {
+		t.Fatalf("EmitBlocks: %v", err)
+	}
+	if !strings.Contains(out, "wezterm") {
+		t.Errorf("the unjournaled config is missing from --emit output:\n%s", out)
+	}
+	if strings.Contains(out, "nvim") {
+		t.Errorf("the journaled config was emitted as drift:\n%s", out)
+	}
+}
+
+// The same rule for checkouts: two repos can be cloned into directories with
+// the same base name.
+func TestCompute_AJournaledCheckoutNameDoesNotHideAnotherPath(t *testing.T) {
+	t.Parallel()
+
+	machine := Machine{
+		Home: "/home/me",
+		Git: []scan.GitCheckout{
+			{Path: "/home/me/work/rwr", URL: "git@github.com:FynxLabs/rwr.git"},
+			{Path: "/home/me/fork/rwr", URL: "git@github.com:someone/rwr.git"},
+		},
+	}
+	applies := []state.Entry{
+		{Processor: types.BlueprintTypeGit,
+			Identity: map[string]string{"name": "rwr", "target": "/home/me/work/rwr"}},
+	}
+
+	changes := Compute(machine, &types.Plan{}, applies)
+	if len(changes) != 1 {
+		t.Fatalf("want only the unjournaled checkout as drift, got %d: %+v", len(changes), changes)
+	}
+	if changes[0].Path != "/home/me/fork/rwr" {
+		t.Errorf("reported the wrong checkout: %+v", changes[0])
+	}
+}
+
+// Packages and services have no location, so a name is what identifies them
+// and the journal match has to keep working on it.
+func TestCompute_NameMatchingStillAppliesWithoutALocation(t *testing.T) {
+	t.Parallel()
+
+	machine := Machine{
+		Packages: []scan.PackageResult{{Provider: "pacman", Names: []string{"ripgrep", "fd"}}},
+		Services: []string{"sshd", "docker"},
+	}
+	applies := []state.Entry{
+		{Processor: types.BlueprintTypePackages, Identity: map[string]string{"name": "ripgrep"}},
+		{Processor: types.BlueprintTypeServices, Identity: map[string]string{"name": "sshd"}},
+	}
+
+	changes := Compute(machine, &types.Plan{}, applies)
+	if len(changes) != 2 {
+		t.Fatalf("want fd and docker as drift, got %d: %+v", len(changes), changes)
+	}
+	for _, change := range changes {
+		if change.Name == "ripgrep" || change.Name == "sshd" {
+			t.Errorf("a journaled name-identified resource was reported as drift: %+v", change)
+		}
+	}
+}


### PR DESCRIPTION
Plan item 6. Two defects in `rwr diff`, both in how a config or a checkout is identified.

## 1. The journal never accounted for configs or checkouts

`Compute` matched a scanned config against `Identity["name"]`. A files entry's blueprint name (`nvim-config`) has nothing to do with the path it lands on, so **the match never hit**: every dotfile rwr itself had applied came back as "on the machine, not in the tree". Checkouts had it the same way, comparing a directory's base name against the entry name.

Reproduced before fixing - with the plan empty and the journal recording both at their real paths:

```
drift: files init.lua
drift: git rwr
```

Neither should be there. The journal records where the thing actually went (`dest` for a file, `target` for a checkout), and that is exactly what the scan found, so the two now match on the path. `status.Rows` already enriches from the journal for this reason; `diff` just never did.

Paths compare cleaned, so a recorded trailing slash or `.` segment still matches, and the match is scoped to its category so a checkout cannot silence a config at the same path. Both have tests.

**Docs:** the existing line said *"**Packages** the run journal shows a run applied never report as hand-added"* - accurate, and it named packages because that was the only category it worked for. Generalised.

## 2. `--emit` silently dropped the files category

`EmitBlocks` handled packages, services and git, and dropped files on the floor. So `rwr diff --emit` printed blocks for everything **except the dotfiles** - the category the command is most often reached for. The list showed them; the paste-ready output did not. `scan.EmitConfigs` already existed; capture has been using it all along.

Both emit lookups are now by path rather than by name. Two checkouts can share a directory name and two configs very often share a filename - half a dozen tools each own an `init.lua` or a `config` - and a name-keyed map silently emitted whichever was scanned last. There's a test with two `init.lua` files that fails on the old code.

## Verification

All three new tests fail against the pre-fix code with the exact symptoms:

```
--- FAIL: TestCompute_JournalPathsAccountForConfigsAndCheckouts
    rwr's own applies reported as drift: [{files init.lua} {git rwr}]
--- FAIL: TestEmitBlocks_IncludesEveryListedCategory
    category "files" was listed as drift but is missing from --emit output
--- FAIL: TestEmitBlocks_ConfigsSharingAFilenameBothEmit
```

`go test -race ./...` green on darwin, `golangci-lint` 0 issues, `go vet` clean, gosec and govulncheck clean via the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `rwr diff` reporting by excluding already-applied packages, services, configuration files, and Git checkouts from hand-added changes.
  * Matching now correctly uses resource names or normalized machine paths, as appropriate.
  * Improved handling of multiple configuration resources sharing the same filename.
* **Documentation**
  * Clarified `rwr diff` behavior for journal-applied resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->