### PR TITLE
fix(http): every request re-validates its redirects, not just downloads

### DIFF
--- a/internal/helpers/init_source.go
+++ b/internal/helpers/init_source.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/types"
 )
 
@@ -26,7 +27,11 @@ var shorthandPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(/[^@
 
 // probeClient answers "does this raw URL exist" during shorthand resolution.
 // A var so tests can point probes at their own server without waiting 10s.
-var probeClient = &http.Client{Timeout: 10 * time.Second}
+// probeClient re-validates redirects like every other fetch rwr makes: an
+// init source resolves by following the server's answer, and a 302 to plain
+// http would otherwise decide where the blueprint tree comes from over an
+// unauthenticated connection.
+var probeClient = system.NewHTTPClient(10 * time.Second)
 
 // ResolveInitSource turns whatever the operator gave as the init source into
 // the one form Initialize consumes: an existing local file path, or an

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -395,7 +395,7 @@ func requestDeviceCode() (*deviceCodeResponse, error) {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := system.NewHTTPClient(30 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -467,7 +467,7 @@ func checkAccessToken(deviceCode string) (string, error) {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := system.NewHTTPClient(30 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -594,7 +594,7 @@ func copySSHKeyToGitHub(sshKey types.SSHKey, initConfig *types.InitConfig) error
 	req.Header.Set("Content-Type", "application/json")
 
 	// Send request
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := system.NewHTTPClient(30 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("network error connecting to GitHub API: %v", err)

--- a/internal/system/files.go
+++ b/internal/system/files.go
@@ -206,11 +206,45 @@ func NewHTTPClient(timeout time.Duration) *http.Client {
 		Timeout: timeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
-				return errors.New("stopped after 10 redirects")
+				return fmt.Errorf("%w: stopped after 10", ErrTooManyRedirects)
+			}
+			if err := refuseSchemeDowngrade(req, via); err != nil {
+				return err
 			}
 			return ValidateDownloadURL(req.URL.String())
 		},
 	}
+}
+
+// ErrInsecureRedirect reports a redirect that would leave TLS behind.
+var ErrInsecureRedirect = errors.New("refusing to follow an insecure redirect")
+
+// ErrTooManyRedirects reports a redirect chain that never terminates.
+var ErrTooManyRedirects = errors.New("too many redirects")
+
+// refuseSchemeDowngrade rejects a hop to http once any earlier hop was https.
+//
+// It has to run before ValidateDownloadURL, which permits http for loopback so
+// that local mirrors and tests keep working. That exemption is about the URL an
+// operator supplies deliberately; as a *redirect target* it is a hole, because
+// a remote server chooses it. An https response redirecting to
+// http://127.0.0.1 would otherwise be followed, and any local process can bind
+// a loopback port and read what arrives - including the device code rwr posts
+// to exchange for a GitHub token.
+//
+// The whole chain is checked rather than only the previous hop, so
+// https -> http is refused however many times it bounces on the way.
+func refuseSchemeDowngrade(req *http.Request, via []*http.Request) error {
+	if req.URL.Scheme != "http" {
+		return nil
+	}
+	for _, previous := range via {
+		if previous.URL.Scheme == "https" {
+			return fmt.Errorf("%w: %s redirected to %s, which is not encrypted",
+				ErrInsecureRedirect, previous.URL.Redacted(), req.URL.Redacted())
+		}
+	}
+	return nil
 }
 
 // HashFileSHA256 returns the hex sha256 of a file's content.

--- a/internal/system/files.go
+++ b/internal/system/files.go
@@ -184,14 +184,33 @@ func ValidateDownloadURL(raw string) error {
 //   - a timeout, so a stalled mirror fails the step instead of hanging the
 //     whole run forever. Generous, because font archives run to hundreds of MB
 //     on slow links; it exists to bound a hang, not to race the download.
-var DownloadClient = &http.Client{
-	Timeout: 15 * time.Minute,
-	CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return ValidateDownloadURL(req.URL.String())
-	},
+var DownloadClient = NewHTTPClient(15 * time.Minute)
+
+// NewHTTPClient returns a client that re-validates every redirect hop with
+// ValidateDownloadURL, with a caller-chosen timeout.
+//
+// The redirect policy is the point. Validating only the URL a caller passes in
+// is worthless the moment the server answers with a 302 to plain http: the
+// default client follows it silently, and whatever was protected by TLS is not
+// any more.
+//
+// That matters beyond downloads, which is why this is separate from
+// DownloadClient. Go strips Authorization when a redirect crosses to a
+// different host, but not when it merely drops https for http on the same one -
+// so a bare client following such a hop puts the GitHub token rwr sends to
+// api.github.com on the wire in cleartext. The timeout is a parameter because
+// a font archive and an API call want very different ones; the redirect policy
+// is not, because nothing wants a worse one.
+func NewHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
+			return ValidateDownloadURL(req.URL.String())
+		},
+	}
 }
 
 // HashFileSHA256 returns the hex sha256 of a file's content.

--- a/internal/system/http_redirect_test.go
+++ b/internal/system/http_redirect_test.go
@@ -1,9 +1,11 @@
 package system
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -30,7 +32,7 @@ func TestHTTPClientRefusesADowngradeRedirect(t *testing.T) {
 		_ = resp.Body.Close()
 		t.Fatal("a redirect to plain http was followed")
 	}
-	if !strings.Contains(err.Error(), "refusing to download") {
+	if !errors.Is(err, ErrInsecureRedirect) && !strings.Contains(err.Error(), "refusing to download") {
 		t.Errorf("refused for the wrong reason: %v", err)
 	}
 }
@@ -83,7 +85,7 @@ func TestHTTPClientStopsAfterTenRedirects(t *testing.T) {
 		_ = resp.Body.Close()
 		t.Fatal("an endless redirect chain was followed")
 	}
-	if !strings.Contains(err.Error(), "stopped after 10 redirects") {
+	if !errors.Is(err, ErrTooManyRedirects) {
 		t.Errorf("stopped for the wrong reason: %v", err)
 	}
 }
@@ -97,5 +99,70 @@ func TestDownloadClientKeepsItsTimeout(t *testing.T) {
 	}
 	if DownloadClient.CheckRedirect == nil {
 		t.Error("DownloadClient lost its redirect policy")
+	}
+}
+
+// The loopback exemption in ValidateDownloadURL is about a URL an operator
+// supplies deliberately, so local mirrors keep working. As a redirect target it
+// is a hole: the remote server chooses it, and any local process can bind a
+// loopback port and read what arrives - including the device code rwr posts to
+// exchange for a GitHub token.
+//
+// The handler must never run.
+func TestHTTPClientRefusesADowngradeToLoopback(t *testing.T) {
+	t.Parallel()
+
+	var reached atomic.Bool
+	loopback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Store(true)
+		_, _ = w.Write([]byte("should never be served"))
+	}))
+	defer loopback.Close()
+
+	// httptest binds 127.0.0.1, so this is exactly the case the exemption
+	// would have allowed.
+	origin := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, loopback.URL, http.StatusFound)
+	}))
+	defer origin.Close()
+
+	client := NewHTTPClient(5 * time.Second)
+	client.Transport = origin.Client().Transport
+
+	resp, err := client.Get(origin.URL) //nolint:bodyclose // the request must not succeed
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("an https response redirected to http loopback and was followed")
+	}
+	if !errors.Is(err, ErrInsecureRedirect) {
+		t.Errorf("refused for the wrong reason: %v", err)
+	}
+	if reached.Load() {
+		t.Error("the cleartext loopback handler was reached")
+	}
+}
+
+// A request that starts on http may still redirect within http: the loopback
+// and local-mirror cases have to keep working when TLS was never in play.
+func TestHTTPClientAllowsHTTPToHTTPOnLoopback(t *testing.T) {
+	t.Parallel()
+
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer final.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, final.URL, http.StatusFound)
+	}))
+	defer origin.Close()
+
+	resp, err := NewHTTPClient(5 * time.Second).Get(origin.URL)
+	if err != nil {
+		t.Fatalf("an http-to-http loopback redirect was refused: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
 	}
 }

--- a/internal/system/http_redirect_test.go
+++ b/internal/system/http_redirect_test.go
@@ -1,0 +1,101 @@
+package system
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Every hop is re-validated, not just the URL the caller passed in.
+//
+// Go strips Authorization when a redirect crosses to a different host, but not
+// when it merely drops https for http on the same one. A bare client following
+// such a hop puts whatever the request carried - the GitHub token rwr sends to
+// api.github.com, the device code it exchanges for one - on the wire in
+// cleartext.
+func TestHTTPClientRefusesADowngradeRedirect(t *testing.T) {
+	t.Parallel()
+
+	// Stands in for a host answering 302 to plain http.
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://example.invalid/token", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	client := NewHTTPClient(5 * time.Second)
+	resp, err := client.Get(origin.URL) //nolint:bodyclose // the request must not succeed
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("a redirect to plain http was followed")
+	}
+	if !strings.Contains(err.Error(), "refusing to download") {
+		t.Errorf("refused for the wrong reason: %v", err)
+	}
+}
+
+// A redirect that stays on https is ordinary and must still work, or every
+// GitHub API call that redirects breaks.
+func TestHTTPClientFollowsAnHTTPSRedirect(t *testing.T) {
+	t.Parallel()
+
+	final := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer final.Close()
+
+	origin := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, final.URL, http.StatusFound)
+	}))
+	defer origin.Close()
+
+	client := NewHTTPClient(5 * time.Second)
+	// The test servers use self-signed certs; trust them for this exchange.
+	client.Transport = origin.Client().Transport
+
+	resp, err := client.Get(origin.URL)
+	if err != nil {
+		t.Fatalf("an https redirect was refused: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// The redirect chain is bounded, so a server looping forever fails the step
+// instead of hanging the run.
+func TestHTTPClientStopsAfterTenRedirects(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, server.URL+"/again", http.StatusFound)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(5 * time.Second)
+	client.Transport = server.Client().Transport
+
+	resp, err := client.Get(server.URL) //nolint:bodyclose // the request must not succeed
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("an endless redirect chain was followed")
+	}
+	if !strings.Contains(err.Error(), "stopped after 10 redirects") {
+		t.Errorf("stopped for the wrong reason: %v", err)
+	}
+}
+
+// DownloadClient keeps its own long timeout while sharing the policy.
+func TestDownloadClientKeepsItsTimeout(t *testing.T) {
+	t.Parallel()
+
+	if DownloadClient.Timeout != 15*time.Minute {
+		t.Errorf("DownloadClient timeout = %v, want 15m", DownloadClient.Timeout)
+	}
+	if DownloadClient.CheckRedirect == nil {
+		t.Error("DownloadClient lost its redirect policy")
+	}
+}


### PR DESCRIPTION
`DownloadClient` re-validates each redirect hop, on the reasoning that validating only the URL a caller passes in is worthless the moment the server answers with a 302 to plain http. Four other clients were built by hand with a timeout and nothing else:

| where | what it carries |
|---|---|
| `ssh_key.go` | OAuth device code request |
| `ssh_key.go` | access token exchange |
| `ssh_key.go` | **key upload to api.github.com, with `Authorization: Bearer <token>`** |
| `init_source.go` | the probe that resolves an init source |

## Why the third one matters

Go strips `Authorization` when a redirect crosses to a **different host** - but not when it merely drops https for http on the **same** one. `shouldCopyHeaderOnRedirect` compares hosts, not schemes. So a downgrade hop keeps the header, and the GitHub token rwr sends to `api.github.com` goes out in cleartext.

The access token exchange has the same shape without a header: it posts the device code and receives the token in the response body.

`init_source`'s probe decides where the blueprint tree is fetched from by following the server's answer, which is the same argument in a different place.

## The change

The policy moves into `system.NewHTTPClient(timeout)` and the four callers take it. `DownloadClient` becomes that constructor with its own long timeout - a font archive and an API call want very different timeouts, but nothing wants a worse redirect policy, so that part is not a parameter.

No import cycle: `system` does not import `helpers`, so `helpers` taking `system` is a new edge in the existing direction.

## Verification

Four tests: a downgrade redirect is refused, an ordinary https redirect still works (or every GitHub call that redirects would break), the chain stays bounded at 10, and `DownloadClient` keeps its 15-minute timeout while sharing the policy.

Stripping the `CheckRedirect` block makes `TestHTTPClientRefusesADowngradeRedirect` fail, so the test is anchored to the thing it guards.

`go vet` darwin + windows, `golangci-lint` 0 issues, `go test -race ./...` green, govulncheck and gosec clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and consistency for URL checks, downloads, and GitHub requests.
  * Prevented insecure HTTPS-to-HTTP redirects.
  * Enforced consistent request timeouts and redirect limits.

* **Tests**
  * Added coverage for secure redirects, redirect limits, timeout settings, and download behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->