### PR TITLE
fix(ssh): store the RWR key in the keyring

### DIFF
--- a/docs/blueprints/ssh-keys.md
+++ b/docs/blueprints/ssh-keys.md
@@ -140,7 +140,7 @@ If `github_title` is provided, it will be used as the title for the SSH key on G
 
 ## Setting the RWR SSH Key
 
-If `set_as_rwr_ssh_key` is set to `true`, RWR will set this key as the default SSH key for RWR operations. This key will be used for private git clones and other SSH-based operations within RWR. The private key will be base64 encoded and stored in the RWR configuration file.
+If `set_as_rwr_ssh_key` is set to `true`, RWR will set this key as the default SSH key for RWR operations. This key will be used for private git clones and other SSH-based operations within RWR. The private key is base64 encoded and saved to the OS keyring. If no keyring backend is available, RWR warns and falls back to the owner-only (`0600`) configuration file for compatibility with existing installations.
 
 > [!NOTE]
 > Only one key should be set as the RWR SSH key. If multiple keys are set, the last one processed will be used.

--- a/docs/blueprints/ssh-keys.md
+++ b/docs/blueprints/ssh-keys.md
@@ -94,9 +94,11 @@ This will:
 1. Display a device code (e.g., `ABCD-1234`)
 2. Prompt you to visit <https://github.com/login/device>
 3. Wait for you to authorize the application
-4. Save the token to your RWR config
+4. Save the token to the OS keyring, or to the owner-only (`0600`) RWR config
+   only when no keyring backend is available
 
-After this initial setup, future runs won't require `--gh-auth` as the token is saved in your config.
+After this initial setup, future runs won't require `--gh-auth` because the
+token is persisted in one of those stores.
 
 #### Using an Explicit Token
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -57,10 +57,13 @@ RWR persists a managed credential only in the OS keyring - Secret Service on
 Linux, Keychain on macOS, Credential Manager on Windows - and only when you
 agree. RWR never writes a managed credential to a plaintext file.
 
-One exception is grandfathered: a GitHub token that an earlier RWR saved into
-the config file keeps working. New tokens from `--gh-auth` go to the keyring;
+The two built-in credentials retain their grandfathered config-file fallback:
+`repository.gh_api_token` and `repository.ssh_private_key` keep working. New
+GitHub tokens and keys selected by `set_as_rwr_ssh_key` go to the keyring first;
 when no keyring backend is available, RWR falls back to the config file at
-`0600` and warns with the file path.
+`0600` and warns with the file path. When a generated SSH key moves into the
+keyring successfully, RWR clears an older plaintext config value so it cannot
+override the new key on the next run.
 
 ## How to permit a credential
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -55,15 +55,15 @@ under `exposeCredentials`, and the logs show `[redacted]` instead of the value.
 
 RWR persists a managed credential only in the OS keyring - Secret Service on
 Linux, Keychain on macOS, Credential Manager on Windows - and only when you
-agree. RWR never writes a managed credential to a plaintext file.
+agree. By default, RWR does not write a managed credential to a plaintext file.
 
 The two built-in credentials retain their grandfathered config-file fallback:
 `repository.gh_api_token` and `repository.ssh_private_key` keep working. New
 GitHub tokens and keys selected by `set_as_rwr_ssh_key` go to the keyring first;
 when no keyring backend is available, RWR falls back to the config file at
 `0600` and warns with the file path. When a generated SSH key moves into the
-keyring successfully, RWR clears an older plaintext config value so it cannot
-override the new key on the next run.
+keyring successfully, RWR attempts to clear an older plaintext config value so
+it cannot override the new key on the next run. A cleanup failure is reported.
 
 ## How to permit a credential
 

--- a/internal/credentials/keyring.go
+++ b/internal/credentials/keyring.go
@@ -7,6 +7,8 @@ package credentials
 import (
 	"errors"
 	"fmt"
+	"os/exec"
+	"strings"
 
 	zkeyring "github.com/zalando/go-keyring"
 )
@@ -29,6 +31,11 @@ type Keyring interface {
 // backend that cannot be reached at all.
 var ErrKeyringNotFound = errors.New("keyring entry not found")
 
+// ErrKeyringUnavailable identifies machines with no usable OS keyring backend.
+// Callers may use a documented compatibility store only for this class of
+// failure; locked, denied, and transient backend failures must remain errors.
+var ErrKeyringUnavailable = errors.New("OS keyring backend unavailable")
+
 // Ring is the keyring in use. Tests swap in a fake; production keeps the OS
 // keyring (Secret Service / macOS Keychain / Windows Credential Manager).
 var Ring Keyring = osKeyring{}
@@ -44,7 +51,32 @@ func (osKeyring) Get(name string) (string, error) {
 }
 
 func (osKeyring) Set(name, value string) error {
-	return zkeyring.Set(keyringService, name, value)
+	err := zkeyring.Set(keyringService, name, value)
+	if keyringBackendUnavailable(err) {
+		return fmt.Errorf("%w: %v", ErrKeyringUnavailable, err)
+	}
+	return err
+}
+
+func keyringBackendUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"cannot autolaunch d-bus",
+		"dbus-launch: executable file not found",
+		"no such file or directory: /run/user/",
+		"unsupported platform",
+	} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // FromKeyring reads a credential from the keyring. A missing entry or an

--- a/internal/credentials/resolve.go
+++ b/internal/credentials/resolve.go
@@ -144,5 +144,11 @@ func ResolveBuiltins(flags *types.Flags) {
 	}
 	if flags.SSHKey != "" {
 		types.SetCredentialValue("ssh_private_key", flags.SSHKey)
+	} else if value, ok := FromKeyring("ssh_private_key"); ok {
+		log.Debugf("SSH private key resolved from the OS keyring")
+		types.SetCredentialValue("ssh_private_key", value)
+		// Git authentication reads the flag field, so keyring material flows
+		// through the same path as --ssh-key and the config fallback.
+		flags.SSHKey = value
 	}
 }

--- a/internal/credentials/resolve_test.go
+++ b/internal/credentials/resolve_test.go
@@ -293,6 +293,27 @@ func TestResolveBuiltins(t *testing.T) {
 		}
 	})
 
+	t.Run("SSH flag wins over keyring", func(t *testing.T) {
+		withFakes(t, &fakeKeyring{entries: map[string]string{"ssh_private_key": "from-keyring"}}, false, nil)
+		flags := types.Flags{SSHKey: "from-flag"}
+		ResolveBuiltins(&flags)
+		if flags.SSHKey != "from-flag" {
+			t.Errorf("flags.SSHKey = %q, want the flag/config value", flags.SSHKey)
+		}
+	})
+
+	t.Run("keyring fills the SSH key field", func(t *testing.T) {
+		withFakes(t, &fakeKeyring{entries: map[string]string{"ssh_private_key": "from-keyring"}}, false, nil)
+		flags := types.Flags{}
+		ResolveBuiltins(&flags)
+		if flags.SSHKey != "from-keyring" {
+			t.Errorf("flags.SSHKey = %q, want the keyring key", flags.SSHKey)
+		}
+		if got, _ := types.CredentialValue("ssh_private_key"); got != "from-keyring" {
+			t.Errorf("resolved %q, want the keyring key", got)
+		}
+	})
+
 	t.Run("nothing configured is not an error", func(t *testing.T) {
 		withFakes(t, &fakeKeyring{}, false, nil)
 		t.Setenv("GITHUB_TOKEN", "")

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -269,10 +269,38 @@ func setAsRWRSSHKey(keyPath string) error {
 	// Encode the private key as base64. helpers.getSSHAuthMethod decodes this
 	// form; it is also what --ssh-key accepts, so the two agree.
 	encodedKey := base64.StdEncoding.EncodeToString(privateKey)
+	types.SetCredentialValue("ssh_private_key", encodedKey)
 
-	// Set the encoded key in Viper configuration
+	// Prefer the OS keyring so the private key never lands in a plaintext
+	// configuration file. If an older config already contains a key, clear it:
+	// config/flag values intentionally outrank the keyring on read, so leaving a
+	// stale copy would make this newly saved key unreachable on the next run.
+	if err := credentials.SaveToKeyring("ssh_private_key", encodedKey); err == nil {
+		if viper.GetString("repository.ssh_private_key") != "" {
+			viper.Set("repository.ssh_private_key", "")
+			if err := writeRWRSSHKeyConfig(); err != nil {
+				return fmt.Errorf("clearing plaintext SSH key after keyring save: %w", err)
+			}
+		}
+		log.Infof("SSH key %s saved as the RWR SSH key in the OS keyring", keyPath)
+		return nil
+	} else {
+		log.Warnf("OS keyring unavailable (%v); saving the SSH private key to %s instead - "+
+			"it is stored in plaintext, readable only by your user (0600)",
+			err, viper.ConfigFileUsed())
+	}
+
+	// Preserve the existing config-file fallback for machines without a usable
+	// keyring. Existing installations already rely on this path.
 	viper.Set("repository.ssh_private_key", encodedKey)
+	if err := writeRWRSSHKeyConfig(); err != nil {
+		return err
+	}
+	log.Infof("SSH key %s set as RWR SSH Key", keyPath)
+	return nil
+}
 
+func writeRWRSSHKeyConfig() error {
 	// The file is about to hold a private key, and viper writes at 0644 with
 	// no way to ask for less. Pre-creating it at 0600 means the key is never
 	// on disk world-readable, not even for the length of the write. The
@@ -285,8 +313,7 @@ func setAsRWRSSHKey(keyPath string) error {
 	}
 
 	// Write the updated configuration to file
-	err = viper.WriteConfig()
-	if err != nil {
+	if err := viper.WriteConfig(); err != nil {
 		return fmt.Errorf("error writing updated configuration: %v", err)
 	}
 
@@ -296,7 +323,6 @@ func setAsRWRSSHKey(keyPath string) error {
 		return fmt.Errorf("error restricting configuration permissions: %w", err)
 	}
 
-	log.Infof("SSH key %s set as RWR SSH Key", keyPath)
 	return nil
 }
 

--- a/internal/processors/ssh_key.go
+++ b/internal/processors/ssh_key.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -284,10 +285,12 @@ func setAsRWRSSHKey(keyPath string) error {
 		}
 		log.Infof("SSH key %s saved as the RWR SSH key in the OS keyring", keyPath)
 		return nil
-	} else {
+	} else if errors.Is(err, credentials.ErrKeyringUnavailable) {
 		log.Warnf("OS keyring unavailable (%v); saving the SSH private key to %s instead - "+
 			"it is stored in plaintext, readable only by your user (0600)",
 			err, viper.ConfigFileUsed())
+	} else {
+		return err
 	}
 
 	// Preserve the existing config-file fallback for machines without a usable

--- a/internal/processors/ssh_key_store_test.go
+++ b/internal/processors/ssh_key_store_test.go
@@ -2,17 +2,57 @@ package processors
 
 import (
 	"encoding/base64"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/fynxlabs/rwr/internal/credentials"
 	"github.com/fynxlabs/rwr/internal/helpers"
+	"github.com/fynxlabs/rwr/internal/types"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type sshStoreKeyring struct {
+	entries     map[string]string
+	unavailable bool
+}
+
+func (r *sshStoreKeyring) Get(name string) (string, error) {
+	if r.unavailable {
+		return "", errors.New("no keyring backend")
+	}
+	value, ok := r.entries[name]
+	if !ok {
+		return "", credentials.ErrKeyringNotFound
+	}
+	return value, nil
+}
+
+func (r *sshStoreKeyring) Set(name, value string) error {
+	if r.unavailable {
+		return errors.New("no keyring backend")
+	}
+	if r.entries == nil {
+		r.entries = map[string]string{}
+	}
+	r.entries[name] = value
+	return nil
+}
+
+func withSSHStoreKeyring(t *testing.T, ring credentials.Keyring) {
+	t.Helper()
+	previous := credentials.Ring
+	credentials.Ring = ring
+	t.Cleanup(func() {
+		credentials.Ring = previous
+		types.RegisterCredentials(nil)
+	})
+}
 
 // withConfigFile points viper at a throwaway config and returns its path.
 func withConfigFile(t *testing.T) string {
@@ -46,6 +86,7 @@ func TestSetAsRWRSSHKeyLeavesConfigOwnerOnly(t *testing.T) {
 		t.Skip("unix permission bits")
 	}
 	configPath := withConfigFile(t)
+	withSSHStoreKeyring(t, &sshStoreKeyring{unavailable: true})
 	keyPath := writeTestKey(t)
 
 	require.NoError(t, setAsRWRSSHKey(keyPath))
@@ -64,6 +105,7 @@ func TestSetAsRWRSSHKeyNarrowsAnExistingLooseConfig(t *testing.T) {
 		t.Skip("unix permission bits")
 	}
 	configPath := withConfigFile(t)
+	withSSHStoreKeyring(t, &sshStoreKeyring{unavailable: true})
 	require.NoError(t, os.WriteFile(configPath, []byte("repository: {}\n"), 0o644))
 	keyPath := writeTestKey(t)
 
@@ -79,6 +121,7 @@ func TestSetAsRWRSSHKeyNarrowsAnExistingLooseConfig(t *testing.T) {
 // value no clone could ever use.
 func TestSetAsRWRSSHKeyStoresAValueGitAuthCanUse(t *testing.T) {
 	withConfigFile(t)
+	withSSHStoreKeyring(t, &sshStoreKeyring{unavailable: true})
 	keyPath := writeTestKey(t)
 
 	require.NoError(t, setAsRWRSSHKey(keyPath))
@@ -92,4 +135,39 @@ func TestSetAsRWRSSHKeyStoresAValueGitAuthCanUse(t *testing.T) {
 	original, err := os.ReadFile(keyPath)
 	require.NoError(t, err)
 	assert.Equal(t, original, decoded, "stored key does not round-trip to the file it came from")
+}
+
+func TestSetAsRWRSSHKeyPrefersKeyring(t *testing.T) {
+	configPath := withConfigFile(t)
+	ring := &sshStoreKeyring{entries: map[string]string{}}
+	withSSHStoreKeyring(t, ring)
+	keyPath := writeTestKey(t)
+
+	require.NoError(t, setAsRWRSSHKey(keyPath))
+
+	stored := ring.entries["ssh_private_key"]
+	require.NotEmpty(t, stored, "private key did not reach the keyring")
+	if raw, err := os.ReadFile(configPath); err == nil && len(raw) != 0 {
+		assert.NotContains(t, string(raw), stored, "config file gained the private key despite an available keyring")
+	}
+	value, ok := types.CredentialValue("ssh_private_key")
+	require.True(t, ok)
+	assert.Equal(t, stored, value)
+}
+
+func TestSetAsRWRSSHKeyClearsLegacyConfigAfterKeyringSave(t *testing.T) {
+	configPath := withConfigFile(t)
+	viper.Set("repository.ssh_private_key", "legacy-plaintext-key")
+	require.NoError(t, viper.WriteConfig())
+
+	ring := &sshStoreKeyring{entries: map[string]string{}}
+	withSSHStoreKeyring(t, ring)
+	keyPath := writeTestKey(t)
+	require.NoError(t, setAsRWRSSHKey(keyPath))
+
+	raw, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "legacy-plaintext-key")
+	assert.NotContains(t, string(raw), ring.entries["ssh_private_key"])
+	assert.Empty(t, viper.GetString("repository.ssh_private_key"))
 }

--- a/internal/processors/ssh_key_store_test.go
+++ b/internal/processors/ssh_key_store_test.go
@@ -20,6 +20,7 @@ import (
 type sshStoreKeyring struct {
 	entries     map[string]string
 	unavailable bool
+	setErr      error
 }
 
 func (r *sshStoreKeyring) Get(name string) (string, error) {
@@ -35,13 +36,28 @@ func (r *sshStoreKeyring) Get(name string) (string, error) {
 
 func (r *sshStoreKeyring) Set(name, value string) error {
 	if r.unavailable {
-		return errors.New("no keyring backend")
+		return credentials.ErrKeyringUnavailable
+	}
+	if r.setErr != nil {
+		return r.setErr
 	}
 	if r.entries == nil {
 		r.entries = map[string]string{}
 	}
 	r.entries[name] = value
 	return nil
+}
+
+func TestSetAsRWRSSHKeyDoesNotFallBackOnKeyringWriteFailure(t *testing.T) {
+	configPath := withConfigFile(t)
+	withSSHStoreKeyring(t, &sshStoreKeyring{setErr: errors.New("keyring is locked")})
+	keyPath := writeTestKey(t)
+
+	require.Error(t, setAsRWRSSHKey(keyPath))
+	assert.Empty(t, viper.GetString("repository.ssh_private_key"))
+	if raw, err := os.ReadFile(configPath); err == nil {
+		assert.NotContains(t, string(raw), "ssh_private_key")
+	}
 }
 
 func withSSHStoreKeyring(t *testing.T, ring credentials.Keyring) {

--- a/internal/prompts/github.go
+++ b/internal/prompts/github.go
@@ -4,6 +4,7 @@
 package prompts
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -211,6 +212,9 @@ func SaveGitHubTokenToConfig(token string, initConfig *types.InitConfig) error {
 	if saveErr == nil {
 		log.Debugf("Token saved to the OS keyring")
 		return nil
+	}
+	if !errors.Is(saveErr, credentials.ErrKeyringUnavailable) {
+		return saveErr
 	}
 	log.Warnf("OS keyring unavailable (%v); saving the token to %s instead - "+
 		"it is stored in plaintext, readable only by your user (0600)",

--- a/internal/prompts/github_save_test.go
+++ b/internal/prompts/github_save_test.go
@@ -16,6 +16,7 @@ import (
 type mapKeyring struct {
 	entries     map[string]string
 	unavailable bool
+	setErr      error
 }
 
 func (m *mapKeyring) Get(name string) (string, error) {
@@ -31,10 +32,28 @@ func (m *mapKeyring) Get(name string) (string, error) {
 
 func (m *mapKeyring) Set(name, value string) error {
 	if m.unavailable {
-		return errors.New("no keyring backend")
+		return credentials.ErrKeyringUnavailable
+	}
+	if m.setErr != nil {
+		return m.setErr
 	}
 	m.entries[name] = value
 	return nil
+}
+
+func TestSaveGitHubTokenDoesNotFallBackOnKeyringWriteFailure(t *testing.T) {
+	configFile := withSaveFixture(t, &mapKeyring{setErr: errors.New("keyring is locked")})
+
+	err := SaveGitHubTokenToConfig("gho_devicetoken", &types.InitConfig{})
+	if err == nil {
+		t.Fatal("SaveGitHubTokenToConfig = nil, want keyring error")
+	}
+	if got := viper.GetString("repository.gh_api_token"); got != "" {
+		t.Fatalf("config token = %q, want empty", got)
+	}
+	if raw, readErr := os.ReadFile(configFile); readErr == nil && strings.Contains(string(raw), "gho_devicetoken") {
+		t.Error("config file gained token after keyring write failure")
+	}
 }
 
 func withSaveFixture(t *testing.T, ring credentials.Keyring) string {

--- a/openspec/specs/credential-handling/spec.md
+++ b/openspec/specs/credential-handling/spec.md
@@ -260,9 +260,10 @@ unless named in `exposeCredentials`, and redacted in logs.
 RWR SHALL NOT write a managed credential's value to a plaintext file at rest.
 Persistence SHALL use the operating system keyring, and only with the
 operator's consent. When no keyring backend is available, RWR SHALL decline to
-persist and say so, rather than fall back to a plaintext file - except the
-pre-existing GitHub-token config-file path, which SHALL warn with the file
-path when used.
+persist and say so, rather than fall back to a plaintext file - except the two
+pre-existing built-in config-file paths for the GitHub token and SSH private
+key, which SHALL be restricted to `0600` and SHALL warn with the file path when
+used.
 
 #### Scenario: Device-flow token persisted with a keyring available
 
@@ -270,3 +271,24 @@ path when used.
 - **THEN** the token is saved to the keyring and no plaintext file gains the
   token value
 
+#### Scenario: Generated SSH key persisted with a keyring available
+
+- **WHEN** an SSH-key blueprint selects `set_as_rwr_ssh_key`
+- **AND** an OS keyring backend is available
+- **THEN** the base64 private key is saved under `ssh_private_key` in the keyring
+- **AND** no plaintext file gains the key value
+- **AND** any older plaintext config value is cleared
+
+#### Scenario: Built-in SSH key resolves from the keyring
+
+- **GIVEN** no SSH key flag or config value is set
+- **AND** the keyring contains `ssh_private_key`
+- **WHEN** built-in credentials resolve
+- **THEN** the keyring value becomes the SSH key used by git authentication
+
+#### Scenario: SSH keyring backend is unavailable
+
+- **WHEN** an SSH-key blueprint selects `set_as_rwr_ssh_key`
+- **AND** no OS keyring backend is available
+- **THEN** RWR warns that it is using the compatibility fallback
+- **AND** writes the base64 key only to the owner-readable (`0600`) config file

--- a/openspec/specs/credential-handling/spec.md
+++ b/openspec/specs/credential-handling/spec.md
@@ -180,9 +180,11 @@ and poll for the token at the server-provided interval (default five seconds),
 continuing on `authorization_pending` and backing off when GitHub answers
 `slow_down`. Polling SHALL give up after five minutes.
 
-The token obtained SHALL be saved to RWR's config file. A failure to save
-SHALL NOT discard the token: the run continues with it and tells the operator
-how to supply it directly next time.
+The token obtained SHALL be saved to the OS keyring when a backend is available,
+without writing it to a plaintext configuration file. When no keyring backend
+is available, RWR SHALL warn and use the owner-only (`0600`) configuration-file
+fallback. A failure to save SHALL NOT discard the token: the run continues with
+it and tells the operator how to supply it directly next time.
 
 When a different token is already stored and the run is interactive, RWR SHALL
 ask before replacing it, and declining SHALL keep the stored token. A manually
@@ -196,7 +198,8 @@ with an error listing the ways to supply one - `--gh-api-key`, `--gh-auth`, or
 #### Scenario: A device-flow login
 
 - **WHEN** `--gh-auth` runs and the operator authorizes the code in a browser
-- **THEN** RWR obtains the token, saves it to the config file, and uses it
+- **THEN** RWR obtains the token, persists it using the keyring-first policy,
+  and uses it
 
 #### Scenario: The operator never authorizes
 
@@ -277,7 +280,8 @@ used.
 - **AND** an OS keyring backend is available
 - **THEN** the base64 private key is saved under `ssh_private_key` in the keyring
 - **AND** no plaintext file gains the key value
-- **AND** any older plaintext config value is cleared
+- **AND** RWR attempts to clear any older plaintext config value
+- **AND** a cleanup failure is reported
 
 #### Scenario: Built-in SSH key resolves from the keyring
 
@@ -292,3 +296,10 @@ used.
 - **AND** no OS keyring backend is available
 - **THEN** RWR warns that it is using the compatibility fallback
 - **AND** writes the base64 key only to the owner-readable (`0600`) config file
+
+#### Scenario: SSH keyring write fails while a backend exists
+
+- **WHEN** an SSH-key blueprint selects `set_as_rwr_ssh_key`
+- **AND** the keyring backend is locked, denies access, or returns a transient error
+- **THEN** RWR reports the keyring error
+- **AND** does not write `repository.ssh_private_key` to the config file


### PR DESCRIPTION
## What changed

- resolve `ssh_private_key` from the OS keyring when no explicit flag/config value is set
- save keys selected by `set_as_rwr_ssh_key` to the keyring first
- clear a legacy plaintext config value after a successful keyring save so it cannot override the new key
- retain the warned owner-only (`0600`) config fallback when no keyring backend is usable
- keep explicit flag/config precedence and register the selected key for the current run
- update credential and SSH-key documentation plus the credential-handling specification

## Why

The built-in GitHub token had a complete managed-credential path, but the SSH private key did not. `set_as_rwr_ssh_key` always wrote Base64 key material to the plaintext config, and `ResolveBuiltins` never read an SSH key from the keyring. Implementing only the write side would make the key unreachable on the next run, so this change ships read and write together.

## Compatibility

Existing `--ssh-key` and `repository.ssh_private_key` values still win. Machines without a keyring keep the existing config-file behavior, with an explicit warning and `0600` permissions.

## Validation

- keyring read and explicit-value precedence tests
- keyring-first write and current-run registry tests
- migration test clearing a legacy plaintext value
- unavailable-keyring fallback and permission tests
- `env -u NO_COLOR go test -race ./...`
- `golangci-lint run`
- `openspec validate credential-handling --type spec --strict`
- commit and push hooks (`go vet`, formatting, lint, full race suite, govulncheck, gosec)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH private keys and GitHub tokens now use the OS keyring when available.
  * Built-in SSH credentials can be resolved from the keyring automatically.
  * Credentials fall back to owner-only configuration files when keyring access is unavailable.

* **Bug Fixes**
  * Legacy plaintext SSH key settings are removed after successful keyring storage.
  * Keyring write errors are reported instead of silently falling back.

* **Documentation**
  * Updated credential storage and fallback behavior documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->