### PR TITLE
fix(system): bound sudo probe work per run

### DIFF
--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -98,25 +98,18 @@ func setupCommandEnvironment(command *exec.Cmd, cmd types.Command) {
 	command.Env = env
 }
 
-// sudoValidatedAt throttles credential validation: sudo's cache lives for
-// minutes, so re-checking before every one of hundreds of elevated commands
-// would be pure overhead.
+// The latest probe result is cached briefly whether it was warm or cold. A
+// failed policy lookup is no more likely to change between adjacent packages
+// than a successful one, and retrying a ten-second timeout for every package
+// turns the bound into an unbounded run-level delay. A cached cold result still
+// sends every potentially escalating command to the terminal, so a password
+// prompt made by the command itself remains visible.
 var (
-	sudoValidateMu  sync.Mutex
-	sudoValidatedAt time.Time
+	sudoValidateMu sync.Mutex
+	sudoProbedAt   time.Time
+	sudoProbeWarm  bool
 )
 
-// ensureSudoCredentials tries to make sure sudo can run without prompting.
-// When the cached credentials have expired and a real terminal exists, the
-// password prompt runs as its own terminal handover (`sudo -v`), so under
-// the TUI the dashboard suspends cleanly instead of painting over the
-// prompt. Best effort by design: without a tty (CI), or when validation
-// fails (a command-scoped NOPASSWD rule makes `sudo -v` itself want a
-// password), the command proceeds and fails or succeeds on its own terms,
-// exactly as it did before validation existed.
-// wantsSudoCredentials reports whether a command should have sudo's credential
-// cache warmed before it runs.
-//
 // Escalates is the case the elevation flags alone miss: a command rwr runs
 // unprivileged that calls sudo itself. brew refuses to run as root, so
 // Elevated is false and validation never ran, and then a cask install shelled
@@ -138,9 +131,6 @@ func mayPromptForSudo(cmd types.Command) bool {
 // package. A run of ordinary formulae queued a password prompt a minute for a
 // privilege it never used.
 //
-// `-n` makes sudo answer from the credential cache or fail, without a prompt.
-// The throttle is on the probe rather than on the asking: spawning sudo per
-// package is wasteful and the answer does not change second to second.
 // sudoProbeArgs is the probe rwr runs. -n is the whole contract: it makes sudo
 // answer from the credential cache or fail, and never prompt. Losing it would
 // turn the probe back into the thing this replaced.
@@ -155,16 +145,16 @@ var sudoProbeArgs = []string{"sudo", "-n", "-v"}
 // every command after it, waiting on a mutex that is never released.
 const sudoProbeTimeout = 10 * time.Second
 
-// sudoProbe runs the probe. A var so a test can substitute one that does not
-// depend on the host's sudo policy or credential state.
-var sudoProbe = func() error {
-	ctx, cancel := context.WithTimeout(context.Background(), sudoProbeTimeout)
-	defer cancel()
+// sudoProbe runs the probe. Its context is rooted in the run context so ctrl-c
+// interrupts a blocked PAM/NSS lookup immediately instead of waiting for the
+// probe deadline. A var lets tests substitute a probe without touching the
+// host's sudo policy or credential state.
+var sudoProbe = func(ctx context.Context) error {
 	return exec.CommandContext(ctx, sudoProbeArgs[0], sudoProbeArgs[1:]...).Run() // #nosec G204 -- fixed argv, not input
 }
 
 // SetSudoProbeForTest substitutes the probe and returns the restore func.
-func SetSudoProbeForTest(probe func() error) (restore func()) {
+func SetSudoProbeForTest(probe func(context.Context) error) (restore func()) {
 	previous := sudoProbe
 	sudoProbe = probe
 	return func() { sudoProbe = previous }
@@ -175,21 +165,23 @@ func SetSudoProbeForTest(probe func() error) (restore func()) {
 func resetSudoThrottleForTest() {
 	sudoValidateMu.Lock()
 	defer sudoValidateMu.Unlock()
-	sudoValidatedAt = time.Time{}
+	sudoProbedAt = time.Time{}
+	sudoProbeWarm = false
 }
 
 func sudoCredentialsCached() bool {
 	sudoValidateMu.Lock()
 	defer sudoValidateMu.Unlock()
 
-	if time.Since(sudoValidatedAt) < time.Minute {
-		return true
+	if time.Since(sudoProbedAt) < time.Minute {
+		return sudoProbeWarm
 	}
-	if err := sudoProbe(); err != nil {
-		return false
-	}
-	sudoValidatedAt = time.Now()
-	return true
+
+	ctx, cancel := context.WithTimeout(RunContext(), sudoProbeTimeout)
+	defer cancel()
+	sudoProbeWarm = sudoProbe(ctx) == nil
+	sudoProbedAt = time.Now()
+	return sudoProbeWarm
 }
 
 // runOnTerminal hands cmd the real terminal via the display layer, falling

--- a/internal/system/sudo_escalation_test.go
+++ b/internal/system/sudo_escalation_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/types"
 )
 
@@ -77,7 +78,7 @@ func TestSudoProbeIsNonInteractive(t *testing.T) {
 
 // A cold cache is reported as cold, and does not prompt on the way there.
 func TestSudoCredentialsCachedWhenTheProbeFails(t *testing.T) {
-	defer SetSudoProbeForTest(func() error { return errors.New("a password is required") })()
+	defer SetSudoProbeForTest(func(context.Context) error { return errors.New("a password is required") })()
 	resetSudoThrottleForTest()
 	defer resetSudoThrottleForTest()
 
@@ -89,7 +90,7 @@ func TestSudoCredentialsCachedWhenTheProbeFails(t *testing.T) {
 // A warm cache is reported as warm, so the command runs captured and the
 // dashboard is not torn down for nothing.
 func TestSudoCredentialsCachedWhenTheProbeSucceeds(t *testing.T) {
-	defer SetSudoProbeForTest(func() error { return nil })()
+	defer SetSudoProbeForTest(func(context.Context) error { return nil })()
 	resetSudoThrottleForTest()
 	defer resetSudoThrottleForTest()
 
@@ -103,7 +104,7 @@ func TestSudoCredentialsCachedWhenTheProbeSucceeds(t *testing.T) {
 // to second.
 func TestSudoProbeIsThrottled(t *testing.T) {
 	var calls int
-	defer SetSudoProbeForTest(func() error {
+	defer SetSudoProbeForTest(func(context.Context) error {
 		calls++
 		return nil
 	})()
@@ -118,12 +119,12 @@ func TestSudoProbeIsThrottled(t *testing.T) {
 	}
 }
 
-// A cold cache is not throttled into looking warm: the answer has to be
-// re-asked until it changes, or the first cold command would be the only one
-// ever given the terminal.
-func TestSudoProbeRetriesWhileCold(t *testing.T) {
+// A cold result is throttled as cold, not converted to warm. Every caller still
+// hands its command the terminal, but a stalled policy backend is not retried
+// once per package.
+func TestSudoProbeIsThrottledWhileCold(t *testing.T) {
 	var calls int
-	defer SetSudoProbeForTest(func() error {
+	defer SetSudoProbeForTest(func(context.Context) error {
 		calls++
 		return errors.New("a password is required")
 	})()
@@ -135,8 +136,72 @@ func TestSudoProbeRetriesWhileCold(t *testing.T) {
 			t.Fatal("a failing probe was read as a warm cache")
 		}
 	}
-	if calls != 3 {
-		t.Errorf("probe ran %d times, want one per call while the cache is cold", calls)
+	if calls != 1 {
+		t.Errorf("probe ran %d times for 3 cold calls, want 1", calls)
+	}
+}
+
+// Throttling a cold probe must only spare the probe process. It must not route
+// later commands back through captured execution, where a password prompt made
+// by the command would disappear behind the dashboard.
+func TestThrottledColdProbeStillHandsEveryCommandTheTerminal(t *testing.T) {
+	if runtime.GOOS == types.OSWindows {
+		t.Skip("no sudo on windows")
+	}
+
+	defer SetSudoProbeForTest(func(context.Context) error {
+		return errors.New("a password is required")
+	})()
+	resetSudoThrottleForTest()
+	defer resetSudoThrottleForTest()
+
+	rec := &recordingReporter{}
+	defer reporting.Set(rec)()
+	for range 2 {
+		if err := RunCommand(types.Command{Exec: "true", Escalates: true}, false); err != nil {
+			t.Fatalf("RunCommand: %v", err)
+		}
+	}
+
+	var handovers int
+	for _, event := range rec.events {
+		if _, ok := event.(reporting.TerminalReq); ok {
+			handovers++
+		}
+	}
+	if handovers != 2 {
+		t.Errorf("terminal handovers = %d, want one for each cold command", handovers)
+	}
+}
+
+// Cancellation is stronger than the fallback deadline: ctrl-c must stop a
+// blocked policy lookup now, not leave the run apparently frozen for ten more
+// seconds before it can return ErrCancelled.
+func TestSudoProbeStopsWhenTheRunIsCancelled(t *testing.T) {
+	started := make(chan struct{})
+	defer SetSudoProbeForTest(func(ctx context.Context) error {
+		close(started)
+		<-ctx.Done()
+		return ctx.Err()
+	})()
+	resetSudoThrottleForTest()
+	defer resetSudoThrottleForTest()
+
+	release := BeginRun()
+	defer release()
+
+	result := make(chan bool, 1)
+	go func() { result <- sudoCredentialsCached() }()
+	<-started
+	Cancel()
+
+	select {
+	case warm := <-result:
+		if warm {
+			t.Fatal("a cancelled probe was read as a warm cache")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("sudo probe ignored run cancellation")
 	}
 }
 
@@ -161,7 +226,7 @@ func TestSudoProbeIsBounded(t *testing.T) {
 // as success would send the command down the captured path, straight back to
 // the invisible prompt this all exists to avoid.
 func TestSudoTimeoutReadsAsColdCache(t *testing.T) {
-	defer SetSudoProbeForTest(func() error { return context.DeadlineExceeded })()
+	defer SetSudoProbeForTest(func(context.Context) error { return context.DeadlineExceeded })()
 	resetSudoThrottleForTest()
 	defer resetSudoThrottleForTest()
 
@@ -173,7 +238,7 @@ func TestSudoTimeoutReadsAsColdCache(t *testing.T) {
 // The lock is not held past the probe: a slow one delays its own caller and
 // nobody else's next attempt.
 func TestSudoProbeDoesNotHoldTheLockAfterReturning(t *testing.T) {
-	defer SetSudoProbeForTest(func() error { return nil })()
+	defer SetSudoProbeForTest(func(context.Context) error { return nil })()
 	resetSudoThrottleForTest()
 	defer resetSudoThrottleForTest()
 

--- a/openspec/specs/command-execution/spec.md
+++ b/openspec/specs/command-execution/spec.md
@@ -104,9 +104,9 @@ Before running a command that is elevated, runs as another user, or may invoke
 `sudo -n -v`. The check SHALL NOT prompt for a password.
 
 The check SHALL use the active run context and a bounded timeout. Cancelling the
-run SHALL cancel an in-flight check immediately. RWR SHALL briefly cache both a
-warm and a cold result so a stalled policy backend cannot impose its full timeout
-once per package.
+run SHALL cancel an in-flight check immediately. RWR SHALL cache both a warm and
+a cold result for one minute so a stalled policy backend cannot impose its full
+timeout once per package.
 
 A cached cold result SHALL NOT be treated as warm. Every command that may invoke
 sudo while the result is cold SHALL receive the real terminal, so any password

--- a/openspec/specs/command-execution/spec.md
+++ b/openspec/specs/command-execution/spec.md
@@ -97,6 +97,40 @@ leaves the run blocked with no indication of what it waits for.
 - **WHEN** an interactive elevated command runs and `sudo` requires a password
 - **THEN** the prompt appears on the terminal and the operator can answer it
 
+### Requirement: Sudo readiness checks never prompt or delay cancellation
+
+Before running a command that is elevated, runs as another user, or may invoke
+`sudo` itself, RWR SHALL check the sudo credential cache using exactly
+`sudo -n -v`. The check SHALL NOT prompt for a password.
+
+The check SHALL use the active run context and a bounded timeout. Cancelling the
+run SHALL cancel an in-flight check immediately. RWR SHALL briefly cache both a
+warm and a cold result so a stalled policy backend cannot impose its full timeout
+once per package.
+
+A cached cold result SHALL NOT be treated as warm. Every command that may invoke
+sudo while the result is cold SHALL receive the real terminal, so any password
+prompt made by the command itself remains visible and answerable.
+
+#### Scenario: Sudo credentials are not cached
+
+- **WHEN** `sudo -n -v` reports that credentials are not cached
+- **THEN** RWR does not ask for a password itself
+- **AND** each potentially escalating command receives the real terminal
+
+#### Scenario: The sudo policy backend stalls
+
+- **WHEN** the non-interactive sudo check reaches its timeout
+- **THEN** the result is cached briefly as cold
+- **AND** adjacent package commands do not each repeat the stalled check
+- **AND** those commands still receive the real terminal
+
+#### Scenario: The operator cancels during the sudo check
+
+- **WHEN** the operator cancels the run while the sudo check is blocked
+- **THEN** the check stops through the run context without waiting for its
+  fallback timeout
+
 ### Requirement: A command's log file stays open while the command runs
 
 When a command declares `LogName` and debug output is off, RWR SHALL open that file


### PR DESCRIPTION
## What changed

- root the non-interactive `sudo -n -v` probe in the active run context
- cache both warm and cold probe results for the existing one-minute window
- keep routing every potentially escalating command to the terminal while the cached result is cold
- remove stale comments describing the old proactive password prompt
- specify the sudo-probe and terminal-handover contract in OpenSpec

## Why

The ten-second timeout bounded one probe but not the work across a package run: a stalled PAM, NSS, or sudo policy lookup was retried once per package. The probe also used a background context, so Ctrl-C could leave the run looking frozen until the timeout expired.

Caching a cold result avoids repeated probe stalls without treating sudo as warm. Commands that may invoke sudo still receive the terminal, preserving the visible, answerable command-time password prompt introduced by #273.

## Validation

- `go test -race ./internal/system`
- `env -u NO_COLOR go test -race ./...`
- `golangci-lint run`
- commit and push hooks (`go vet`, formatting, lint, full race suite)
- `openspec validate --specs --strict` validates `command-execution`; the repository's pre-existing `blueprint-validation` spec remains the only unrelated failure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repeated sudo credential checks by briefly caching both successful and unsuccessful results.
  * Sudo checks now stop promptly when a command run is cancelled or times out.
  * Commands continue receiving terminal access when sudo credentials are unavailable.
* **Documentation**
  * Documented non-interactive sudo readiness checks and their cancellation and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->