### PR TITLE
fix(system): never ask for sudo on rwr's own account

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -340,11 +340,18 @@ That distinction matters because of where the password prompt goes. RWR
 captures a command's output through pipes, but sudo reads its password from
 `/dev/tty` instead - so a prompt from a provider RWR did not know would
 escalate is invisible under the dashboard, and the run hangs on a password
-nobody was asked for. Declaring `escalates` makes RWR warm sudo's credential
-cache first, through a proper terminal handover, so the install never prompts.
+nobody was asked for.
 
-Only set it on providers you have actually seen escalate. Setting it on one
-that does not will ask for a password on runs that never need root.
+RWR never asks for a password on its own account. Declaring `escalates` only
+changes what happens when sudo is **not** already cached: that command is given
+the real terminal, so if the work itself turns out to need a password the
+prompt is visible and answerable. When sudo is already cached, nothing changes
+and nothing prompts.
+
+That matters because RWR cannot predict which command will need root. Homebrew
+decides cask or formula on its own and the provider declares one install verb
+for both, so a formula install - which never touches root - is
+indistinguishable up front. Asking in advance would ask on every package.
 
 ## Best Practices
 

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -7,6 +7,7 @@ package system
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -145,10 +146,21 @@ func mayPromptForSudo(cmd types.Command) bool {
 // turn the probe back into the thing this replaced.
 var sudoProbeArgs = []string{"sudo", "-n", "-v"}
 
+// sudoProbeTimeout bounds the probe.
+//
+// -n means sudo will not prompt, but that is not the same as sudo returning.
+// A policy lookup can block underneath it - PAM against a directory server,
+// NSS resolving a group over the network - and the probe holds
+// sudoValidateMu while it runs, so a stall there is not one slow command but
+// every command after it, waiting on a mutex that is never released.
+const sudoProbeTimeout = 10 * time.Second
+
 // sudoProbe runs the probe. A var so a test can substitute one that does not
 // depend on the host's sudo policy or credential state.
 var sudoProbe = func() error {
-	return exec.Command(sudoProbeArgs[0], sudoProbeArgs[1:]...).Run() // #nosec G204 -- fixed argv, not input
+	ctx, cancel := context.WithTimeout(context.Background(), sudoProbeTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, sudoProbeArgs[0], sudoProbeArgs[1:]...).Run() // #nosec G204 -- fixed argv, not input
 }
 
 // SetSudoProbeForTest substitutes the probe and returns the restore func.

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -21,7 +21,6 @@ import (
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/types"
-	"golang.org/x/term"
 )
 
 // buildCommand creates an *exec.Cmd from the given types.Command.
@@ -122,40 +121,37 @@ var (
 // Elevated is false and validation never ran, and then a cask install shelled
 // out to sudo, prompted on /dev/tty behind the dashboard, and hung the run
 // with no visible prompt.
-func wantsSudoCredentials(cmd types.Command) bool {
+func mayPromptForSudo(cmd types.Command) bool {
 	if runtime.GOOS == "windows" {
 		return false
 	}
 	return cmd.Elevated || cmd.AsUser != "" || cmd.Escalates
 }
 
-func ensureSudoCredentials() {
+// sudoCredentialsCached reports whether sudo would run without asking.
+//
+// It never prompts, and that is the whole point. rwr used to run `sudo -v`
+// itself before any command that might escalate, which meant asking for a
+// password on its own account - and since brew decides cask or formula on its
+// own, and the provider has one install verb for both, "might" was every
+// package. A run of ordinary formulae queued a password prompt a minute for a
+// privilege it never used.
+//
+// `-n` makes sudo answer from the credential cache or fail, without a prompt.
+// The throttle is on the probe rather than on the asking: spawning sudo per
+// package is wasteful and the answer does not change second to second.
+func sudoCredentialsCached() bool {
 	sudoValidateMu.Lock()
 	defer sudoValidateMu.Unlock()
 
 	if time.Since(sudoValidatedAt) < time.Minute {
-		return
+		return true
 	}
-
-	// Cheap probe: -n never prompts, it just reports whether the cache holds.
-	probe := exec.Command("sudo", "-n", "-v")
-	if err := probe.Run(); err == nil {
-		sudoValidatedAt = time.Now()
-		return
-	}
-
-	// No terminal, no prompt: leave it to the command (CI runs are
-	// NOPASSWD or root, where sudo never needed a tty in the first place).
-	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return
-	}
-
-	// Cache expired: ask for the password on the real terminal.
-	if err := runOnTerminal(exec.Command("sudo", "-v")); err != nil {
-		log.Debugf("sudo validation inconclusive (%v); running the command anyway", err)
-		return
+	if err := exec.Command("sudo", "-n", "-v").Run(); err != nil {
+		return false
 	}
 	sudoValidatedAt = time.Now()
+	return true
 }
 
 // runOnTerminal hands cmd the real terminal via the display layer, falling
@@ -254,23 +250,30 @@ func runCommand(cmd types.Command, debug bool) error {
 		return nil
 	}
 
-	// A captured elevated command can still make sudo prompt: sudo reads the
-	// password from /dev/tty, straight past the captured pipes - under the
-	// TUI the prompt and the dashboard then fight over the terminal and the
-	// dashboard eats half the password. Validate credentials first, through
-	// a proper terminal handover when the cache has expired. Advisory only:
-	// a failed validation must not fail the command - `sudo -v` is not
-	// command-scoped, so a NOPASSWD rule for just this command makes
-	// validation want a password the command itself never needs.
-	// Escalates covers the case this guard used to miss entirely: a command
-	// rwr runs unprivileged that calls sudo itself. brew is the example - it
-	// refuses to run as root, so Elevated is false and validation never ran,
-	// and then a cask install shelled out to sudo, prompted on /dev/tty behind
-	// the dashboard, and hung the run with no visible prompt. Earlier casks in
-	// the same run succeeded only because the credential cache was still warm
-	// from something else.
-	if wantsSudoCredentials(cmd) {
-		ensureSudoCredentials()
+	// A captured command that reaches sudo prompts on /dev/tty, straight past
+	// the pipes rwr captured, so under the dashboard the prompt is invisible
+	// and the run hangs on a password nobody was asked for. That is what hung
+	// a cask install.
+	//
+	// Asking first was the wrong answer to it. rwr cannot tell which brew
+	// command will need root - brew decides cask or formula itself, and the
+	// provider declares one install verb for both - so asking up front asked
+	// on every package, and a formula never needs it.
+	if mayPromptForSudo(cmd) && !sudoCredentialsCached() {
+		// Nothing here asks for a password. If sudo is already cached the
+		// command runs captured as usual and never prompts. If it is not, this
+		// one command gets the terminal, so that if the work itself turns out
+		// to need a password the prompt is visible and answerable - and the
+		// credential it establishes covers the rest of the run.
+		log.Debugf("sudo not cached; running %s on the terminal so any prompt it makes is visible", cmd.Exec)
+		if err := runOnTerminal(command); err != nil {
+			if Cancelled() {
+				return ErrCancelled
+			}
+			log.Errorf("Error running command: %v (stderr above)", err)
+			return err
+		}
+		return nil
 	}
 	{
 		// Under the TUI, captured stderr streams into the log view (the `≫`

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -140,6 +140,32 @@ func mayPromptForSudo(cmd types.Command) bool {
 // `-n` makes sudo answer from the credential cache or fail, without a prompt.
 // The throttle is on the probe rather than on the asking: spawning sudo per
 // package is wasteful and the answer does not change second to second.
+// sudoProbeArgs is the probe rwr runs. -n is the whole contract: it makes sudo
+// answer from the credential cache or fail, and never prompt. Losing it would
+// turn the probe back into the thing this replaced.
+var sudoProbeArgs = []string{"sudo", "-n", "-v"}
+
+// sudoProbe runs the probe. A var so a test can substitute one that does not
+// depend on the host's sudo policy or credential state.
+var sudoProbe = func() error {
+	return exec.Command(sudoProbeArgs[0], sudoProbeArgs[1:]...).Run() // #nosec G204 -- fixed argv, not input
+}
+
+// SetSudoProbeForTest substitutes the probe and returns the restore func.
+func SetSudoProbeForTest(probe func() error) (restore func()) {
+	previous := sudoProbe
+	sudoProbe = probe
+	return func() { sudoProbe = previous }
+}
+
+// resetSudoThrottleForTest clears the probe throttle so a test observes the
+// probe rather than a cached answer from an earlier one.
+func resetSudoThrottleForTest() {
+	sudoValidateMu.Lock()
+	defer sudoValidateMu.Unlock()
+	sudoValidatedAt = time.Time{}
+}
+
 func sudoCredentialsCached() bool {
 	sudoValidateMu.Lock()
 	defer sudoValidateMu.Unlock()
@@ -147,7 +173,7 @@ func sudoCredentialsCached() bool {
 	if time.Since(sudoValidatedAt) < time.Minute {
 		return true
 	}
-	if err := exec.Command("sudo", "-n", "-v").Run(); err != nil {
+	if err := sudoProbe(); err != nil {
 		return false
 	}
 	sudoValidatedAt = time.Now()

--- a/internal/system/sudo_escalation_test.go
+++ b/internal/system/sudo_escalation_test.go
@@ -1,9 +1,10 @@
 package system
 
 import (
+	"errors"
 	"runtime"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/fynxlabs/rwr/internal/types"
 )
@@ -60,23 +61,79 @@ func TestSudoTerminalHandoverCoversCommandsThatEscalateThemselves(t *testing.T) 
 
 // rwr must never ask for a password on its own account.
 //
-// It used to run `sudo -v` before any command that might escalate, which meant
-// a prompt per minute through a run of ordinary formulae that never touch
-// root. The probe replacing it uses -n, which answers from the cache or fails
-// and never prompts.
-func TestSudoProbeNeverPrompts(t *testing.T) {
-	if runtime.GOOS == types.OSWindows {
-		t.Skip("no sudo on windows")
+// -n is the whole contract: it makes sudo answer from the credential cache or
+// fail, and never prompt. Asserting only that the probe returns quickly does
+// not pin that - on a host that cannot prompt at all, a bare `sudo -v` also
+// returns immediately, so such a test passes with -n removed.
+func TestSudoProbeIsNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	if got := strings.Join(sudoProbeArgs, " "); got != "sudo -n -v" {
+		t.Fatalf("probe = %q, want exactly \"sudo -n -v\"", got)
 	}
+}
 
-	// Whatever the machine's cache state, the probe has to return promptly
-	// rather than sit on a password prompt.
-	done := make(chan bool, 1)
-	go func() { done <- sudoCredentialsCached() }()
+// A cold cache is reported as cold, and does not prompt on the way there.
+func TestSudoCredentialsCachedWhenTheProbeFails(t *testing.T) {
+	defer SetSudoProbeForTest(func() error { return errors.New("a password is required") })()
+	resetSudoThrottleForTest()
+	defer resetSudoThrottleForTest()
 
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		t.Fatal("the sudo probe blocked; it must never prompt")
+	if sudoCredentialsCached() {
+		t.Error("a failing probe was read as a warm cache")
+	}
+}
+
+// A warm cache is reported as warm, so the command runs captured and the
+// dashboard is not torn down for nothing.
+func TestSudoCredentialsCachedWhenTheProbeSucceeds(t *testing.T) {
+	defer SetSudoProbeForTest(func() error { return nil })()
+	resetSudoThrottleForTest()
+	defer resetSudoThrottleForTest()
+
+	if !sudoCredentialsCached() {
+		t.Error("a succeeding probe was read as a cold cache")
+	}
+}
+
+// The probe is throttled, so a run of a hundred packages does not spawn a
+// hundred sudo processes to ask a question whose answer does not change second
+// to second.
+func TestSudoProbeIsThrottled(t *testing.T) {
+	var calls int
+	defer SetSudoProbeForTest(func() error {
+		calls++
+		return nil
+	})()
+	resetSudoThrottleForTest()
+	defer resetSudoThrottleForTest()
+
+	for range 10 {
+		sudoCredentialsCached()
+	}
+	if calls != 1 {
+		t.Errorf("probe ran %d times for 10 commands, want 1", calls)
+	}
+}
+
+// A cold cache is not throttled into looking warm: the answer has to be
+// re-asked until it changes, or the first cold command would be the only one
+// ever given the terminal.
+func TestSudoProbeRetriesWhileCold(t *testing.T) {
+	var calls int
+	defer SetSudoProbeForTest(func() error {
+		calls++
+		return errors.New("a password is required")
+	})()
+	resetSudoThrottleForTest()
+	defer resetSudoThrottleForTest()
+
+	for range 3 {
+		if sudoCredentialsCached() {
+			t.Fatal("a failing probe was read as a warm cache")
+		}
+	}
+	if calls != 3 {
+		t.Errorf("probe ran %d times, want one per call while the cache is cold", calls)
 	}
 }

--- a/internal/system/sudo_escalation_test.go
+++ b/internal/system/sudo_escalation_test.go
@@ -3,15 +3,16 @@ package system
 import (
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/fynxlabs/rwr/internal/types"
 )
 
-// The guard decides whether sudo's credential cache is warmed before a command
-// runs. Getting it wrong is not a cosmetic failure: an un-warmed command that
-// calls sudo internally prompts on /dev/tty, behind the dashboard, and the run
-// hangs with no visible prompt.
-func TestSudoValidationCoversCommandsThatEscalateThemselves(t *testing.T) {
+// The guard decides which commands get the terminal when sudo is not already
+// cached, so that a password prompt the work itself makes is visible rather
+// than hidden behind the dashboard. It never causes rwr to ask on its own
+// account.
+func TestSudoTerminalHandoverCoversCommandsThatEscalateThemselves(t *testing.T) {
 	t.Parallel()
 
 	if runtime.GOOS == types.OSWindows {
@@ -50,9 +51,32 @@ func TestSudoValidationCoversCommandsThatEscalateThemselves(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := wantsSudoCredentials(tt.cmd); got != tt.want {
-				t.Errorf("wantsSudoCredentials = %v, want %v", got, tt.want)
+			if got := mayPromptForSudo(tt.cmd); got != tt.want {
+				t.Errorf("mayPromptForSudo = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// rwr must never ask for a password on its own account.
+//
+// It used to run `sudo -v` before any command that might escalate, which meant
+// a prompt per minute through a run of ordinary formulae that never touch
+// root. The probe replacing it uses -n, which answers from the cache or fails
+// and never prompts.
+func TestSudoProbeNeverPrompts(t *testing.T) {
+	if runtime.GOOS == types.OSWindows {
+		t.Skip("no sudo on windows")
+	}
+
+	// Whatever the machine's cache state, the probe has to return promptly
+	// rather than sit on a password prompt.
+	done := make(chan bool, 1)
+	go func() { done <- sudoCredentialsCached() }()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the sudo probe blocked; it must never prompt")
 	}
 }

--- a/internal/system/sudo_escalation_test.go
+++ b/internal/system/sudo_escalation_test.go
@@ -1,10 +1,12 @@
 package system
 
 import (
+	"context"
 	"errors"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fynxlabs/rwr/internal/types"
 )
@@ -135,5 +137,58 @@ func TestSudoProbeRetriesWhileCold(t *testing.T) {
 	}
 	if calls != 3 {
 		t.Errorf("probe ran %d times, want one per call while the cache is cold", calls)
+	}
+}
+
+// A probe that never returns must not take the run with it.
+//
+// -n means sudo will not prompt, but that is not the same as sudo returning:
+// a policy lookup can block underneath it, and the probe holds
+// sudoValidateMu while it runs. Unbounded, a stall there is not one slow
+// command but every command after it, waiting on a mutex nobody releases.
+func TestSudoProbeIsBounded(t *testing.T) {
+	t.Parallel()
+
+	if sudoProbeTimeout <= 0 {
+		t.Fatal("the sudo probe has no deadline")
+	}
+	if sudoProbeTimeout > 30*time.Second {
+		t.Errorf("sudoProbeTimeout = %v, too long to hold every later command behind", sudoProbeTimeout)
+	}
+}
+
+// A probe that timed out is a cold cache, not a warm one. Reading a deadline
+// as success would send the command down the captured path, straight back to
+// the invisible prompt this all exists to avoid.
+func TestSudoTimeoutReadsAsColdCache(t *testing.T) {
+	defer SetSudoProbeForTest(func() error { return context.DeadlineExceeded })()
+	resetSudoThrottleForTest()
+	defer resetSudoThrottleForTest()
+
+	if sudoCredentialsCached() {
+		t.Error("a timed-out probe was read as a warm cache")
+	}
+}
+
+// The lock is not held past the probe: a slow one delays its own caller and
+// nobody else's next attempt.
+func TestSudoProbeDoesNotHoldTheLockAfterReturning(t *testing.T) {
+	defer SetSudoProbeForTest(func() error { return nil })()
+	resetSudoThrottleForTest()
+	defer resetSudoThrottleForTest()
+
+	sudoCredentialsCached()
+
+	done := make(chan struct{})
+	go func() {
+		resetSudoThrottleForTest()
+		sudoCredentialsCached()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sudoValidateMu was still held after the probe returned")
 	}
 }


### PR DESCRIPTION
Fixes the regression #270 introduced: rwr asking for a password constantly.


## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sudo escalation behavior by avoiding unnecessary credential prompts.
  * Commands that require elevated permissions now receive the terminal when needed, making required prompts visible without preemptive prompting.
  * Cached sudo credentials continue to work as before.
  * Added safeguards to prevent credential checks from blocking indefinitely.

* **Documentation**
  * Clarified that escalation requirements may not always be predictable before a command runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sudo escalation to avoid unnecessary prompts before commands run.
  * Commands requiring elevated permissions now display prompts directly in the terminal when credentials are not cached.
  * Preserved cached sudo behavior while improving credential checks, retries, cancellation handling, and responsiveness.
  * Added safeguards to prevent repeated checks and ensure timed-out checks are handled correctly.

* **Documentation**
  * Updated escalation guidance to explain that sudo requirements may not always be predictable in advance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->