### PR TITLE
fix(scripts): exec self does not widen the file it runs

### DIFF
--- a/docs/blueprints/scripts.md
+++ b/docs/blueprints/scripts.md
@@ -121,7 +121,7 @@ The Scripts blueprint supports the following fields:
 | `import` | Yes, if `name` is not provided | Path to import script definitions from another file (relative to blueprint directory) |
 | `profiles` | No | List of profiles this script belongs to. If empty, script always runs (base item). |
 | `action` | Yes | The action to perform with the script. Currently, only `run` is supported. |
-| `exec` | No | The program that runs the script: `bash`, `python`, `ruby`, `perl`, `lua`, `powershell`, or `self`. The default is `bash` on Linux and macOS, and `powershell` on Windows. `self` runs the script file directly |
+| `exec` | No | The program that runs the script: `bash`, `python`, `ruby`, `perl`, `lua`, `powershell`, or `self`. The default is `bash` on Linux and macOS, and `powershell` on Windows. `self` runs the script file directly, adding the owner's execute bit if the file does not already have it |
 | `source` | No | The path to the script file (relative to blueprint directory). |
 | `content` | No | The inline content of the script. |
 | `args` | No | Arguments to pass to the script, as a string (split on whitespace) or a list (each element taken verbatim). |

--- a/internal/processors/scripts.go
+++ b/internal/processors/scripts.go
@@ -128,7 +128,13 @@ func runScript(script types.Script, osInfo *types.OSInfo, initConfig *types.Init
 		}
 		defer os.Remove(tempFile.Name()) //nolint:errcheck
 
-		err = os.WriteFile(tempFile.Name(), []byte(script.Content), 0755) // #nosec G306 -- TODO(PR8): create with target mode instead of chmod-after
+		// 0600, which is what CreateTemp already made it. The mode argument
+		// said 0755, which was both wider than anything needed and a lie:
+		// WriteFile does not change the mode of a file that already exists,
+		// so it never took effect. An inline script is blueprint content and
+		// can carry whatever a template interpolated into it, so it has no
+		// business being readable by other users of a shared temp directory.
+		err = os.WriteFile(tempFile.Name(), []byte(script.Content), 0o600)
 		if err != nil {
 			return fmt.Errorf("error writing script content to temporary file: %v", err)
 		}
@@ -142,10 +148,8 @@ func runScript(script types.Script, osInfo *types.OSInfo, initConfig *types.Init
 	switch script.Exec {
 	case "self":
 		log.Debugf("Using 'self' executor for script: %s", script.Name)
-		// Make the script executable
-		err := os.Chmod(scriptPath, 0755) // #nosec G302 -- TODO(PR8): create with target mode instead of chmod-after
-		if err != nil {
-			return fmt.Errorf("error setting script as executable: %v", err)
+		if err := makeOwnerExecutable(scriptPath); err != nil {
+			return fmt.Errorf("error setting script as executable: %w", err)
 		}
 		scriptCmd = types.Command{
 			Exec: scriptPath,
@@ -262,4 +266,34 @@ func processScriptImports(items []types.Script, blueprintDir string, format stri
 			}
 			return d.Scripts, nil
 		}, format)
+}
+
+// makeOwnerExecutable adds the owner's execute bit and changes nothing else.
+//
+// `exec: self` runs the script file directly, so it has to be executable. It
+// used to get that with a flat chmod 0755, which is wrong twice over.
+//
+// With `source:`, scriptPath is a file inside the operator's blueprint tree.
+// Forcing 0755 widened a file they may have deliberately restricted - 0600
+// became world-readable and world-executable - and left a permission change
+// sitting in their checkout as a spurious diff. rwr is applying a blueprint,
+// not reformatting the tree it came from.
+//
+// With `content:`, it is a staging file in a shared temp directory holding
+// whatever a template interpolated into the script, which can include a
+// credential the operator exposed.
+//
+// rwr runs the script as the user it is already running as, so the owner bit
+// is the only one it needs.
+func makeOwnerExecutable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	mode := info.Mode().Perm()
+	if mode&0o100 != 0 {
+		return nil
+	}
+	return os.Chmod(path, mode|0o100)
 }

--- a/internal/processors/scripts.go
+++ b/internal/processors/scripts.go
@@ -291,9 +291,26 @@ func makeOwnerExecutable(path string) error {
 		return err
 	}
 
-	mode := info.Mode().Perm()
-	if mode&0o100 != 0 {
+	mode := info.Mode()
+	if mode.Perm()&ownerExecute != 0 {
 		return nil
 	}
-	return os.Chmod(path, mode|0o100)
+	return os.Chmod(path, executableMode(mode))
+}
+
+// ownerExecute is the only bit rwr adds: it runs the script as the user it is
+// already running as.
+const ownerExecute = 0o100
+
+// executableMode is mode with the owner's execute bit added and everything
+// else preserved.
+//
+// The special bits have to be carried across explicitly. os.FileMode.Perm()
+// returns the nine permission bits only, so chmodding to Perm()|0o100 would
+// silently clear setuid, setgid and sticky from a script that had them - rwr
+// would be stripping a property of the operator's file as a side effect of
+// making it runnable, which is the same class of unasked-for change as the
+// flat 0755 this replaced.
+func executableMode(mode os.FileMode) os.FileMode {
+	return mode&(os.ModePerm|os.ModeSetuid|os.ModeSetgid|os.ModeSticky) | ownerExecute
 }

--- a/internal/processors/scripts_argv_test.go
+++ b/internal/processors/scripts_argv_test.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/fynxlabs/rwr/internal/exectest"
@@ -396,5 +397,122 @@ scripts: [{name: "setup.sh", action: "run", source: ".", exec: "bash", args: 42}
 				t.Fatal("a non-string args value was accepted")
 			}
 		})
+	}
+}
+
+// `exec: self` runs the script file directly, so it has to be executable -
+// but with `source:` that file lives in the operator's blueprint tree.
+//
+// A flat chmod 0755 widened a file they may have deliberately restricted,
+// turning 0600 into world-readable and world-executable, and left a permission
+// change in their checkout as a spurious diff. rwr is applying a blueprint,
+// not reformatting the tree it came from.
+func TestProcessScripts_SelfExecDoesNotWidenTheBlueprintTree(t *testing.T) {
+	if runtime.GOOS == types.OSWindows {
+		t.Skip("unix permission bits")
+	}
+
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "setup.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho hi\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	blueprint := []byte(`
+scripts:
+  - name: "setup.sh"
+    action: "run"
+    source: "."
+    exec: "self"
+`)
+	if err := ProcessScripts(blueprint, dir, "yaml", scriptOSInfo(), &types.InitConfig{}); err != nil {
+		t.Fatalf("ProcessScripts: %v", err)
+	}
+
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := info.Mode().Perm()
+
+	// Executable by its owner, and nothing else gained a thing.
+	if got&0o100 == 0 {
+		t.Errorf("mode = %04o, want the owner execute bit set", got)
+	}
+	if got&0o077 != 0 {
+		t.Errorf("mode = %04o, want no group or other bits on a file that started 0600", got)
+	}
+	if got != 0o700 {
+		t.Errorf("mode = %04o, want 0700", got)
+	}
+}
+
+// A file that is already executable is left entirely alone.
+func TestProcessScripts_SelfExecLeavesAnExecutableFileAlone(t *testing.T) {
+	if runtime.GOOS == types.OSWindows {
+		t.Skip("unix permission bits")
+	}
+
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "setup.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	blueprint := []byte(`
+scripts:
+  - name: "setup.sh"
+    action: "run"
+    source: "."
+    exec: "self"
+`)
+	if err := ProcessScripts(blueprint, dir, "yaml", scriptOSInfo(), &types.InitConfig{}); err != nil {
+		t.Fatalf("ProcessScripts: %v", err)
+	}
+
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Errorf("mode = %04o, want 0755 untouched", got)
+	}
+}
+
+// An inline script is staged in a shared temp directory and can carry whatever
+// a template interpolated into it, so it must not be readable by other users.
+func TestProcessScripts_InlineContentIsNotWorldReadable(t *testing.T) {
+	if runtime.GOOS == types.OSWindows {
+		t.Skip("unix permission bits")
+	}
+
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+
+	blueprint := []byte(`
+scripts:
+  - name: "inline"
+    action: "run"
+    exec: "self"
+    content: "#!/bin/sh\necho hi\n"
+`)
+	if err := ProcessScripts(blueprint, t.TempDir(), "yaml", scriptOSInfo(), &types.InitConfig{}); err != nil {
+		t.Fatalf("ProcessScripts: %v", err)
+	}
+
+	if len(rec.Calls) != 1 {
+		t.Fatalf("recorded %d calls, want 1", len(rec.Calls))
+	}
+	// The staging file is removed when runScript returns, so the recorded
+	// path is checked while it is the command's Exec.
+	staged := rec.Calls[0].Exec
+	if staged == "" {
+		t.Fatal("no staged script path recorded")
 	}
 }

--- a/internal/processors/scripts_argv_test.go
+++ b/internal/processors/scripts_argv_test.go
@@ -485,15 +485,35 @@ scripts:
 	}
 }
 
+// statOnRun records the mode of the command's Exec while the command is being
+// handled. The staging file is removed as soon as runScript returns, so it can
+// only be inspected from inside the executor.
+type statOnRun struct {
+	mode os.FileMode
+	seen bool
+}
+
+func (s *statOnRun) Run(cmd types.Command, _ bool) error {
+	if info, err := os.Stat(cmd.Exec); err == nil {
+		s.mode, s.seen = info.Mode().Perm(), true
+	}
+	return nil
+}
+
+func (s *statOnRun) Output(cmd types.Command, debug bool) (string, error) {
+	return "", s.Run(cmd, debug)
+}
+
 // An inline script is staged in a shared temp directory and can carry whatever
-// a template interpolated into it, so it must not be readable by other users.
-func TestProcessScripts_InlineContentIsNotWorldReadable(t *testing.T) {
+// a template interpolated into it, including a credential the operator exposed
+// to blueprints. Nobody else on the machine has any business reading it.
+func TestProcessScripts_InlineContentIsNotReadableByOthers(t *testing.T) {
 	if runtime.GOOS == types.OSWindows {
 		t.Skip("unix permission bits")
 	}
 
-	rec := exectest.New()
-	defer system.SetExecutor(rec)()
+	stat := &statOnRun{}
+	defer system.SetExecutor(stat)()
 
 	blueprint := []byte(`
 scripts:
@@ -506,13 +526,64 @@ scripts:
 		t.Fatalf("ProcessScripts: %v", err)
 	}
 
-	if len(rec.Calls) != 1 {
-		t.Fatalf("recorded %d calls, want 1", len(rec.Calls))
+	if !stat.seen {
+		t.Fatal("the staging file was never stat'd; the test proves nothing")
 	}
-	// The staging file is removed when runScript returns, so the recorded
-	// path is checked while it is the command's Exec.
-	staged := rec.Calls[0].Exec
-	if staged == "" {
-		t.Fatal("no staged script path recorded")
+	if stat.mode&0o077 != 0 {
+		t.Errorf("staged script mode = %04o, want no group or other bits", stat.mode)
+	}
+	if stat.mode&0o100 == 0 {
+		t.Errorf("staged script mode = %04o, want it executable by its owner", stat.mode)
+	}
+}
+
+// Adding the execute bit must not take anything away.
+//
+// os.FileMode.Perm() returns the nine permission bits only, so chmodding to
+// Perm()|0o100 silently clears setuid, setgid and sticky - rwr would strip a
+// property of the operator's file as a side effect of making it runnable,
+// which is the same class of unasked-for change as the flat 0755 this
+// replaced. Asserted on the mode arithmetic rather than through the
+// filesystem, because a test cannot rely on the OS honouring setgid on a
+// scratch file.
+func TestExecutableMode_PreservesEverythingElse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   os.FileMode
+		want os.FileMode
+	}{
+		{name: "owner only", in: 0o600, want: 0o700},
+		{name: "group readable", in: 0o640, want: 0o740},
+		{name: "world readable", in: 0o644, want: 0o744},
+		{name: "already executable", in: 0o755, want: 0o755},
+		{name: "setgid is kept", in: 0o600 | os.ModeSetgid, want: 0o700 | os.ModeSetgid},
+		{name: "setuid is kept", in: 0o600 | os.ModeSetuid, want: 0o700 | os.ModeSetuid},
+		{name: "sticky is kept", in: 0o600 | os.ModeSticky, want: 0o700 | os.ModeSticky},
+		{
+			name: "all three are kept",
+			in:   0o640 | os.ModeSetuid | os.ModeSetgid | os.ModeSticky,
+			want: 0o740 | os.ModeSetuid | os.ModeSetgid | os.ModeSticky,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := executableMode(tt.in); got != tt.want {
+				t.Errorf("executableMode(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// The type bits of a mode are not permissions and must not survive into a
+// chmod argument.
+func TestExecutableMode_DropsTypeBits(t *testing.T) {
+	t.Parallel()
+
+	if got := executableMode(os.ModeDir | 0o600); got&os.ModeDir != 0 {
+		t.Errorf("executableMode kept a type bit: %v", got)
 	}
 }

--- a/internal/processors/scripts_argv_test.go
+++ b/internal/processors/scripts_argv_test.go
@@ -554,6 +554,9 @@ func TestExecutableMode_PreservesEverythingElse(t *testing.T) {
 		in   os.FileMode
 		want os.FileMode
 	}{
+		// The floor: a file nobody can do anything with still only gains the
+		// one bit rwr needs to run it.
+		{name: "no permissions at all", in: 0o000, want: 0o100},
 		{name: "owner only", in: 0o600, want: 0o700},
 		{name: "group readable", in: 0o640, want: 0o740},
 		{name: "world readable", in: 0o644, want: 0o744},


### PR DESCRIPTION
Found while auditing the `TODO(PR8)` suppressions. Two of them were hiding a real bug.

## `exec: self` chmods the operator's blueprint tree to 0755

`exec: self` runs the script file directly, so it has to be executable, and it got there with a flat `chmod 0755`.

With `source:`, that path is a file **inside the operator's blueprint tree**. Verified against a real run:

```
before: 0600
after:  0755  <- the operator's blueprint file
```

So a script the operator deliberately restricted comes back world-readable and world-executable, and the permission change sits in their git checkout as a spurious diff. rwr is applying a blueprint, not reformatting the tree it came from.

With `content:`, the path is a staging file in a shared temp directory holding whatever a template interpolated into the script - which can include a credential the operator exposed to blueprints.

## The fix

Only the owner's execute bit is added, and only when missing. rwr runs the script as the user it is already running as, so that is the whole of what it needs:

| before | after |
|---|---|
| 0600 | 0700 |
| 0644 | 0744 |
| 0755 | untouched |

The staging write also claimed `0755` and never applied it - `WriteFile` does not change the mode of a file that already exists, so it kept the 0600 `CreateTemp` gave it. The argument now says 0600, which is both what happens and what is wanted.

## Verification

Three tests. Against the old flat chmod:

```
--- FAIL: TestProcessScripts_SelfExecDoesNotWidenTheBlueprintTree
    mode = 0755, want no group or other bits on a file that started 0600
    mode = 0755, want 0700
```

`go vet` darwin + windows, `golangci-lint` 0 issues, `go test -race ./...` green, govulncheck and gosec clean. Docs updated, since this changes observable behaviour of `exec: self`.

## Scope

Both sites were marked `TODO(PR8)` - a PR that exists in neither openspec, the archive, nor the history. The other 42 PR8 markers are a separate problem; these two were real bugs rather than deferred hardening, so they are fixed here rather than re-labelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved script file permissions to reduce unintended access.
  - Inline scripts are created without permissions that allow access by others.
  - Self-executed scripts gain only the owner execute permission when required, preserving existing permissions.

- **Documentation**
  - Clarified that self-execution may add the owner’s execute permission to a script file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->