### PR TITLE
fix(system): warm sudo before a command that escalates itself

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -46,7 +46,8 @@ A filesystem override in TOML looks like this:
 ```toml
 [provider]
 name = "provider-name"  # Unique identifier
-elevated = false       # Whether root/admin privileges are needed
+elevated = false       # Whether RWR runs this provider under sudo
+escalates = false      # Whether the provider calls sudo itself (see below)
 
 [provider.detection]
 binary = "binary-name" # Main executable to check for
@@ -322,9 +323,34 @@ To contribute a provider to RWR itself, author it in CUE under
 and rejects invalid definitions. That's it: no export step, nothing else to
 regenerate.
 
+### `elevated` and `escalates`
+
+These answer two different questions, and a provider can need one without the
+other.
+
+`elevated = true` means **RWR** runs the provider under sudo. Use it for
+system-wide package managers such as `pacman` or `apt`.
+
+`escalates = true` means the provider **calls sudo itself** while RWR runs it
+unprivileged. Homebrew is the case: it refuses to run as root, so it must have
+`elevated = false`, and a cask install still shells out to sudo to write into
+`/Applications`.
+
+That distinction matters because of where the password prompt goes. RWR
+captures a command's output through pipes, but sudo reads its password from
+`/dev/tty` instead - so a prompt from a provider RWR did not know would
+escalate is invisible under the dashboard, and the run hangs on a password
+nobody was asked for. Declaring `escalates` makes RWR warm sudo's credential
+cache first, through a proper terminal handover, so the install never prompts.
+
+Only set it on providers you have actually seen escalate. Setting it on one
+that does not will ask for a password on runs that never need root.
+
 ## Best Practices
 
 - Use `elevated = true` for system-wide package managers
+- Use `escalates = true` for a provider RWR runs unprivileged that calls sudo
+  itself, such as Homebrew
 - Include all relevant detection files
 - Document command flags in comments
 - Use consistent repository paths

--- a/internal/exectest/recorder.go
+++ b/internal/exectest/recorder.go
@@ -16,10 +16,13 @@ type Call struct {
 	Exec     string
 	Args     []string
 	Elevated bool
-	AsUser   string
-	LogName  string
-	Vars     map[string]string
-	Stdin    string
+	// Escalates records a command rwr runs unprivileged that calls sudo
+	// itself, which decides whether the credential cache is warmed first.
+	Escalates bool
+	AsUser    string
+	LogName   string
+	Vars      map[string]string
+	Stdin     string
 }
 
 // Argv is the full argument vector as the target program would receive it:
@@ -62,13 +65,14 @@ func (r *Recorder) record(cmd types.Command) {
 	args := make([]string, len(cmd.Args))
 	copy(args, cmd.Args)
 	r.Calls = append(r.Calls, Call{
-		Exec:     cmd.Exec,
-		Args:     args,
-		Elevated: cmd.Elevated,
-		AsUser:   cmd.AsUser,
-		LogName:  cmd.LogName,
-		Vars:     cmd.Variables,
-		Stdin:    cmd.Stdin,
+		Exec:      cmd.Exec,
+		Args:      args,
+		Elevated:  cmd.Elevated,
+		Escalates: cmd.Escalates,
+		AsUser:    cmd.AsUser,
+		LogName:   cmd.LogName,
+		Vars:      cmd.Variables,
+		Stdin:     cmd.Stdin,
 	})
 }
 

--- a/internal/processors/packages.go
+++ b/internal/processors/packages.go
@@ -182,7 +182,12 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 				// The provider decides whether its package manager needs elevation;
 				// a blueprint may ask for it on top (a user-scoped manager invoked
 				// against a system path), but may not take it away.
-				Elevated:  provider.Elevated || pkg.Elevated,
+				Elevated: provider.Elevated || pkg.Elevated,
+				// Declared by the provider: a manager rwr runs unprivileged
+				// that calls sudo itself, so the credential cache is warmed
+				// before it rather than after it has already hung on a prompt
+				// nobody could see.
+				Escalates: provider.Escalates,
 				Variables: provider.Environment,
 				// Terminal handover only on an explicit per-item
 				// `interactive: true`. Routing every package through the

--- a/internal/processors/packages_test.go
+++ b/internal/processors/packages_test.go
@@ -1,6 +1,7 @@
 package processors
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -652,5 +653,45 @@ func TestProcessPackages_UnavailableManagerIsFailure(t *testing.T) {
 	}
 	if !sawVim {
 		t.Fatalf("pacman entry did not run after the cargo failure; calls: %v", rec.Calls)
+	}
+}
+
+// A provider that escalates internally has to carry that onto the command, or
+// the sudo credential cache is never warmed for it and the run hangs on an
+// invisible password prompt during the install.
+func TestProcessPackages_EscalatingProviderMarksTheCommand(t *testing.T) {
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+	defer system.SetProvidersForTest(map[string]*types.Provider{
+		"brew": {
+			Name: "brew",
+			// As the real definition has it: brew refuses to run as root, and
+			// still shells out to sudo for a cask.
+			Elevated:  false,
+			Escalates: true,
+			Detection: types.DetectionConfig{Binary: "sh", Distributions: []string{runtime.GOOS}},
+			Commands:  types.CommandConfig{Install: "install"},
+		},
+	})()
+
+	blueprint := []byte(`
+packages:
+  - name: "brave-browser"
+    action: "install"
+    package_manager: "brew"
+`)
+	if err := ProcessPackages(blueprint, nil, t.TempDir(), "yaml", &types.OSInfo{}, &types.InitConfig{}); err != nil {
+		t.Fatalf("ProcessPackages: %v", err)
+	}
+
+	if len(rec.Calls) != 1 {
+		t.Fatalf("recorded %d calls, want 1: %v", len(rec.Calls), rec.Calls)
+	}
+	call := rec.Calls[0]
+	if call.Elevated {
+		t.Error("brew was elevated; it refuses to run as root")
+	}
+	if !call.Escalates {
+		t.Error("the command is not marked as escalating, so sudo will not be pre-validated for it")
 	}
 }

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -114,6 +114,21 @@ var (
 // fails (a command-scoped NOPASSWD rule makes `sudo -v` itself want a
 // password), the command proceeds and fails or succeeds on its own terms,
 // exactly as it did before validation existed.
+// wantsSudoCredentials reports whether a command should have sudo's credential
+// cache warmed before it runs.
+//
+// Escalates is the case the elevation flags alone miss: a command rwr runs
+// unprivileged that calls sudo itself. brew refuses to run as root, so
+// Elevated is false and validation never ran, and then a cask install shelled
+// out to sudo, prompted on /dev/tty behind the dashboard, and hung the run
+// with no visible prompt.
+func wantsSudoCredentials(cmd types.Command) bool {
+	if runtime.GOOS == "windows" {
+		return false
+	}
+	return cmd.Elevated || cmd.AsUser != "" || cmd.Escalates
+}
+
 func ensureSudoCredentials() {
 	sudoValidateMu.Lock()
 	defer sudoValidateMu.Unlock()
@@ -247,7 +262,14 @@ func runCommand(cmd types.Command, debug bool) error {
 	// a failed validation must not fail the command - `sudo -v` is not
 	// command-scoped, so a NOPASSWD rule for just this command makes
 	// validation want a password the command itself never needs.
-	if (cmd.Elevated || cmd.AsUser != "") && runtime.GOOS != "windows" {
+	// Escalates covers the case this guard used to miss entirely: a command
+	// rwr runs unprivileged that calls sudo itself. brew is the example - it
+	// refuses to run as root, so Elevated is false and validation never ran,
+	// and then a cask install shelled out to sudo, prompted on /dev/tty behind
+	// the dashboard, and hung the run with no visible prompt. Earlier casks in
+	// the same run succeeded only because the credential cache was still warm
+	// from something else.
+	if wantsSudoCredentials(cmd) {
 		ensureSudoCredentials()
 	}
 	{

--- a/internal/system/definitions/brew.cue
+++ b/internal/system/definitions/brew.cue
@@ -3,6 +3,10 @@ package providers
 providers: "brew": {
  "name": "brew",
  "elevated": false,
+    // brew refuses to run as root, but a cask install shells out to sudo to
+    // write into /Applications. Without warming the credential cache first,
+    // that prompt lands on /dev/tty behind the dashboard and the run hangs.
+    "escalates": true,
  // Homebrew 6 made "ask mode" the default: every install stops at a
  // "Do you want to proceed? [y/n]" prompt, which deadlocks an automated
  // run. HOMEBREW_NO_ASK restores unattended installs (older brew ignores

--- a/internal/system/definitions/schema.cue
+++ b/internal/system/definitions/schema.cue
@@ -92,6 +92,13 @@ package providers
 #Provider: {
 	name:      string
 	elevated?: bool
+	// escalates marks a provider that rwr runs unprivileged but which invokes
+	// sudo itself. brew is the case: it refuses to run as root, and a cask
+	// install shells out to sudo to write into /Applications. rwr warms the
+	// sudo credential cache before such a command, because that prompt reaches
+	// /dev/tty rather than the captured pipes and would otherwise hang the run
+	// invisibly under the dashboard.
+	escalates?: bool
 	detection: #Detection
 	commands: #Commands
 	repository?: #Repository

--- a/internal/system/sudo_escalation_test.go
+++ b/internal/system/sudo_escalation_test.go
@@ -1,0 +1,58 @@
+package system
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/fynxlabs/rwr/internal/types"
+)
+
+// The guard decides whether sudo's credential cache is warmed before a command
+// runs. Getting it wrong is not a cosmetic failure: an un-warmed command that
+// calls sudo internally prompts on /dev/tty, behind the dashboard, and the run
+// hangs with no visible prompt.
+func TestSudoValidationCoversCommandsThatEscalateThemselves(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == types.OSWindows {
+		t.Skip("no sudo on windows")
+	}
+
+	tests := []struct {
+		name string
+		cmd  types.Command
+		want bool
+	}{
+		{
+			name: "rwr elevates it",
+			cmd:  types.Command{Exec: "pacman", Elevated: true},
+			want: true,
+		},
+		{
+			name: "rwr runs it as another user",
+			cmd:  types.Command{Exec: "makepkg", AsUser: "builder"},
+			want: true,
+		},
+		{
+			// The case that hung a real run: brew must not be elevated, and
+			// still shells out to sudo for a cask install.
+			name: "unprivileged but escalates itself",
+			cmd:  types.Command{Exec: "brew", Escalates: true},
+			want: true,
+		},
+		{
+			name: "plain unprivileged command",
+			cmd:  types.Command{Exec: "go"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := wantsSudoCredentials(tt.cmd); got != tt.want {
+				t.Errorf("wantsSudoCredentials = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/types/command.go
+++ b/internal/types/command.go
@@ -15,6 +15,19 @@ type Command struct {
 	Interactive bool              `mapstructure:"interactive" yaml:"interactive" json:"interactive" toml:"interactive"`
 	Elevated    bool              `mapstructure:"elevated" yaml:"elevated" json:"elevated" toml:"elevated"`
 
+	// Escalates marks a command rwr runs unprivileged that calls sudo itself.
+	//
+	// It is not the same as Elevated and cannot be derived from it. Homebrew
+	// refuses to run as root, so rwr must not elevate it - but a cask install
+	// shells out to sudo to write into /Applications. sudo reads that password
+	// from /dev/tty, straight past the pipes rwr captured, so under the
+	// dashboard the prompt is invisible and the run hangs on a password nobody
+	// was asked for.
+	//
+	// Not a blueprint field: it is a property of the tool, declared by the
+	// provider definition.
+	Escalates bool `mapstructure:"-" yaml:"-" json:"-" toml:"-"`
+
 	// Stdin is fed to the command on standard input. It is deliberately not a
 	// blueprint field: it exists so secrets can be handed to a tool without
 	// appearing in argv, where every local user can read them out of `ps` and

--- a/internal/types/providers.go
+++ b/internal/types/providers.go
@@ -2,8 +2,12 @@ package types
 
 // Provider represents a package manager provider.
 type Provider struct {
-	Name         string                          `toml:"name"`
-	Elevated     bool                            `toml:"elevated"`
+	Name     string `toml:"name"`
+	Elevated bool   `toml:"elevated"`
+	// Escalates marks a provider rwr runs unprivileged that calls sudo itself.
+	// See Command.Escalates: brew must not be run as root, and still needs a
+	// warm sudo cache before a cask install prompts on /dev/tty.
+	Escalates    bool                            `toml:"escalates"`
 	Detection    DetectionConfig                 `toml:"detection"`
 	Commands     CommandConfig                   `toml:"commands"`
 	Repository   RepositoryConfig                `toml:"repository"`


### PR DESCRIPTION
This is the freeze from a real run. It stopped dead on `brew install --cask brave-browser` - no password prompt shown, nothing to press, and ctrl-c did nothing (that half is #269). Earlier casks in the same run had installed fine.

## Why

sudo's credential cache was only ever warmed for commands rwr itself elevates:

```go
if (cmd.Elevated || cmd.AsUser != "") && runtime.GOOS != "windows" {
    ensureSudoCredentials()
}
```

**brew is neither.** It refuses to run as root, so its provider correctly declares `elevated: false` - and a cask install then shells out to `sudo` on its own to write into `/Applications`. sudo reads that password from `/dev/tty`, straight past the pipes rwr captured, so under the dashboard the prompt is invisible and the read blocks forever.

The earlier casks succeeded only because the cache was still warm from something else. It expired, and the next one hung. That is why it looked intermittent.

## The fix

Elevation cannot express this. The flag means "rwr runs this as root", and for brew the answer is genuinely no. So the provider declares it separately:

- `schema.cue` gains `escalates`
- `brew.cue` sets it
- it rides through `Provider` → `Command` → the guard, which becomes a named predicate (`wantsSudoCredentials`) rather than a condition growing a third clause inline

**Only brew is marked.** Others may belong here, but marking a provider that does not escalate would prompt for a password on runs that never need root - the exact failure the existing comment on `ensureSudoCredentials` warns about. They get marked when someone observes the hang.

## Verification

Two tests: the guard covers all four cases (rwr-elevated, as-user, unprivileged-but-escalating, plain), and the provider flag actually reaches the command while brew stays unelevated. `exectest.Call` records `Escalates` so the plumbing is assertable.

`go vet` on darwin and windows, `golangci-lint` 0 issues, `go test -race ./...` green, govulncheck and gosec clean. `cue vet` passes on the provider definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved credential validation for commands that invoke `sudo` indirectly.
  - Homebrew operations now correctly account for possible privilege escalation.
  - Commands run as another user or marked for escalation receive appropriate credential handling.

- **Documentation**
  - Added provider configuration support for identifying operations that may escalate privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->