### PR TITLE
fix(status): match resources by location

### DIFF
--- a/internal/processors/plan_stage2.go
+++ b/internal/processors/plan_stage2.go
@@ -47,7 +47,7 @@ func ResolveStage2(plan *types.Plan, osInfo *types.OSInfo) {
 func enumerateResources(processor string, file types.ResolvedFile, defaultProvider string) []types.Resource {
 	usesProviders := processor == types.BlueprintTypePackages || processor == types.BlueprintTypeRepositories
 	var resources []types.Resource
-	add := func(provider, name, action string) {
+	addAt := func(provider, name, action, location string) {
 		if name == "" {
 			return
 		}
@@ -58,10 +58,12 @@ func enumerateResources(processor string, file types.ResolvedFile, defaultProvid
 			Processor: processor,
 			Provider:  provider,
 			Name:      name,
+			Location:  location,
 			Action:    action,
 			Status:    types.StatusPlanned,
 		})
 	}
+	add := func(provider, name, action string) { addAt(provider, name, action, "") }
 
 	switch processor {
 	case types.BlueprintTypePackages:
@@ -97,11 +99,19 @@ func enumerateResources(processor string, file types.ResolvedFile, defaultProvid
 				names = []string{f.Name}
 			}
 			for _, name := range names {
-				add("", name, f.Action)
+				location := ""
+				if f.Target != "" {
+					location = resolveTargetPath(f.Target, name)
+				}
+				addAt("", name, f.Action, location)
 			}
 		}
 		for _, tmpl := range d.Templates {
-			add("", tmpl.Name, "template")
+			location := ""
+			if tmpl.Target != "" {
+				location = resolveTargetPath(tmpl.Target, tmpl.Name)
+			}
+			addAt("", tmpl.Name, "template", location)
 		}
 		for _, dir := range d.Directories {
 			names := dir.Names
@@ -109,7 +119,11 @@ func enumerateResources(processor string, file types.ResolvedFile, defaultProvid
 				names = []string{dir.Name}
 			}
 			for _, name := range names {
-				add("", name, dir.Action)
+				location := ""
+				if dir.Target != "" {
+					location = system.ExpandPath(resolveTargetPath(dir.Target, name))
+				}
+				addAt("", name, dir.Action, location)
 			}
 		}
 	case types.BlueprintTypeServices:
@@ -126,7 +140,7 @@ func enumerateResources(processor string, file types.ResolvedFile, defaultProvid
 			return nil
 		}
 		for _, repo := range d.Repos {
-			add("", repo.Name, repo.Action)
+			addAt("", repo.Name, repo.Action, system.ExpandPath(repo.Path))
 		}
 	case types.BlueprintTypeScripts:
 		var d types.ScriptData

--- a/internal/processors/plan_test.go
+++ b/internal/processors/plan_test.go
@@ -79,6 +79,8 @@ func TestResolveStage2_ProvidersAndResources(t *testing.T) {
 }
 
 func TestEnumerateResourcesCarriesLocationIdentity(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	files := enumerateResources(types.BlueprintTypeFiles, types.ResolvedFile{
 		Format:   "yaml",

--- a/internal/processors/plan_test.go
+++ b/internal/processors/plan_test.go
@@ -77,3 +77,29 @@ func TestResolveStage2_ProvidersAndResources(t *testing.T) {
 		t.Errorf("resources missing: %v (got %+v)", want, plan.Resources)
 	}
 }
+
+func TestEnumerateResourcesCarriesLocationIdentity(t *testing.T) {
+	dir := t.TempDir()
+	files := enumerateResources(types.BlueprintTypeFiles, types.ResolvedFile{
+		Format:   "yaml",
+		Resolved: []byte("files:\n  - name: init.lua\n    action: create\n    target: " + filepath.ToSlash(dir) + "/\n"),
+	}, "")
+	if len(files) != 1 {
+		t.Fatalf("file resources = %d, want 1", len(files))
+	}
+	if want := filepath.Join(dir, "init.lua"); files[0].Location != want {
+		t.Errorf("file location = %q, want %q", files[0].Location, want)
+	}
+
+	checkout := filepath.Join(dir, "checkout")
+	git := enumerateResources(types.BlueprintTypeGit, types.ResolvedFile{
+		Format:   "yaml",
+		Resolved: []byte("git:\n  - name: source\n    action: clone\n    path: " + filepath.ToSlash(checkout) + "\n"),
+	}, "")
+	if len(git) != 1 {
+		t.Fatalf("git resources = %d, want 1", len(git))
+	}
+	if git[0].Location != checkout {
+		t.Errorf("git location = %q, want %q", git[0].Location, checkout)
+	}
+}

--- a/internal/processors/progress.go
+++ b/internal/processors/progress.go
@@ -58,10 +58,15 @@ func (p *progress) itemIdentity(provider, name, action string, status types.Stat
 	if status == types.StatusFailed {
 		p.failed[provider] = true
 	}
+	location := identity["dest"]
+	if location == "" {
+		location = identity["target"]
+	}
 	reporting.Emit(reporting.ResourceDone{Resource: types.Resource{
 		Processor: p.processor,
 		Provider:  provider,
 		Name:      name,
+		Location:  location,
 		Action:    action,
 		Status:    status,
 		Detail:    detail,

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -41,7 +42,7 @@ func Rows(plan *types.Plan, applies []state.Entry, querier *Querier) []Row {
 	unreversed := map[string]*state.Entry{}
 	for i := range applies {
 		entry := &applies[i]
-		key := entry.Processor + "\x00" + entry.Identity["name"]
+		key := entryStatusKey(*entry)
 		recorded[key] = entry
 		if !entry.Reversed {
 			unreversed[key] = entry
@@ -51,7 +52,7 @@ func Rows(plan *types.Plan, applies []state.Entry, querier *Querier) []Row {
 	var rows []Row
 	seen := map[string]bool{}
 	for _, resource := range plan.Resources {
-		key := resource.Processor + "\x00" + resource.Name
+		key := resourceStatusKey(resource)
 		seen[key] = true
 		rows = append(rows, classify(resource, recorded[key], querier))
 	}
@@ -75,6 +76,30 @@ func Rows(plan *types.Plan, applies []state.Entry, querier *Querier) []Row {
 		})
 	}
 	return rows
+}
+
+// Files and git checkouts are identified by where they live, not by a display
+// name that can legitimately repeat. Packages, services, and the remaining
+// locationless resources retain name matching.
+func resourceStatusKey(resource types.Resource) string {
+	if resource.Location != "" && (resource.Processor == types.BlueprintTypeFiles || resource.Processor == types.BlueprintTypeGit) {
+		return resource.Processor + "\x00path\x00" + filepath.Clean(resource.Location)
+	}
+	return resource.Processor + "\x00name\x00" + resource.Name
+}
+
+func entryStatusKey(entry state.Entry) string {
+	location := ""
+	switch entry.Processor {
+	case types.BlueprintTypeFiles:
+		location = entry.Identity["dest"]
+	case types.BlueprintTypeGit:
+		location = entry.Identity["target"]
+	}
+	if location != "" {
+		return entry.Processor + "\x00path\x00" + filepath.Clean(location)
+	}
+	return entry.Processor + "\x00name\x00" + entry.Identity["name"]
 }
 
 // classify decides one desired resource's verdict.

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -92,19 +92,21 @@ func TestRowsClassification(t *testing.T) {
 		t.Fatal(err)
 	}
 	sum, _ := system.HashFileSHA256(present)
+	stale := filepath.Join(dir, "stale")
 
+	missing := filepath.Join(dir, "gone")
 	plan := &types.Plan{Resources: []types.Resource{
-		{Processor: types.BlueprintTypeFiles, Name: "present"},
-		{Processor: types.BlueprintTypeFiles, Name: "missing"},
+		{Processor: types.BlueprintTypeFiles, Name: "present", Location: present},
+		{Processor: types.BlueprintTypeFiles, Name: "missing", Location: missing},
 		{Processor: types.BlueprintTypeScripts, Name: "setup.sh"},
 	}}
 	applies := []state.Entry{
 		{Processor: types.BlueprintTypeFiles, OK: true, Outcome: "ok",
 			Identity: map[string]string{"name": "present", "dest": present, "sha256": sum}},
 		{Processor: types.BlueprintTypeFiles, OK: true, Outcome: "ok",
-			Identity: map[string]string{"name": "missing", "dest": filepath.Join(dir, "gone"), "sha256": sum}},
+			Identity: map[string]string{"name": "missing", "dest": missing, "sha256": sum}},
 		{Processor: types.BlueprintTypeFiles, OK: true, Outcome: "ok",
-			Identity: map[string]string{"name": "stale-one", "dest": present, "sha256": sum}},
+			Identity: map[string]string{"name": "stale-one", "dest": stale, "sha256": sum}},
 	}
 
 	rows := Rows(plan, applies, NewQuerier())
@@ -126,5 +128,40 @@ func TestRowsClassification(t *testing.T) {
 	}
 	if !Drifted(rows) {
 		t.Error("missing+stale rows did not count as drift")
+	}
+}
+
+// A display name is not a file identity. Two tools can both manage an
+// init.lua, and the journal entry for one path must never classify the other.
+func TestRowsMatchSameNamedFilesByDestination(t *testing.T) {
+	dir := t.TempDir()
+	present := filepath.Join(dir, "nvim", "init.lua")
+	missing := filepath.Join(dir, "wezterm", "init.lua")
+	if err := os.MkdirAll(filepath.Dir(present), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(present, []byte("live"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum, err := system.HashFileSHA256(present)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plan := &types.Plan{Resources: []types.Resource{
+		{Processor: types.BlueprintTypeFiles, Name: "init.lua", Location: present},
+		{Processor: types.BlueprintTypeFiles, Name: "init.lua", Location: missing},
+	}}
+	applies := []state.Entry{
+		{Processor: types.BlueprintTypeFiles, Identity: map[string]string{"name": "init.lua", "dest": present, "sha256": sum}},
+		{Processor: types.BlueprintTypeFiles, Identity: map[string]string{"name": "init.lua", "dest": missing, "sha256": sum}},
+	}
+
+	rows := Rows(plan, applies, NewQuerier())
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2: %+v", len(rows), rows)
+	}
+	if rows[0].Class != InSync || rows[1].Class != Missing {
+		t.Fatalf("classes = [%s, %s], want [in-sync, missing]", rows[0].Class, rows[1].Class)
 	}
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -86,6 +86,8 @@ func TestQueryNeverRunsNonListCommands(t *testing.T) {
 }
 
 func TestRowsClassification(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	present := filepath.Join(dir, "present")
 	if err := os.WriteFile(present, []byte("x"), 0o644); err != nil {
@@ -134,6 +136,8 @@ func TestRowsClassification(t *testing.T) {
 // A display name is not a file identity. Two tools can both manage an
 // init.lua, and the journal entry for one path must never classify the other.
 func TestRowsMatchSameNamedFilesByDestination(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	present := filepath.Join(dir, "nvim", "init.lua")
 	missing := filepath.Join(dir, "wezterm", "init.lua")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"io"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -327,6 +328,9 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 		for i := range m.plan.Resources {
 			planned := &m.plan.Resources[i]
 			if planned.Status != types.StatusPlanned || planned.Processor != res.Processor || planned.Name != res.Name {
+				continue
+			}
+			if planned.Location != "" && res.Location != "" && filepath.Clean(planned.Location) != filepath.Clean(res.Location) {
 				continue
 			}
 			planned.Provider, planned.Status, planned.Detail, planned.Dur = res.Provider, res.Status, res.Detail, res.Dur

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -330,8 +330,10 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 			if planned.Status != types.StatusPlanned || planned.Processor != res.Processor || planned.Name != res.Name {
 				continue
 			}
-			if planned.Location != "" && res.Location != "" && filepath.Clean(planned.Location) != filepath.Clean(res.Location) {
-				continue
+			if planned.Location != "" {
+				if res.Location == "" || filepath.Clean(planned.Location) != filepath.Clean(res.Location) {
+					continue
+				}
 			}
 			planned.Provider, planned.Status, planned.Detail, planned.Dur = res.Provider, res.Status, res.Detail, res.Dur
 			matched = true

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -71,6 +71,31 @@ func TestModel_FramesRender(t *testing.T) {
 	}
 }
 
+func TestResourceDoneMatchesSameNamedFilesByLocation(t *testing.T) {
+	plan := &types.Plan{
+		Init:  &types.InitConfig{},
+		Order: []string{types.BlueprintTypeFiles},
+		Resources: []types.Resource{
+			{Processor: types.BlueprintTypeFiles, Name: "init.lua", Location: "/one/init.lua", Status: types.StatusPlanned},
+			{Processor: types.BlueprintTypeFiles, Name: "init.lua", Location: "/two/init.lua", Status: types.StatusPlanned},
+		},
+	}
+	m := New(mustTheme("rwr"), plan, reporting.NewStore(10), false, "")
+	m.apply(reporting.ResourceDone{Resource: types.Resource{
+		Processor: types.BlueprintTypeFiles,
+		Name:      "init.lua",
+		Location:  "/two/init.lua",
+		Status:    types.StatusOK,
+	}})
+
+	if plan.Resources[0].Status != types.StatusPlanned {
+		t.Errorf("first same-named file status = %s, want planned", plan.Resources[0].Status)
+	}
+	if plan.Resources[1].Status != types.StatusOK {
+		t.Errorf("second same-named file status = %s, want ok", plan.Resources[1].Status)
+	}
+}
+
 // Resize below either threshold trips compact mode live and back.
 func TestModel_CompactModeOnResize(t *testing.T) {
 	m := testModel(t)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -96,6 +96,30 @@ func TestResourceDoneMatchesSameNamedFilesByLocation(t *testing.T) {
 	}
 }
 
+func TestResourceDoneWithoutLocationDoesNotMatchLocationIdentifiedFiles(t *testing.T) {
+	plan := &types.Plan{
+		Init:  &types.InitConfig{},
+		Order: []string{types.BlueprintTypeFiles},
+		Resources: []types.Resource{
+			{Processor: types.BlueprintTypeFiles, Name: "init.lua", Location: "/one/init.lua", Status: types.StatusPlanned},
+			{Processor: types.BlueprintTypeFiles, Name: "init.lua", Location: "/two/init.lua", Status: types.StatusPlanned},
+		},
+	}
+	m := New(mustTheme("rwr"), plan, reporting.NewStore(10), false, "")
+	m.apply(reporting.ResourceDone{Resource: types.Resource{
+		Processor: types.BlueprintTypeFiles,
+		Name:      "init.lua",
+		Status:    types.StatusOK,
+	}})
+
+	if plan.Resources[0].Status != types.StatusPlanned || plan.Resources[1].Status != types.StatusPlanned {
+		t.Fatalf("location-identified file statuses = [%s, %s], want both planned", plan.Resources[0].Status, plan.Resources[1].Status)
+	}
+	if len(plan.Resources) != 3 || plan.Resources[2].Status != types.StatusOK {
+		t.Fatalf("resources = %+v, want unmatched result appended", plan.Resources)
+	}
+}
+
 // Resize below either threshold trips compact mode live and back.
 func TestModel_CompactModeOnResize(t *testing.T) {
 	m := testModel(t)

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -43,10 +43,14 @@ type Resource struct {
 	Processor string
 	Provider  string // empty for files, services, git, scripts
 	Name      string // "neovim", "~/.config/nvim/"
-	Action    string // install, copy, enable, clone
-	Status    Status
-	Detail    string
-	Dur       time.Duration
+	// Location identifies resources whose name is not unique: the destination
+	// of a file/directory or the target of a git checkout. Empty for resources
+	// such as packages and services that are identified by name.
+	Location string
+	Action   string // install, copy, enable, clone
+	Status   Status
+	Detail   string
+	Dur      time.Duration
 }
 
 // Severity classifies a diagnostic.

--- a/openspec/specs/state-tracking/spec.md
+++ b/openspec/specs/state-tracking/spec.md
@@ -43,3 +43,27 @@ matches the record, and SHALL refuse to uninstall when no run record exists.
 - **THEN** it exits with an error explaining that nothing was recorded, and
   changes nothing
 
+### Requirement: Status matches location-identified resources by path
+
+RWR SHALL match planned files and git checkouts to journal entries by their
+category-scoped, cleaned destination or target path. It SHALL NOT use a file or
+checkout's display name as its identity when a location is available. Packages,
+services, and other resources without a location SHALL continue to match by
+name.
+
+The same location SHALL flow through planned and completed resource events so
+the TUI updates the correct row when display names repeat.
+
+#### Scenario: Two managed files have the same name
+
+- **GIVEN** two planned files named `init.lua` at different destinations
+- **AND** one destination exists while the other is missing
+- **WHEN** `rwr status` joins the plan to the journal
+- **THEN** each row is classified from its own destination
+- **AND** neither journal entry overwrites or hides the other
+
+#### Scenario: A same-named file completes under the TUI
+
+- **GIVEN** two planned file resources share a name and have different destinations
+- **WHEN** one completed-resource event arrives with its destination
+- **THEN** only the planned resource at that destination receives the outcome


### PR DESCRIPTION
## What changed

- carry file destinations and git checkout targets on planned resources
- propagate the same location through completed-resource events
- match status journal entries by category-scoped cleaned path for files and git
- retain name matching for packages, services, and other locationless resources
- make the TUI update the correct planned row when resource names repeat
- document the location-identity contract in OpenSpec

## Why

`status.Rows` keyed every journal entry by `processor + name`. Two managed files named `init.lua` at different destinations overwrote each other in that map, so both rows could be classified from the last journal entry. The TUI used the same name-only matching for completed events.

Display names are not identities for path-backed resources. Their destination or checkout target is.

## Validation

- collision regression: two same-named files, one present and one missing
- planner coverage for file and git locations
- TUI regression proving a completed event updates only its destination
- `env -u NO_COLOR go test -race ./...`
- `golangci-lint run`
- `openspec validate state-tracking --type spec --strict`
- commit and push hooks (`go vet`, formatting, lint, full race suite, govulncheck, gosec)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking for files and Git checkouts that share the same name.
  * Statuses now match resources by their destination or checkout location when available.
  * The interface updates only the correctly located resource when duplicate names exist.
  * Added path normalization for more reliable status and completion reporting.
  * Preserved location details across resource planning and completion updates.

* **Documentation**
  * Documented location-aware resource tracking and duplicate-name scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->