### PR TITLE
Use shared redirect policy for version checks

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"charm.land/log/v2"
+	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -164,7 +165,7 @@ func checkForNewVersion(app *AppConfig) {
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "rwr/"+buildInfo.Version)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := system.NewHTTPClient(2 * time.Second).Do(req)
 	if err != nil {
 		log.Debugf("Version check failed: %v", err)
 		return


### PR DESCRIPTION
## What changed

The advisory GitHub release check now uses `system.NewHTTPClient` with its existing two-second timeout instead of `http.DefaultClient`.

## Why

The default client bypassed RWR's shared redirect validation, including HTTPS downgrade and redirect-limit protections.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run --fix`
- `govulncheck ./...`
- `gosec -quiet -fmt=text -exclude-dir=openspec -exclude-dir=docs -exclude-dir=examples ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when checking for release version information by using a dedicated HTTP client with a two-second timeout.
  * Prevented version checks from waiting indefinitely when the release service is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->