### PR TITLE
fix: keep Homebrew formula output in the TUI

### DIFF
--- a/docs/blueprints/directories.md
+++ b/docs/blueprints/directories.md
@@ -48,7 +48,7 @@ The following settings are available for the Directories Blueprint:
 | `group` | string | The group of the directory (applied by `chown`/`chgrp`, and after `create` and `copy`) |
 | `mode` | string | The permissions of the directory. Write a quoted octal string: `mode: "0755"`. A bare `mode: 755` is an **error** - see [File modes](files.md#file-modes). Defaults to `0755` when omitted; required for `chmod` |
 | `elevated` | bool | Read by `copy` only; other directory actions are performed by rwr's own process (default: false) |
-| `interactive` | bool | Override global interactive mode for this directory (`true`/`false`). If omitted, uses the global `--interactive` flag. Controls whether diffs are shown before overwriting existing files during copy operations |
+| `interactive` | bool | Override global interactive mode for this directory (`true`/`false`). If omitted, uses the global `--interactive` flag. Controls whether diffs are shown before overwriting existing files during copy operations. TUI runs keep the diff and Yes/No prompt inside the dashboard; headless runs use terminal input. |
 
 ## Examples
 

--- a/docs/blueprints/users-and-groups.md
+++ b/docs/blueprints/users-and-groups.md
@@ -49,8 +49,9 @@ See [Fields Common to Every Blueprint](common-fields.md) for `profiles`,
 
 Ordinary user-management commands such as macOS `dscl` do not take over the
 terminal merely because the run uses the interactive TUI. RWR performs any
-required sudo authentication through its masked prompt first and keeps the
-command output inside the dashboard. Set an entry's own `interactive: true`
+required sudo authentication through a masked prompt inside the dashboard,
+falling back to its masked terminal prompt in headless runs, and keeps command
+output inside the dashboard. Set an entry's own `interactive: true`
 only when the underlying account-management command genuinely needs direct
 terminal interaction.
 

--- a/docs/blueprints/users-and-groups.md
+++ b/docs/blueprints/users-and-groups.md
@@ -47,6 +47,13 @@ groups:
 See [Fields Common to Every Blueprint](common-fields.md) for `profiles`,
 `import`, `interactive`, and the rule that an unknown key is an error.
 
+Ordinary user-management commands such as macOS `dscl` do not take over the
+terminal merely because the run uses the interactive TUI. RWR performs any
+required sudo authentication through its masked prompt first and keeps the
+command output inside the dashboard. Set an entry's own `interactive: true`
+only when the underlying account-management command genuinely needs direct
+terminal interaction.
+
 ## Actions
 
 `create`, `modify` and `remove` for both users and groups. `delete` is an

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -342,16 +342,12 @@ captures a command's output through pipes, but sudo reads its password from
 escalate is invisible under the dashboard, and the run hangs on a password
 nobody was asked for.
 
-RWR never asks for a password on its own account. Declaring `escalates` only
-changes what happens when sudo is **not** already cached: that command is given
-the real terminal, so if the work itself turns out to need a password the
-prompt is visible and answerable. When sudo is already cached, nothing changes
-and nothing prompts.
-
-That matters because RWR cannot predict which command will need root. Homebrew
-decides cask or formula on its own and the provider declares one install verb
-for both, so a formula install - which never touches root - is
-indistinguishable up front. Asking in advance would ask on every package.
+RWR never asks for a password on its own account. For Homebrew, RWR narrows the
+provider-wide declaration to cask operations using explicit `--cask` or local
+`brew info --json=v2` metadata. Formula operations remain captured in the TUI.
+When a cask may need sudo and credentials are not cached, only that command is
+given the real terminal so its own prompt is visible and answerable. If metadata
+cannot classify a package, RWR fails safe and preserves the terminal handoff.
 
 ## Best Practices
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -342,12 +342,12 @@ captures a command's output through pipes, but sudo reads its password from
 escalate is invisible under the dashboard, and the run hangs on a password
 nobody was asked for.
 
-RWR never asks for a password on its own account. For Homebrew, RWR narrows the
-provider-wide declaration to cask operations using explicit `--cask` or local
-`brew info --json=v2` metadata. Formula operations remain captured in the TUI.
-When a cask may need sudo and credentials are not cached, only that command is
-given the real terminal so its own prompt is visible and answerable. If metadata
-cannot classify a package, RWR fails safe and preserves the terminal handoff.
+For Homebrew, RWR narrows the provider-wide declaration to cask operations using
+explicit `--cask` or local `brew info --json=v2` metadata. Formula operations
+remain captured in the TUI. When an operation really may need sudo and
+credentials are not cached, RWR uses a masked terminal prompt to validate sudo
+once, then runs the actual command captured inside the TUI. If metadata cannot
+classify a package, RWR fails safe and treats it as potentially escalating.
 
 ## Best Practices
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -345,7 +345,8 @@ nobody was asked for.
 For Homebrew, RWR narrows the provider-wide declaration to cask operations using
 explicit `--cask` or local `brew info --json=v2` metadata. Formula operations
 remain captured in the TUI. When an operation really may need sudo and
-credentials are not cached, RWR uses a masked terminal prompt to validate sudo
+credentials are not cached, RWR collects the masked password inside the TUI;
+headless runs fall back to a masked terminal prompt. RWR validates sudo
 once, then runs the actual command captured inside the TUI. If metadata cannot
 classify a package, RWR fails safe and treats it as potentially escalating.
 

--- a/internal/exectest/recorder.go
+++ b/internal/exectest/recorder.go
@@ -13,9 +13,10 @@ import (
 
 // Call is one recorded command.
 type Call struct {
-	Exec     string
-	Args     []string
-	Elevated bool
+	Exec        string
+	Args        []string
+	Elevated    bool
+	Interactive bool
 	// Escalates records a command rwr runs unprivileged that calls sudo
 	// itself, which decides whether the credential cache is warmed first.
 	Escalates bool
@@ -65,14 +66,15 @@ func (r *Recorder) record(cmd types.Command) {
 	args := make([]string, len(cmd.Args))
 	copy(args, cmd.Args)
 	r.Calls = append(r.Calls, Call{
-		Exec:      cmd.Exec,
-		Args:      args,
-		Elevated:  cmd.Elevated,
-		Escalates: cmd.Escalates,
-		AsUser:    cmd.AsUser,
-		LogName:   cmd.LogName,
-		Vars:      cmd.Variables,
-		Stdin:     cmd.Stdin,
+		Exec:        cmd.Exec,
+		Args:        args,
+		Elevated:    cmd.Elevated,
+		Interactive: cmd.Interactive,
+		Escalates:   cmd.Escalates,
+		AsUser:      cmd.AsUser,
+		LogName:     cmd.LogName,
+		Vars:        cmd.Variables,
+		Stdin:       cmd.Stdin,
 	})
 }
 

--- a/internal/processors/all.go
+++ b/internal/processors/all.go
@@ -302,8 +302,6 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 		log.Infof("No changes were made to the system.")
 	}
 
-	reporting.Emit(reporting.RunFinished{Errs: stepErrs})
-
 	// A cancelled run is not a failed one. Whatever was in flight when the
 	// operator stopped it was killed and reported as an error by the
 	// processors that were mid-item, and listing those as failures says rwr
@@ -320,6 +318,7 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 		for _, stepErr := range stepErrs {
 			log.Errorf("Processor %s failed: %v", stepErr.Processor, stepErr.Err)
 		}
+		reporting.Emit(reporting.RunFinished{Errs: stepErrs})
 		return fmt.Errorf("%d processor(s) failed", len(stepErrs))
 	}
 
@@ -328,9 +327,13 @@ func All(initConfig *types.InitConfig, osInfo *types.OSInfo, runOrder []string) 
 	// where every package failed still exited 0.
 	if err := failureError(); err != nil {
 		log.Errorf("RWR run finished with %d failure(s)", failureCount())
+		if initConfig.Variables.Flags.Interactive {
+			reporting.RequestFinalHalt(err)
+		}
 		return err
 	}
 
+	reporting.Emit(reporting.RunFinished{Errs: stepErrs})
 	log.Info("RWR Run Complete!")
 	return nil
 }

--- a/internal/processors/packages.go
+++ b/internal/processors/packages.go
@@ -1,8 +1,10 @@
 package processors
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -13,6 +15,59 @@ import (
 	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/types"
 )
+
+func packageCommandEscalates(provider *types.Provider, args []string, name string, cache map[string]bool) bool {
+	if !provider.Escalates {
+		return false
+	}
+	if filepath.Base(provider.BinPath) != "brew" {
+		return true
+	}
+	for _, arg := range args {
+		switch arg {
+		case "--cask":
+			return true
+		case "--formula":
+			return false
+		}
+	}
+	if escalates, ok := cache[name]; ok {
+		return escalates
+	}
+
+	output, err := system.RunCommandOutput(types.Command{
+		Exec:      provider.BinPath,
+		Args:      []string{"info", "--json=v2", name},
+		Variables: provider.Environment,
+	}, false)
+	if err != nil {
+		cache[name] = true
+		return true
+	}
+	escalates, known := brewMetadataEscalates([]byte(output))
+	if !known {
+		escalates = true
+	}
+	cache[name] = escalates
+	return escalates
+}
+
+func brewMetadataEscalates(data []byte) (escalates, known bool) {
+	var metadata struct {
+		Formulae []json.RawMessage `json:"formulae"`
+		Casks    []json.RawMessage `json:"casks"`
+	}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return false, false
+	}
+	if len(metadata.Casks) > 0 && len(metadata.Formulae) == 0 {
+		return true, true
+	}
+	if len(metadata.Formulae) > 0 && len(metadata.Casks) == 0 {
+		return false, true
+	}
+	return false, false
+}
 
 // ProcessPackages installs or removes packages based on blueprint definitions.
 // It supports two modes:
@@ -84,6 +139,7 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 		names    []string
 	}
 	var units []packageUnit
+	brewEscalationCache := make(map[string]bool)
 	track := newProgress(types.BlueprintTypePackages)
 	for _, pkg := range filteredPackages {
 		// Get provider
@@ -187,7 +243,7 @@ func ProcessPackages(data []byte, packages *types.PackagesData, blueprintDir str
 				// that calls sudo itself, so the credential cache is warmed
 				// before it rather than after it has already hung on a prompt
 				// nobody could see.
-				Escalates: provider.Escalates,
+				Escalates: packageCommandEscalates(provider, args, name, brewEscalationCache),
 				Variables: provider.Environment,
 				// Terminal handover only on an explicit per-item
 				// `interactive: true`. Routing every package through the

--- a/internal/processors/packages_test.go
+++ b/internal/processors/packages_test.go
@@ -679,6 +679,7 @@ packages:
   - name: "brave-browser"
     action: "install"
     package_manager: "brew"
+    args: ["--cask"]
 `)
 	if err := ProcessPackages(blueprint, nil, t.TempDir(), "yaml", &types.OSInfo{}, &types.InitConfig{}); err != nil {
 		t.Fatalf("ProcessPackages: %v", err)
@@ -693,5 +694,52 @@ packages:
 	}
 	if !call.Escalates {
 		t.Error("the command is not marked as escalating, so sudo will not be pre-validated for it")
+	}
+}
+
+func TestBrewMetadataEscalates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		metadata  string
+		escalates bool
+		known     bool
+	}{
+		{name: "formula", metadata: `{"formulae":[{"name":"curl"}],"casks":[]}`, known: true},
+		{name: "cask", metadata: `{"formulae":[],"casks":[{"token":"claude"}]}`, escalates: true, known: true},
+		{name: "ambiguous", metadata: `{"formulae":[{}],"casks":[{}]}`},
+		{name: "invalid", metadata: `{`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			escalates, known := brewMetadataEscalates([]byte(tt.metadata))
+			if escalates != tt.escalates || known != tt.known {
+				t.Errorf("brewMetadataEscalates() = (%v, %v), want (%v, %v)", escalates, known, tt.escalates, tt.known)
+			}
+		})
+	}
+}
+
+func TestPackageCommandEscalatesUsesExplicitBrewKind(t *testing.T) {
+	t.Parallel()
+
+	provider := &types.Provider{Name: "brew", BinPath: "/opt/homebrew/bin/brew", Escalates: true}
+	cache := make(map[string]bool)
+	if packageCommandEscalates(provider, []string{"install", "curl", "--formula"}, "curl", cache) {
+		t.Error("explicit formula was marked as escalating")
+	}
+	if !packageCommandEscalates(provider, []string{"install", "brave-browser", "--cask"}, "brave-browser", cache) {
+		t.Error("explicit cask was not marked as escalating")
+	}
+	cache["curl"] = false
+	cache["claude"] = true
+	if packageCommandEscalates(provider, []string{"install", "curl"}, "curl", cache) {
+		t.Error("metadata-classified formula was marked as escalating")
+	}
+	if !packageCommandEscalates(provider, []string{"install", "claude"}, "claude", cache) {
+		t.Error("metadata-classified cask was not marked as escalating")
 	}
 }

--- a/internal/processors/reporter_output_test.go
+++ b/internal/processors/reporter_output_test.go
@@ -10,6 +10,7 @@ import (
 
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/exectest"
+	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/system"
 	"github.com/fynxlabs/rwr/internal/types"
 )
@@ -89,6 +90,60 @@ func TestAll_HeadlessOutputUnchanged(t *testing.T) {
 			t.Fatalf("output order wrong: %q appears before the previous marker:\n%s", want, out)
 		}
 		last = idx
+	}
+}
+
+type finalFailureReporter struct {
+	halt chan reporting.HaltReq
+}
+
+func (r finalFailureReporter) Emit(event reporting.Event) {
+	if halt, ok := event.(reporting.HaltReq); ok {
+		r.halt <- halt
+		if reporting.TryClaim(halt.Claim) {
+			halt.Decision <- reporting.HaltSkip
+		}
+	}
+}
+
+func TestAll_InteractiveLedgerFailuresWaitForDecision(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "files"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "files", "bad.yaml"), []byte("files:\n  - name: broken\n    action: copy\n    target: "+filepath.Join(dir, "out")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := exectest.New()
+	defer system.SetExecutor(rec)()
+	defer system.SetProvidersForTest(map[string]*types.Provider{})()
+	reporter := finalFailureReporter{halt: make(chan reporting.HaltReq, 1)}
+	defer reporting.Set(reporter)()
+
+	initConfig := &types.InitConfig{}
+	initConfig.Init.Location = dir
+	initConfig.Init.Format = "yaml"
+	initConfig.Variables.Flags.Interactive = true
+	initConfig.Variables.UserDefined = map[string]interface{}{}
+	osInfo := &types.OSInfo{}
+	osInfo.System.OS = runtime.GOOS
+	osInfo.PackageManager.Managers = map[string]types.PackageManagerInfo{"sh": {Name: "sh", Bin: "/bin/sh"}}
+
+	err := All(initConfig, osInfo, []string{"files"})
+	if err == nil {
+		t.Fatal("All returned nil despite the recorded file failure")
+	}
+	select {
+	case halt := <-reporter.halt:
+		if halt.Processor != "run" {
+			t.Fatalf("halt processor = %q, want run", halt.Processor)
+		}
+		if halt.Retryable {
+			t.Fatal("final ledger halt must not offer a full-run retry")
+		}
+	default:
+		t.Fatal("interactive ledger failure returned without requesting a decision")
 	}
 }
 

--- a/internal/processors/user_opendirectory.go
+++ b/internal/processors/user_opendirectory.go
@@ -121,7 +121,7 @@ func createUserDarwin(user types.User, initConfig *types.InitConfig) error {
 		realName = user.Name
 	}
 
-	interactive := helpers.ResolveInteractive(user.Interactive, initConfig.Variables.Flags.Interactive)
+	interactive := helpers.ResolveInteractive(user.Interactive, false)
 
 	if commandExists("sysadminctl") {
 		cmd := types.Command{
@@ -231,7 +231,7 @@ func modifyUserDarwin(user types.User, initConfig *types.InitConfig) error {
 		attrs = append(attrs, [2]string{"NFSHomeDirectory", user.Home})
 	}
 
-	interactive := helpers.ResolveInteractive(user.Interactive, initConfig.Variables.Flags.Interactive)
+	interactive := helpers.ResolveInteractive(user.Interactive, false)
 
 	for _, attr := range attrs {
 		cmd := types.Command{
@@ -301,7 +301,7 @@ func removeUserDarwin(user types.User, initConfig *types.InitConfig) error {
 		return nil
 	}
 
-	interactive := helpers.ResolveInteractive(user.Interactive, initConfig.Variables.Flags.Interactive)
+	interactive := helpers.ResolveInteractive(user.Interactive, false)
 
 	if commandExists("sysadminctl") {
 		// sysadminctl deletes the home directory unless told otherwise, which is

--- a/internal/processors/user_opendirectory_test.go
+++ b/internal/processors/user_opendirectory_test.go
@@ -289,6 +289,21 @@ func TestDarwinUserArgv(t *testing.T) {
 	}
 }
 
+func TestDarwinModifyDoesNotHandNonInteractiveDsclToTerminal(t *testing.T) {
+	rec := platform(t, "darwin", true, true, "")
+	config := newTestInitConfig()
+	config.Variables.Flags.Interactive = true
+
+	if err := modifyUserDarwin(types.User{Name: "levi", NewShell: "/opt/homebrew/bin/fish"}, config); err != nil {
+		t.Fatalf("modifyUserDarwin: %v", err)
+	}
+	for _, call := range rec.Find("dscl") {
+		if call.Interactive {
+			t.Fatalf("noninteractive dscl command was handed the terminal: %v", call)
+		}
+	}
+}
+
 // macOS accepts no crypt hash, so the cleartext rule must not leak onto it.
 func TestDarwinPasswordAcceptsCleartext(t *testing.T) {
 	rec := platform(t, "darwin", true, false, "")

--- a/internal/reporting/reporter.go
+++ b/internal/reporting/reporter.go
@@ -6,6 +6,7 @@
 package reporting
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"sync"
@@ -20,6 +21,20 @@ import (
 type Reporter interface {
 	Emit(Event)
 }
+
+// SupportsInlinePrompts reports whether the active display can collect input
+// without releasing the terminal. The Bubble Tea reporter supports this;
+// LogReporter deliberately leaves the established terminal fallback intact.
+func SupportsInlinePrompts() bool {
+	currentMu.RLock()
+	r := current
+	currentMu.RUnlock()
+	provider, ok := r.(interface{ SupportsInlinePrompts() bool })
+	return ok && provider.SupportsInlinePrompts()
+}
+
+var ErrPromptUnavailable = errors.New("inline prompt unavailable")
+var ErrPromptCancelled = errors.New("prompt cancelled")
 
 // Event is one run occurrence. The concrete set below is closed by design:
 // the display layer switches over it.
@@ -81,6 +96,31 @@ type TerminalFunc struct {
 	Claim *atomic.Bool
 }
 
+type SecretResult struct {
+	Value []byte
+	Err   error
+}
+
+// SecretReq asks the active display to collect a masked value without handing
+// away the terminal. It is used only when SupportsInlinePrompts is true.
+type SecretReq struct {
+	Prompt string
+	Result chan SecretResult
+	Claim  *atomic.Bool
+}
+
+type ConfirmResult struct {
+	Yes bool
+	Err error
+}
+
+// ConfirmReq asks a yes/no question inside the active display.
+type ConfirmReq struct {
+	Prompt string
+	Result chan ConfirmResult
+	Claim  *atomic.Bool
+}
+
 // HaltDecision is the operator's answer to an interactive halt.
 type HaltDecision int
 
@@ -122,6 +162,8 @@ func (LaneUpdate) runEvent()   {}
 func (ResourceDone) runEvent() {}
 func (TerminalReq) runEvent()  {}
 func (TerminalFunc) runEvent() {}
+func (SecretReq) runEvent()    {}
+func (ConfirmReq) runEvent()   {}
 func (HaltReq) runEvent()      {}
 func (RunFinished) runEvent()  {}
 
@@ -174,6 +216,14 @@ func (LogReporter) Emit(event Event) {
 			return
 		}
 		e.Done <- e.Run()
+	case SecretReq:
+		if TryClaim(e.Claim) {
+			e.Result <- SecretResult{Err: ErrPromptUnavailable}
+		}
+	case ConfirmReq:
+		if TryClaim(e.Claim) {
+			e.Result <- ConfirmResult{Err: ErrPromptUnavailable}
+		}
 	case HaltReq:
 		// Headless interactive keeps its historical behavior: the first
 		// processor error aborts the run.
@@ -184,6 +234,44 @@ func (LogReporter) Emit(event Event) {
 	case ProcFinished, LaneUpdate, ResourceDone, RunFinished:
 		// The streaming output never printed these as their own lines; the
 		// processors' own log calls carry the detail.
+	}
+}
+
+func RequestSecret(prompt string) ([]byte, error) {
+	if !SupportsInlinePrompts() {
+		return nil, ErrPromptUnavailable
+	}
+	result := make(chan SecretResult, 1)
+	claim := &atomic.Bool{}
+	Emit(SecretReq{Prompt: prompt, Result: result, Claim: claim})
+	select {
+	case answer := <-result:
+		return answer.Value, answer.Err
+	case <-TerminalLost():
+		if claim.CompareAndSwap(false, true) {
+			return nil, ErrPromptUnavailable
+		}
+		answer := <-result
+		return answer.Value, answer.Err
+	}
+}
+
+func RequestConfirmation(prompt string) (bool, error) {
+	if !SupportsInlinePrompts() {
+		return false, ErrPromptUnavailable
+	}
+	result := make(chan ConfirmResult, 1)
+	claim := &atomic.Bool{}
+	Emit(ConfirmReq{Prompt: prompt, Result: result, Claim: claim})
+	select {
+	case answer := <-result:
+		return answer.Yes, answer.Err
+	case <-TerminalLost():
+		if claim.CompareAndSwap(false, true) {
+			return false, ErrPromptUnavailable
+		}
+		answer := <-result
+		return answer.Yes, answer.Err
 	}
 }
 

--- a/internal/reporting/reporter.go
+++ b/internal/reporting/reporter.go
@@ -137,6 +137,7 @@ const (
 type HaltReq struct {
 	Processor string
 	Err       error
+	Retryable bool
 	Decision  chan HaltDecision
 	// Claim is CAS'd by whoever answers - the operator's keypress or the
 	// terminal-lost fallback - so a decision is made exactly once.
@@ -344,9 +345,20 @@ func TerminalLost() <-chan struct{} {
 // If the dashboard dies before answering, the headless default (abort) is
 // taken rather than blocking forever on a dropped Send.
 func RequestHalt(processor string, err error) HaltDecision {
+	return requestHalt(processor, err, true)
+}
+
+// RequestFinalHalt reports failures collected after all processors have run.
+// Retrying is deliberately unavailable because replaying the entire run could
+// repeat operations that already succeeded.
+func RequestFinalHalt(err error) HaltDecision {
+	return requestHalt("run", err, false)
+}
+
+func requestHalt(processor string, err error, retryable bool) HaltDecision {
 	decision := make(chan HaltDecision, 1)
 	claim := &atomic.Bool{}
-	Emit(HaltReq{Processor: processor, Err: err, Decision: decision, Claim: claim})
+	Emit(HaltReq{Processor: processor, Err: err, Retryable: retryable, Decision: decision, Claim: claim})
 	select {
 	case d := <-decision:
 		return d

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -139,8 +139,12 @@ func TestGitCheckouts(t *testing.T) {
 	if err := os.MkdirAll(repo, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	gitEnv := append(os.Environ(), "GIT_DIR="+filepath.Join(repo, ".git"), "GIT_WORK_TREE="+repo)
 	for _, args := range [][]string{{"init", "-q"}, {"remote", "add", "origin", "https://example.com/org/repo.git"}} {
-		if out, err := exec.Command("git", append([]string{"-C", repo}, args...)...).CombinedOutput(); err != nil {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = gitEnv
+		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("git %v: %v %s", args, err, out)
 		}
 	}

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -148,6 +148,8 @@ func TestGitCheckouts(t *testing.T) {
 			t.Fatalf("git %v: %v %s", args, err, out)
 		}
 	}
+	t.Setenv("GIT_DIR", filepath.Join(t.TempDir(), "wrong.git"))
+	t.Setenv("GIT_WORK_TREE", t.TempDir())
 	checkouts := GitCheckouts([]string{root})
 	if len(checkouts) != 1 || checkouts[0].URL != "https://example.com/org/repo.git" {
 		t.Fatalf("checkouts = %+v", checkouts)

--- a/internal/scan/services_git.go
+++ b/internal/scan/services_git.go
@@ -65,7 +65,9 @@ func GitCheckouts(roots []string) []GitCheckout {
 					continue
 				}
 				url := ""
-				if out, err := exec.Command("git", "-C", dir, "remote", "get-url", "origin").Output(); err == nil { // #nosec G204 -- dir comes from the operator's own filesystem glob; read-only query
+				command := exec.Command("git", "-C", dir, "remote", "get-url", "origin") // #nosec G204 -- dir comes from the operator's own filesystem glob; read-only query
+				command.Env = gitScanEnvironment()
+				if out, err := command.Output(); err == nil {
 					url = strings.TrimSpace(string(out))
 				}
 				checkouts = append(checkouts, GitCheckout{Path: dir, URL: url})
@@ -74,4 +76,22 @@ func GitCheckouts(roots []string) []GitCheckout {
 	}
 	sort.Slice(checkouts, func(i, j int) bool { return checkouts[i].Path < checkouts[j].Path })
 	return checkouts
+}
+
+func gitScanEnvironment() []string {
+	blocked := map[string]bool{
+		"GIT_DIR":              true,
+		"GIT_WORK_TREE":        true,
+		"GIT_COMMON_DIR":       true,
+		"GIT_INDEX_FILE":       true,
+		"GIT_OBJECT_DIRECTORY": true,
+	}
+	env := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if !blocked[name] {
+			env = append(env, entry)
+		}
+	}
+	return env
 }

--- a/internal/system/cancel.go
+++ b/internal/system/cancel.go
@@ -30,6 +30,7 @@ var (
 // function that releases it. Calling it again replaces the previous one, so a
 // second run in the same process starts uncancelled.
 func BeginRun() (release func()) {
+	clearSudoPassword()
 	cancelMu.Lock()
 	defer cancelMu.Unlock()
 
@@ -37,6 +38,7 @@ func BeginRun() (release func()) {
 	runCtx, runCancel = ctx, cancel
 
 	return func() {
+		clearSudoPassword()
 		cancelMu.Lock()
 		defer cancelMu.Unlock()
 		cancel()
@@ -49,6 +51,7 @@ func BeginRun() (release func()) {
 // which matters because it is reached from a signal handler and from the
 // dashboard's key handling at the same time.
 func Cancel() {
+	clearSudoPassword()
 	cancelMu.Lock()
 	cancel := runCancel
 	cancelMu.Unlock()

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -130,6 +130,11 @@ var (
 	sudoValidateMu sync.Mutex
 	sudoProbedAt   time.Time
 	sudoProbeWarm  bool
+	// sudoWarmFromPrompt distinguishes a ticket RWR created for a
+	// self-escalating command from an ambient ticket proven by `sudo -n -v`.
+	// Some macOS sudo policies let the original command use the former but do
+	// not let a later, separately spawned sudo process reuse it.
+	sudoWarmFromPrompt bool
 )
 
 // ErrSudoAuthentication reports that a command requiring sudo could not be
@@ -234,6 +239,7 @@ func resetSudoThrottleForTest() {
 	defer sudoValidateMu.Unlock()
 	sudoProbedAt = time.Time{}
 	sudoProbeWarm = false
+	sudoWarmFromPrompt = false
 }
 
 func sudoCredentialsCached() bool {
@@ -247,8 +253,18 @@ func sudoCredentialsCached() bool {
 	ctx, cancel := context.WithTimeout(RunContext(), sudoProbeTimeout)
 	defer cancel()
 	sudoProbeWarm = sudoProbe(ctx) == nil
+	sudoWarmFromPrompt = false
 	sudoProbedAt = time.Now()
 	return sudoProbeWarm
+}
+
+func sudoCredentialsReusableByManagedCommand() bool {
+	if !sudoCredentialsCached() {
+		return false
+	}
+	sudoValidateMu.Lock()
+	defer sudoValidateMu.Unlock()
+	return !sudoWarmFromPrompt
 }
 
 func ensureSudoCredentials() error {
@@ -266,13 +282,14 @@ func ensureSudoCredentials() error {
 		return err
 	}
 
-	markSudoWarm()
+	markSudoWarm(true)
 	return nil
 }
 
-func markSudoWarm() {
+func markSudoWarm(fromPrompt bool) {
 	sudoValidateMu.Lock()
 	sudoProbeWarm = true
+	sudoWarmFromPrompt = fromPrompt
 	sudoProbedAt = time.Now()
 	sudoValidateMu.Unlock()
 }
@@ -292,7 +309,7 @@ func zeroBytes(value []byte) {
 }
 
 func commandForRun(cmd types.Command) (*exec.Cmd, []byte, error) {
-	if runtime.GOOS == "windows" || (!cmd.Elevated && cmd.AsUser == "") || sudoCredentialsCached() {
+	if runtime.GOOS == "windows" || (!cmd.Elevated && cmd.AsUser == "") || sudoCredentialsReusableByManagedCommand() {
 		return buildCommand(cmd), nil, nil
 	}
 	password, err := sudoPassword()
@@ -420,7 +437,7 @@ func runCommand(cmd types.Command, debug bool) error {
 			return err
 		}
 		if sudoInput != nil {
-			markSudoWarm()
+			markSudoWarm(true)
 		}
 		return nil
 	}
@@ -464,7 +481,7 @@ func runCommand(cmd types.Command, debug bool) error {
 		return err
 	}
 	if sudoInput != nil {
-		markSudoWarm()
+		markSudoWarm(true)
 	}
 
 	return nil
@@ -525,7 +542,7 @@ func runCommandOutput(cmd types.Command, debug bool) (string, error) {
 		return "", err
 	}
 	if sudoInput != nil {
-		markSudoWarm()
+		markSudoWarm(true)
 	}
 
 	return stdout.String(), nil

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -8,6 +8,7 @@ package system
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -22,6 +23,7 @@ import (
 	"charm.land/log/v2"
 	"github.com/fynxlabs/rwr/internal/reporting"
 	"github.com/fynxlabs/rwr/internal/types"
+	"golang.org/x/term"
 )
 
 // buildCommand creates an *exec.Cmd from the given types.Command.
@@ -110,6 +112,12 @@ var (
 	sudoProbeWarm  bool
 )
 
+// ErrSudoAuthentication reports that a command requiring sudo could not be
+// authenticated through the controlled masked prompt.
+var ErrSudoAuthentication = errors.New("sudo authentication failed")
+
+var errNoSudoTerminal = errors.New("sudo credentials are not cached and no terminal is available")
+
 // Escalates is the case the elevation flags alone miss: a command rwr runs
 // unprivileged that calls sudo itself. brew refuses to run as root, so
 // Elevated is false and validation never ran, and then a cask install shelled
@@ -124,12 +132,9 @@ func mayPromptForSudo(cmd types.Command) bool {
 
 // sudoCredentialsCached reports whether sudo would run without asking.
 //
-// It never prompts, and that is the whole point. rwr used to run `sudo -v`
-// itself before any command that might escalate, which meant asking for a
-// password on its own account - and since brew decides cask or formula on its
-// own, and the provider has one install verb for both, "might" was every
-// package. A run of ordinary formulae queued a password prompt a minute for a
-// privilege it never used.
+// It never prompts. A cold result is handled separately by the controlled
+// masked authentication path, and only for a command known to need or invoke
+// sudo. Homebrew formulae are classified before this point and never reach it.
 //
 // sudoProbeArgs is the probe rwr runs. -n is the whole contract: it makes sudo
 // answer from the credential cache or fail, and never prompt. Losing it would
@@ -153,11 +158,54 @@ var sudoProbe = func(ctx context.Context) error {
 	return exec.CommandContext(ctx, sudoProbeArgs[0], sudoProbeArgs[1:]...).Run() // #nosec G204 -- fixed argv, not input
 }
 
+func sudoValidationCommand(ctx context.Context, input []byte) *exec.Cmd {
+	command := exec.CommandContext(ctx, "sudo", "-S", "-p", "", "-v") // #nosec G204 -- fixed argv
+	command.Stdin = bytes.NewReader(input)
+	command.Stdout = io.Discard
+	command.Stderr = os.Stderr
+	return command
+}
+
+var sudoAuthenticate = func(ctx context.Context) error {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return errNoSudoTerminal
+	}
+	return reporting.WithTerminal(func() error {
+		_, _ = fmt.Fprint(os.Stderr, "sudo password: ")
+		password, err := term.ReadPassword(int(os.Stdin.Fd()))
+		_, _ = fmt.Fprintln(os.Stderr)
+		if err != nil {
+			return fmt.Errorf("reading sudo password: %w", err)
+		}
+		defer func() {
+			for i := range password {
+				password[i] = 0
+			}
+		}()
+
+		input := make([]byte, len(password)+1)
+		copy(input, password)
+		input[len(input)-1] = '\n'
+		defer func() {
+			for i := range input {
+				input[i] = 0
+			}
+		}()
+		return sudoValidationCommand(ctx, input).Run()
+	})
+}
+
 // SetSudoProbeForTest substitutes the probe and returns the restore func.
 func SetSudoProbeForTest(probe func(context.Context) error) (restore func()) {
 	previous := sudoProbe
 	sudoProbe = probe
 	return func() { sudoProbe = previous }
+}
+
+func SetSudoAuthenticateForTest(authenticate func(context.Context) error) (restore func()) {
+	previous := sudoAuthenticate
+	sudoAuthenticate = authenticate
+	return func() { sudoAuthenticate = previous }
 }
 
 // resetSudoThrottleForTest clears the probe throttle so a test observes the
@@ -182,6 +230,21 @@ func sudoCredentialsCached() bool {
 	sudoProbeWarm = sudoProbe(ctx) == nil
 	sudoProbedAt = time.Now()
 	return sudoProbeWarm
+}
+
+func ensureSudoCredentials() error {
+	if sudoCredentialsCached() {
+		return nil
+	}
+	if err := sudoAuthenticate(RunContext()); err != nil {
+		return err
+	}
+
+	sudoValidateMu.Lock()
+	sudoProbeWarm = true
+	sudoProbedAt = time.Now()
+	sudoValidateMu.Unlock()
+	return nil
 }
 
 // runOnTerminal hands cmd the real terminal via the display layer, falling
@@ -257,6 +320,16 @@ func runCommand(cmd types.Command, debug bool) error {
 		// os.Stdin instead would hang waiting for a human.
 		command.Stdin = strings.NewReader(cmd.Stdin)
 	}
+	if mayPromptForSudo(cmd) {
+		if err := ensureSudoCredentials(); err != nil {
+			if Cancelled() {
+				return ErrCancelled
+			}
+			if !errors.Is(err, errNoSudoTerminal) {
+				return fmt.Errorf("%w: %v", ErrSudoAuthentication, err)
+			}
+		}
+	}
 
 	if cmd.Interactive {
 		// Interactive commands must reach the terminal directly - capturing
@@ -280,31 +353,6 @@ func runCommand(cmd types.Command, debug bool) error {
 		return nil
 	}
 
-	// A captured command that reaches sudo prompts on /dev/tty, straight past
-	// the pipes rwr captured, so under the dashboard the prompt is invisible
-	// and the run hangs on a password nobody was asked for. That is what hung
-	// a cask install.
-	//
-	// Asking first was the wrong answer to it. rwr cannot tell which brew
-	// command will need root - brew decides cask or formula itself, and the
-	// provider declares one install verb for both - so asking up front asked
-	// on every package, and a formula never needs it.
-	if mayPromptForSudo(cmd) && !sudoCredentialsCached() {
-		// Nothing here asks for a password. If sudo is already cached the
-		// command runs captured as usual and never prompts. If it is not, this
-		// one command gets the terminal, so that if the work itself turns out
-		// to need a password the prompt is visible and answerable - and the
-		// credential it establishes covers the rest of the run.
-		log.Debugf("sudo not cached; running %s on the terminal so any prompt it makes is visible", cmd.Exec)
-		if err := runOnTerminal(command); err != nil {
-			if Cancelled() {
-				return ErrCancelled
-			}
-			log.Errorf("Error running command: %v (stderr above)", err)
-			return err
-		}
-		return nil
-	}
 	{
 		// Under the TUI, captured stderr streams into the log view (the `≫`
 		// lines); headless it streams to the real stderr like the pre-TUI

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -44,6 +44,27 @@ import (
 // matches the previous behavior of running through `cmd /C` without any elevation.
 func buildCommand(cmd types.Command) *exec.Cmd {
 	built := spawn(cmd)
+	configureCommandCancellation(built)
+	return built
+}
+
+// buildAuthenticatedCommand binds a freshly-read password to the exact sudo
+// process that runs the requested command. Some sudo policies do not make a
+// ticket created by a separate `sudo -v` available to the later process.
+func buildAuthenticatedCommand(cmd types.Command) *exec.Cmd {
+	ctx := RunContext()
+	var args []string
+	if cmd.Elevated {
+		args = append([]string{"-S", "-p", "", "--", cmd.Exec}, cmd.Args...)
+	} else {
+		args = append([]string{"-S", "-p", "", "-u", cmd.AsUser, "--", cmd.Exec}, cmd.Args...)
+	}
+	built := exec.CommandContext(ctx, "sudo", args...) // #nosec G204 -- fixed sudo flags followed by discrete command argv
+	configureCommandCancellation(built)
+	return built
+}
+
+func configureCommandCancellation(built *exec.Cmd) {
 	// Cancelling the run kills the command's whole process group, not just the
 	// process rwr spawned: `brew install` is a shell that forks curl and git,
 	// and `sudo pacman` is sudo with pacman underneath. Killing only the direct
@@ -55,7 +76,6 @@ func buildCommand(cmd types.Command) *exec.Cmd {
 	// that leaks a descriptor to a grandchild keeps Wait blocked and the
 	// cancellation the operator asked for never completes.
 	built.WaitDelay = 5 * time.Second
-	return built
 }
 
 // spawn builds the *exec.Cmd for a command, before cancellation is wired onto
@@ -166,33 +186,26 @@ func sudoValidationCommand(ctx context.Context, input []byte) *exec.Cmd {
 	return command
 }
 
-var sudoAuthenticate = func(ctx context.Context) error {
+var sudoValidate = func(ctx context.Context, input []byte) error {
+	return sudoValidationCommand(ctx, input).Run()
+}
+
+var sudoPassword = func() ([]byte, error) {
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return errNoSudoTerminal
+		return nil, errNoSudoTerminal
 	}
-	return reporting.WithTerminal(func() error {
+	var password []byte
+	err := reporting.WithTerminal(func() error {
 		_, _ = fmt.Fprint(os.Stderr, "sudo password: ")
-		password, err := term.ReadPassword(int(os.Stdin.Fd()))
+		var err error
+		password, err = term.ReadPassword(int(os.Stdin.Fd()))
 		_, _ = fmt.Fprintln(os.Stderr)
 		if err != nil {
 			return fmt.Errorf("reading sudo password: %w", err)
 		}
-		defer func() {
-			for i := range password {
-				password[i] = 0
-			}
-		}()
-
-		input := make([]byte, len(password)+1)
-		copy(input, password)
-		input[len(input)-1] = '\n'
-		defer func() {
-			for i := range input {
-				input[i] = 0
-			}
-		}()
-		return sudoValidationCommand(ctx, input).Run()
+		return nil
 	})
+	return password, err
 }
 
 // SetSudoProbeForTest substitutes the probe and returns the restore func.
@@ -202,10 +215,16 @@ func SetSudoProbeForTest(probe func(context.Context) error) (restore func()) {
 	return func() { sudoProbe = previous }
 }
 
-func SetSudoAuthenticateForTest(authenticate func(context.Context) error) (restore func()) {
-	previous := sudoAuthenticate
-	sudoAuthenticate = authenticate
-	return func() { sudoAuthenticate = previous }
+func SetSudoPasswordForTest(prompt func() ([]byte, error)) (restore func()) {
+	previous := sudoPassword
+	sudoPassword = prompt
+	return func() { sudoPassword = previous }
+}
+
+func SetSudoValidateForTest(validate func(context.Context, []byte) error) (restore func()) {
+	previous := sudoValidate
+	sudoValidate = validate
+	return func() { sudoValidate = previous }
 }
 
 // resetSudoThrottleForTest clears the probe throttle so a test observes the
@@ -236,15 +255,56 @@ func ensureSudoCredentials() error {
 	if sudoCredentialsCached() {
 		return nil
 	}
-	if err := sudoAuthenticate(RunContext()); err != nil {
+	password, err := sudoPassword()
+	if err != nil {
+		return err
+	}
+	input := passwordInput(password, "")
+	zeroBytes(password)
+	defer zeroBytes(input)
+	if err := sudoValidate(RunContext(), input); err != nil {
 		return err
 	}
 
+	markSudoWarm()
+	return nil
+}
+
+func markSudoWarm() {
 	sudoValidateMu.Lock()
 	sudoProbeWarm = true
 	sudoProbedAt = time.Now()
 	sudoValidateMu.Unlock()
-	return nil
+}
+
+func passwordInput(password []byte, stdin string) []byte {
+	input := make([]byte, 0, len(password)+1+len(stdin))
+	input = append(input, password...)
+	input = append(input, '\n')
+	input = append(input, stdin...)
+	return input
+}
+
+func zeroBytes(value []byte) {
+	for i := range value {
+		value[i] = 0
+	}
+}
+
+func commandForRun(cmd types.Command) (*exec.Cmd, []byte, error) {
+	if runtime.GOOS == "windows" || (!cmd.Elevated && cmd.AsUser == "") || sudoCredentialsCached() {
+		return buildCommand(cmd), nil, nil
+	}
+	password, err := sudoPassword()
+	if err != nil {
+		if errors.Is(err, errNoSudoTerminal) {
+			return buildCommand(cmd), nil, nil
+		}
+		return nil, nil, fmt.Errorf("%w: %v", ErrSudoAuthentication, err)
+	}
+	input := passwordInput(password, cmd.Stdin)
+	zeroBytes(password)
+	return buildAuthenticatedCommand(cmd), input, nil
 }
 
 // runOnTerminal hands cmd the real terminal via the display layer, falling
@@ -311,16 +371,25 @@ func runCommand(cmd types.Command, debug bool) error {
 		return nil
 	}
 
-	command := buildCommand(cmd)
+	command, sudoInput, err := commandForRun(cmd)
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(sudoInput)
 	setupCommandEnvironment(command, cmd)
 
-	if cmd.Stdin != "" {
+	if sudoInput != nil {
+		command.Stdin = bytes.NewReader(sudoInput)
+		if cmd.Interactive {
+			command.Stdin = io.MultiReader(command.Stdin, os.Stdin)
+		}
+	} else if cmd.Stdin != "" {
 		// Supplied input wins over the terminal even for an interactive command:
 		// the caller is feeding the tool something specific, and inheriting
 		// os.Stdin instead would hang waiting for a human.
 		command.Stdin = strings.NewReader(cmd.Stdin)
 	}
-	if mayPromptForSudo(cmd) {
+	if cmd.Escalates && !cmd.Elevated && cmd.AsUser == "" {
 		if err := ensureSudoCredentials(); err != nil {
 			if Cancelled() {
 				return ErrCancelled
@@ -349,6 +418,9 @@ func runCommand(cmd types.Command, debug bool) error {
 			}
 			log.Errorf("Error running command: %v (stderr above)", err)
 			return err
+		}
+		if sudoInput != nil {
+			markSudoWarm()
 		}
 		return nil
 	}
@@ -391,6 +463,9 @@ func runCommand(cmd types.Command, debug bool) error {
 		log.Errorf("Error running command: %v (stderr above)", err)
 		return err
 	}
+	if sudoInput != nil {
+		markSudoWarm()
+	}
 
 	return nil
 }
@@ -412,7 +487,7 @@ func runCommandOutput(cmd types.Command, debug bool) (string, error) {
 		log.Infof("[DRY-RUN] Would execute: %s %s", cmd.Exec, strings.Join(cmd.LogArgs(), " "))
 		return "", nil
 	}
-	if mayPromptForSudo(cmd) {
+	if cmd.Escalates && !cmd.Elevated && cmd.AsUser == "" {
 		if err := ensureSudoCredentials(); err != nil {
 			if Cancelled() {
 				return "", ErrCancelled
@@ -423,18 +498,24 @@ func runCommandOutput(cmd types.Command, debug bool) (string, error) {
 		}
 	}
 
-	command := buildCommand(cmd)
+	command, sudoInput, err := commandForRun(cmd)
+	if err != nil {
+		return "", err
+	}
+	defer zeroBytes(sudoInput)
 	setupCommandEnvironment(command, cmd)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	if cmd.Stdin != "" {
+	if sudoInput != nil {
+		command.Stdin = bytes.NewReader(sudoInput)
+	} else if cmd.Stdin != "" {
 		command.Stdin = strings.NewReader(cmd.Stdin)
 	}
 	command.Stdout = &stdout
 	command.Stderr = &stderr
 
-	err := command.Run()
+	err = command.Run()
 	if err != nil {
 		if Cancelled() {
 			return "", ErrCancelled
@@ -442,6 +523,9 @@ func runCommandOutput(cmd types.Command, debug bool) (string, error) {
 		errMsg := fmt.Sprintf("Error running command: %v\nStderr: %s", err, stderr.String())
 		log.Error(errMsg)
 		return "", err
+	}
+	if sudoInput != nil {
+		markSudoWarm()
 	}
 
 	return stdout.String(), nil

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -65,11 +65,11 @@ func spawn(cmd types.Command) *exec.Cmd {
 	if runtime.GOOS != "windows" {
 		if cmd.Elevated {
 			log.Debugf("Running command as sudo - Running Command: %v %v", cmd.Exec, cmd.LogArgs())
-			return exec.CommandContext(ctx, "sudo", append([]string{"--", cmd.Exec}, cmd.Args...)...) // #nosec G204 -- argv, not a shell string: args are passed as discrete arguments
+			return exec.CommandContext(ctx, "sudo", append([]string{"-n", "--", cmd.Exec}, cmd.Args...)...) // #nosec G204 -- argv, not a shell string: args are passed as discrete arguments
 		}
 		if cmd.AsUser != "" {
 			log.Debugf("Running command as user: %v - Running Command: %v %v", cmd.AsUser, cmd.Exec, cmd.LogArgs())
-			return exec.CommandContext(ctx, "sudo", append([]string{"-u", cmd.AsUser, "--", cmd.Exec}, cmd.Args...)...) // #nosec G204 -- argv, not a shell string: args are passed as discrete arguments
+			return exec.CommandContext(ctx, "sudo", append([]string{"-n", "-u", cmd.AsUser, "--", cmd.Exec}, cmd.Args...)...) // #nosec G204 -- argv, not a shell string: args are passed as discrete arguments
 		}
 	} else if cmd.Elevated {
 		log.Debugf("Elevated requested on Windows; running in-process (no sudo equivalent): %v %v", cmd.Exec, cmd.LogArgs())
@@ -411,6 +411,16 @@ func runCommandOutput(cmd types.Command, debug bool) (string, error) {
 	if dryRunMode {
 		log.Infof("[DRY-RUN] Would execute: %s %s", cmd.Exec, strings.Join(cmd.LogArgs(), " "))
 		return "", nil
+	}
+	if mayPromptForSudo(cmd) {
+		if err := ensureSudoCredentials(); err != nil {
+			if Cancelled() {
+				return "", ErrCancelled
+			}
+			if !errors.Is(err, errNoSudoTerminal) {
+				return "", fmt.Errorf("%w: %v", ErrSudoAuthentication, err)
+			}
+		}
 	}
 
 	command := buildCommand(cmd)

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -296,20 +296,32 @@ func ensureSudoCredentials() error {
 	if sudoCredentialsCached() {
 		return nil
 	}
-	password, err := sudoPassword()
+	password, err := validatedSudoPassword()
 	if err != nil {
 		return err
 	}
-	input := passwordInput(password, "")
 	zeroBytes(password)
-	defer zeroBytes(input)
-	if err := sudoValidate(RunContext(), input); err != nil {
-		return err
-	}
-	cacheSudoPassword(input[:len(input)-1])
-
 	markSudoWarm(true)
 	return nil
+}
+
+func validatedSudoPassword() ([]byte, error) {
+	if password := cachedSudoPassword(); len(password) != 0 {
+		return password, nil
+	}
+	password, err := sudoPassword()
+	if err != nil {
+		return nil, err
+	}
+	input := passwordInput(password, "")
+	defer zeroBytes(input)
+	if err := sudoValidate(RunContext(), input); err != nil {
+		zeroBytes(password)
+		clearSudoPassword()
+		return nil, err
+	}
+	cacheSudoPassword(password)
+	return password, nil
 }
 
 func markSudoWarm(fromPrompt bool) {
@@ -338,17 +350,12 @@ func commandForRun(cmd types.Command) (*exec.Cmd, []byte, error) {
 	if runtime.GOOS == "windows" || (!cmd.Elevated && cmd.AsUser == "") || sudoCredentialsReusableByManagedCommand() {
 		return buildCommand(cmd), nil, nil
 	}
-	password := cachedSudoPassword()
-	if len(password) == 0 {
-		var err error
-		password, err = sudoPassword()
-		if err != nil {
-			if errors.Is(err, errNoSudoTerminal) {
-				return buildCommand(cmd), nil, nil
-			}
-			return nil, nil, fmt.Errorf("%w: %v", ErrSudoAuthentication, err)
+	password, err := validatedSudoPassword()
+	if err != nil {
+		if errors.Is(err, errNoSudoTerminal) {
+			return buildCommand(cmd), nil, nil
 		}
-		cacheSudoPassword(password)
+		return nil, nil, fmt.Errorf("%w: %v", ErrSudoAuthentication, err)
 	}
 	input := passwordInput(password, cmd.Stdin)
 	zeroBytes(password)
@@ -456,9 +463,6 @@ func runCommand(cmd types.Command, debug bool) error {
 		// a TUI suspends itself around the child instead. This path also
 		// serves per-item `interactive: true` inside non-interactive runs.
 		if err := runOnTerminal(command); err != nil {
-			if sudoInput != nil {
-				clearSudoPassword()
-			}
 			// An interactive command reaches the terminal directly, so a
 			// cancelled one comes back as its kill status rather than through
 			// the context. Without this it reports "signal: killed" and gets
@@ -503,9 +507,6 @@ func runCommand(cmd types.Command, debug bool) error {
 	}
 
 	if err := command.Run(); err != nil {
-		if sudoInput != nil {
-			clearSudoPassword()
-		}
 		// A command killed by cancellation exits non-zero like any failure.
 		// Reporting it as one would fill the summary with "signal: killed"
 		// for work the operator deliberately stopped.
@@ -571,9 +572,6 @@ func runCommandOutput(cmd types.Command, debug bool) (string, error) {
 
 	err = command.Run()
 	if err != nil {
-		if sudoInput != nil {
-			clearSudoPassword()
-		}
 		if Cancelled() {
 			return "", ErrCancelled
 		}

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -135,6 +135,9 @@ var (
 	// Some macOS sudo policies let the original command use the former but do
 	// not let a later, separately spawned sudo process reuse it.
 	sudoWarmFromPrompt bool
+	// Retained only for this run so separately-scoped sudo processes do not
+	// ask for the same password repeatedly. Callers receive disposable copies.
+	sudoRunPassword []byte
 )
 
 // ErrSudoAuthentication reports that a command requiring sudo could not be
@@ -240,6 +243,28 @@ func resetSudoThrottleForTest() {
 	sudoProbedAt = time.Time{}
 	sudoProbeWarm = false
 	sudoWarmFromPrompt = false
+	zeroBytes(sudoRunPassword)
+	sudoRunPassword = nil
+}
+
+func cacheSudoPassword(password []byte) {
+	sudoValidateMu.Lock()
+	defer sudoValidateMu.Unlock()
+	zeroBytes(sudoRunPassword)
+	sudoRunPassword = append([]byte(nil), password...)
+}
+
+func cachedSudoPassword() []byte {
+	sudoValidateMu.Lock()
+	defer sudoValidateMu.Unlock()
+	return append([]byte(nil), sudoRunPassword...)
+}
+
+func clearSudoPassword() {
+	sudoValidateMu.Lock()
+	defer sudoValidateMu.Unlock()
+	zeroBytes(sudoRunPassword)
+	sudoRunPassword = nil
 }
 
 func sudoCredentialsCached() bool {
@@ -281,6 +306,7 @@ func ensureSudoCredentials() error {
 	if err := sudoValidate(RunContext(), input); err != nil {
 		return err
 	}
+	cacheSudoPassword(input[:len(input)-1])
 
 	markSudoWarm(true)
 	return nil
@@ -312,12 +338,17 @@ func commandForRun(cmd types.Command) (*exec.Cmd, []byte, error) {
 	if runtime.GOOS == "windows" || (!cmd.Elevated && cmd.AsUser == "") || sudoCredentialsReusableByManagedCommand() {
 		return buildCommand(cmd), nil, nil
 	}
-	password, err := sudoPassword()
-	if err != nil {
-		if errors.Is(err, errNoSudoTerminal) {
-			return buildCommand(cmd), nil, nil
+	password := cachedSudoPassword()
+	if len(password) == 0 {
+		var err error
+		password, err = sudoPassword()
+		if err != nil {
+			if errors.Is(err, errNoSudoTerminal) {
+				return buildCommand(cmd), nil, nil
+			}
+			return nil, nil, fmt.Errorf("%w: %v", ErrSudoAuthentication, err)
 		}
-		return nil, nil, fmt.Errorf("%w: %v", ErrSudoAuthentication, err)
+		cacheSudoPassword(password)
 	}
 	input := passwordInput(password, cmd.Stdin)
 	zeroBytes(password)
@@ -425,6 +456,9 @@ func runCommand(cmd types.Command, debug bool) error {
 		// a TUI suspends itself around the child instead. This path also
 		// serves per-item `interactive: true` inside non-interactive runs.
 		if err := runOnTerminal(command); err != nil {
+			if sudoInput != nil {
+				clearSudoPassword()
+			}
 			// An interactive command reaches the terminal directly, so a
 			// cancelled one comes back as its kill status rather than through
 			// the context. Without this it reports "signal: killed" and gets
@@ -469,6 +503,9 @@ func runCommand(cmd types.Command, debug bool) error {
 	}
 
 	if err := command.Run(); err != nil {
+		if sudoInput != nil {
+			clearSudoPassword()
+		}
 		// A command killed by cancellation exits non-zero like any failure.
 		// Reporting it as one would fill the summary with "signal: killed"
 		// for work the operator deliberately stopped.
@@ -534,6 +571,9 @@ func runCommandOutput(cmd types.Command, debug bool) (string, error) {
 
 	err = command.Run()
 	if err != nil {
+		if sudoInput != nil {
+			clearSudoPassword()
+		}
 		if Cancelled() {
 			return "", ErrCancelled
 		}

--- a/internal/system/commands.go
+++ b/internal/system/commands.go
@@ -199,6 +199,9 @@ var sudoValidate = func(ctx context.Context, input []byte) error {
 }
 
 var sudoPassword = func() ([]byte, error) {
+	if reporting.SupportsInlinePrompts() {
+		return reporting.RequestSecret("sudo password")
+	}
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return nil, errNoSudoTerminal
 	}

--- a/internal/system/commands_test.go
+++ b/internal/system/commands_test.go
@@ -148,7 +148,7 @@ func TestBuildCommand_ShellMetacharactersAreNotInterpreted(t *testing.T) {
 				Elevated: true,
 			})
 
-			want := []string{"sudo", "--", "pacman", "-S", payload}
+			want := []string{"sudo", "-n", "--", "pacman", "-S", payload}
 			if !equalArgs(argv, want) {
 				t.Fatalf("argv = %#v, want %#v", argv, want)
 			}
@@ -215,17 +215,17 @@ func TestBuildCommand_Elevation(t *testing.T) {
 		{
 			name: "elevated prefixes sudo with -- terminator",
 			cmd:  types.Command{Exec: "apt", Args: []string{"install", "jq"}, Elevated: true},
-			want: []string{"sudo", "--", "apt", "install", "jq"},
+			want: []string{"sudo", "-n", "--", "apt", "install", "jq"},
 		},
 		{
 			name: "as-user uses sudo -u",
 			cmd:  types.Command{Exec: "paru", Args: []string{"-S", "jq"}, AsUser: "levi"},
-			want: []string{"sudo", "-u", "levi", "--", "paru", "-S", "jq"},
+			want: []string{"sudo", "-n", "-u", "levi", "--", "paru", "-S", "jq"},
 		},
 		{
 			name: "elevated wins over as-user",
 			cmd:  types.Command{Exec: "apt", Args: []string{"update"}, Elevated: true, AsUser: "levi"},
-			want: []string{"sudo", "--", "apt", "update"},
+			want: []string{"sudo", "-n", "--", "apt", "update"},
 		},
 	}
 

--- a/internal/system/diff.go
+++ b/internal/system/diff.go
@@ -198,6 +198,12 @@ func terminalShape() (int, int, error) {
 
 // ShowDiff displays a colored unified diff between two files to stdout.
 func ShowDiff(source, target string) error {
+	return ShowDiffTo(os.Stdout, source, target)
+}
+
+// ShowDiffTo writes the diff to writer so a TUI run can keep it inside the
+// dashboard log panel instead of tearing down the frame to print directly.
+func ShowDiffTo(writer io.Writer, source, target string) error {
 	sourceContent, err := os.ReadFile(source) // #nosec G304 -- path is operator-supplied blueprint/config input; containment added in PR8
 	if err != nil {
 		return err
@@ -227,7 +233,7 @@ func ShowDiff(source, target string) error {
 	}
 
 	// Write the diff output
-	err = WriteUnifiedDiff(os.Stdout, diff, opt)
+	err = WriteUnifiedDiff(writer, diff, opt)
 	if err != nil {
 		return err
 	}

--- a/internal/system/files.go
+++ b/internal/system/files.go
@@ -653,11 +653,12 @@ func CopyFile(source, target string, elevated bool, osInfo *types.OSInfo) error 
 }
 
 func setFilePermissionsElevated(path string, mode os.FileMode) error {
-	// "--" so a path starting with "-" can never be read as a chmod option:
-	// the path comes from blueprint values, and the command runs as root.
+	// filepath targets are resolved before this point, so they are absolute and
+	// cannot be read as options. BSD chmod (macOS) does not accept GNU's `--`
+	// after MODE; it treats it as a filename and fails every elevated copy.
 	cmd := types.Command{
 		Exec:     "chmod",
-		Args:     []string{fmt.Sprintf("%o", mode), "--", path},
+		Args:     []string{fmt.Sprintf("%o", mode), path},
 		Elevated: true,
 	}
 	return RunCommand(cmd, false)

--- a/internal/system/files.go
+++ b/internal/system/files.go
@@ -720,17 +720,17 @@ func CopyDirectory(source, target string, elevated, interactive bool) error {
 				// reading stdin over the dashboard tore the viewport and
 				// fought it for keystrokes.
 				if interactive {
-					var overwrite bool
-					promptErr := reporting.WithTerminal(func() error {
-						fmt.Printf("File '%s' already exists at the target location.\n", targetPath)
-						fmt.Printf("Diff:\n")
-						if diffErr := ShowDiff(path, targetPath); diffErr != nil {
-							log.Errorf("Failed to show diff: %v", diffErr)
-						}
-						var innerErr error
-						overwrite, innerErr = promptOverwrite()
-						return innerErr
-					})
+					writer := io.Writer(os.Stdout)
+					if captured := reporting.CommandOutputWriter(reporting.SrcStdout); captured != nil {
+						writer = captured
+					}
+					if _, writeErr := fmt.Fprintf(writer, "File %q already exists at the target location.\nDiff:\n", targetPath); writeErr != nil {
+						return fmt.Errorf("writing overwrite notice: %w", writeErr)
+					}
+					if diffErr := ShowDiffTo(writer, path, targetPath); diffErr != nil {
+						log.Errorf("Failed to show diff: %v", diffErr)
+					}
+					overwrite, promptErr := promptOverwrite(targetPath)
 					if promptErr != nil {
 						return promptErr
 					}
@@ -806,10 +806,17 @@ func LookupGID(group string) (int, error) {
 // log.Fatalf here bypassed the failure ledger and every deferred cleanup, and
 // interactive defaults to true, so a piped stdin hitting EOF killed the whole
 // run mid-flight.
-func promptOverwrite() (bool, error) {
+func promptOverwrite(path string) (bool, error) {
+	if reporting.SupportsInlinePrompts() {
+		return reporting.RequestConfirmation(fmt.Sprintf("Overwrite existing file? %s", path))
+	}
 	var input string
-	fmt.Print("Do you want to overwrite the file? (y/n): ")
-	if _, err := fmt.Scanln(&input); err != nil {
+	err := reporting.WithTerminal(func() error {
+		fmt.Print("Do you want to overwrite the file? (y/n): ")
+		_, err := fmt.Scanln(&input)
+		return err
+	})
+	if err != nil {
 		return false, fmt.Errorf("reading overwrite confirmation (run with --interactive=false to skip prompts): %w", err)
 	}
 	return strings.EqualFold(input, "y") || strings.EqualFold(input, "yes"), nil

--- a/internal/system/files_test.go
+++ b/internal/system/files_test.go
@@ -8,7 +8,27 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/fynxlabs/rwr/internal/exectest"
 )
+
+func TestSetFilePermissionsElevatedUsesBSDCompatibleArgv(t *testing.T) {
+	rec := exectest.New()
+	defer SetExecutor(rec)()
+	if err := setFilePermissionsElevated("/Library/Fonts/Hack.ttf", 0o644); err != nil {
+		t.Fatalf("setFilePermissionsElevated: %v", err)
+	}
+	if len(rec.Calls) != 1 {
+		t.Fatalf("calls = %d, want 1", len(rec.Calls))
+	}
+	call := rec.Calls[0]
+	if got, want := strings.Join(call.Args, " "), "644 /Library/Fonts/Hack.ttf"; got != want {
+		t.Fatalf("chmod args = %q, want %q", got, want)
+	}
+	if !call.Elevated {
+		t.Fatal("chmod command was not elevated")
+	}
+}
 
 // Commands are argv now, so no shell expands a leading ~ on the way to a
 // program. Every blueprint path that reaches a command or a filesystem call has

--- a/internal/system/sudo_escalation_test.go
+++ b/internal/system/sudo_escalation_test.go
@@ -229,6 +229,37 @@ func TestColdProbeAuthenticatesOnceAndKeepsCommandsCaptured(t *testing.T) {
 	}
 }
 
+func TestPromptWarmedCredentialIsNotReusedBySeparateManagedSudo(t *testing.T) {
+	if runtime.GOOS == types.OSWindows {
+		t.Skip("no sudo on windows")
+	}
+
+	defer SetSudoProbeForTest(func(context.Context) error { return errors.New("cold") })()
+	var prompts int
+	defer SetSudoPasswordForTest(func() ([]byte, error) {
+		prompts++
+		return []byte("test password"), nil
+	})()
+	defer SetSudoValidateForTest(func(context.Context, []byte) error { return nil })()
+	resetSudoThrottleForTest()
+	defer resetSudoThrottleForTest()
+
+	if err := ensureSudoCredentials(); err != nil {
+		t.Fatalf("warming for self-escalating command: %v", err)
+	}
+	command, input, err := commandForRun(types.Command{Exec: "dscl", Elevated: true})
+	defer zeroBytes(input)
+	if err != nil {
+		t.Fatalf("commandForRun: %v", err)
+	}
+	if prompts != 2 {
+		t.Fatalf("password prompts = %d, want a separate prompt for the managed sudo command", prompts)
+	}
+	if !slices.Equal(command.Args, []string{"sudo", "-S", "-p", "", "--", "dscl"}) {
+		t.Fatalf("managed command argv = %q, want password-bound sudo", command.Args)
+	}
+}
+
 func TestSudoAuthenticationFailureStopsTheCommand(t *testing.T) {
 	if runtime.GOOS == types.OSWindows {
 		t.Skip("no sudo on windows")

--- a/internal/system/sudo_escalation_test.go
+++ b/internal/system/sudo_escalation_test.go
@@ -92,6 +92,36 @@ func TestSudoValidationKeepsPasswordOutOfArgv(t *testing.T) {
 	}
 }
 
+func TestAuthenticatedCommandRunsTheTargetInThePasswordReceivingSudo(t *testing.T) {
+	t.Parallel()
+
+	command := buildAuthenticatedCommand(types.Command{
+		Exec:     "dscl",
+		Args:     []string{".", "-create", "/Users/levi", "UserShell", "/opt/homebrew/bin/fish"},
+		Elevated: true,
+	})
+	want := []string{"sudo", "-S", "-p", "", "--", "dscl", ".", "-create", "/Users/levi", "UserShell", "/opt/homebrew/bin/fish"}
+	if !slices.Equal(command.Args, want) {
+		t.Fatalf("authenticated argv = %q, want %q", command.Args, want)
+	}
+}
+
+func TestPasswordInputKeepsSecretOutOfArgvAndPreservesCommandInput(t *testing.T) {
+	t.Parallel()
+
+	password := []byte("correct horse battery staple")
+	input := passwordInput(password, "target input\n")
+	if got, want := string(input), "correct horse battery staple\ntarget input\n"; got != want {
+		t.Fatalf("stdin = %q, want %q", got, want)
+	}
+	command := buildAuthenticatedCommand(types.Command{Exec: "chpasswd", Elevated: true})
+	for _, arg := range command.Args {
+		if strings.Contains(arg, "correct horse") {
+			t.Fatal("password appeared in sudo argv")
+		}
+	}
+}
+
 // A cold cache is reported as cold, and does not prompt on the way there.
 func TestSudoCredentialsCachedWhenTheProbeFails(t *testing.T) {
 	defer SetSudoProbeForTest(func(context.Context) error { return errors.New("a password is required") })()
@@ -169,10 +199,11 @@ func TestColdProbeAuthenticatesOnceAndKeepsCommandsCaptured(t *testing.T) {
 		return errors.New("a password is required")
 	})()
 	var authentications int
-	defer SetSudoAuthenticateForTest(func(context.Context) error {
+	defer SetSudoPasswordForTest(func() ([]byte, error) {
 		authentications++
-		return nil
+		return []byte("test password"), nil
 	})()
+	defer SetSudoValidateForTest(func(context.Context, []byte) error { return nil })()
 	resetSudoThrottleForTest()
 	defer resetSudoThrottleForTest()
 
@@ -204,7 +235,7 @@ func TestSudoAuthenticationFailureStopsTheCommand(t *testing.T) {
 	}
 
 	defer SetSudoProbeForTest(func(context.Context) error { return errors.New("cold") })()
-	defer SetSudoAuthenticateForTest(func(context.Context) error { return errors.New("denied") })()
+	defer SetSudoPasswordForTest(func() ([]byte, error) { return nil, errors.New("denied") })()
 	resetSudoThrottleForTest()
 	defer resetSudoThrottleForTest()
 
@@ -220,7 +251,7 @@ func TestNoTerminalLeavesCommandScopedNopasswdPathAvailable(t *testing.T) {
 	}
 
 	defer SetSudoProbeForTest(func(context.Context) error { return errors.New("cold") })()
-	defer SetSudoAuthenticateForTest(func(context.Context) error { return errNoSudoTerminal })()
+	defer SetSudoPasswordForTest(func() ([]byte, error) { return nil, errNoSudoTerminal })()
 	resetSudoThrottleForTest()
 	defer resetSudoThrottleForTest()
 

--- a/internal/system/sudo_escalation_test.go
+++ b/internal/system/sudo_escalation_test.go
@@ -236,27 +236,36 @@ func TestPromptedPasswordIsReusedBySeparateManagedSudo(t *testing.T) {
 
 	defer SetSudoProbeForTest(func(context.Context) error { return errors.New("cold") })()
 	var prompts int
+	var validations int
 	defer SetSudoPasswordForTest(func() ([]byte, error) {
 		prompts++
 		return []byte("test password"), nil
 	})()
-	defer SetSudoValidateForTest(func(context.Context, []byte) error { return nil })()
+	defer SetSudoValidateForTest(func(context.Context, []byte) error {
+		validations++
+		return nil
+	})()
 	resetSudoThrottleForTest()
 	defer resetSudoThrottleForTest()
 
 	if err := ensureSudoCredentials(); err != nil {
 		t.Fatalf("warming for self-escalating command: %v", err)
 	}
-	command, input, err := commandForRun(types.Command{Exec: "dscl", Elevated: true})
-	defer zeroBytes(input)
-	if err != nil {
-		t.Fatalf("commandForRun: %v", err)
+	for range 2 {
+		command, input, err := commandForRun(types.Command{Exec: "dscl", Elevated: true})
+		if err != nil {
+			t.Fatalf("commandForRun: %v", err)
+		}
+		if !slices.Equal(command.Args, []string{"sudo", "-S", "-p", "", "--", "dscl"}) {
+			t.Fatalf("managed command argv = %q, want password-bound sudo", command.Args)
+		}
+		zeroBytes(input)
 	}
 	if prompts != 1 {
 		t.Fatalf("password prompts = %d, want the run-scoped password reused", prompts)
 	}
-	if !slices.Equal(command.Args, []string{"sudo", "-S", "-p", "", "--", "dscl"}) {
-		t.Fatalf("managed command argv = %q, want password-bound sudo", command.Args)
+	if validations != 1 {
+		t.Fatalf("password validations = %d, want one", validations)
 	}
 }
 

--- a/internal/system/sudo_escalation_test.go
+++ b/internal/system/sudo_escalation_test.go
@@ -229,7 +229,7 @@ func TestColdProbeAuthenticatesOnceAndKeepsCommandsCaptured(t *testing.T) {
 	}
 }
 
-func TestPromptWarmedCredentialIsNotReusedBySeparateManagedSudo(t *testing.T) {
+func TestPromptedPasswordIsReusedBySeparateManagedSudo(t *testing.T) {
 	if runtime.GOOS == types.OSWindows {
 		t.Skip("no sudo on windows")
 	}
@@ -252,11 +252,30 @@ func TestPromptWarmedCredentialIsNotReusedBySeparateManagedSudo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commandForRun: %v", err)
 	}
-	if prompts != 2 {
-		t.Fatalf("password prompts = %d, want a separate prompt for the managed sudo command", prompts)
+	if prompts != 1 {
+		t.Fatalf("password prompts = %d, want the run-scoped password reused", prompts)
 	}
 	if !slices.Equal(command.Args, []string{"sudo", "-S", "-p", "", "--", "dscl"}) {
 		t.Fatalf("managed command argv = %q, want password-bound sudo", command.Args)
+	}
+}
+
+func TestRunLifecycleErasesCachedSudoPassword(t *testing.T) {
+	resetSudoThrottleForTest()
+	defer resetSudoThrottleForTest()
+
+	cacheSudoPassword([]byte("temporary secret"))
+	release := BeginRun()
+	if password := cachedSudoPassword(); len(password) != 0 {
+		zeroBytes(password)
+		t.Fatal("BeginRun retained a password from an earlier run")
+	}
+
+	cacheSudoPassword([]byte("current run secret"))
+	release()
+	if password := cachedSudoPassword(); len(password) != 0 {
+		zeroBytes(password)
+		t.Fatal("run release retained the current run password")
 	}
 }
 

--- a/internal/system/sudo_escalation_test.go
+++ b/internal/system/sudo_escalation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -76,6 +77,21 @@ func TestSudoProbeIsNonInteractive(t *testing.T) {
 	}
 }
 
+func TestSudoValidationKeepsPasswordOutOfArgv(t *testing.T) {
+	t.Parallel()
+
+	password := []byte("correct horse battery staple\n")
+	command := sudoValidationCommand(context.Background(), password)
+	if want := []string{"sudo", "-S", "-p", "", "-v"}; !slices.Equal(command.Args, want) {
+		t.Fatalf("validation argv = %q, want %q", command.Args, want)
+	}
+	for _, arg := range command.Args {
+		if strings.Contains(arg, "correct horse") {
+			t.Fatal("password appeared in sudo argv")
+		}
+	}
+}
+
 // A cold cache is reported as cold, and does not prompt on the way there.
 func TestSudoCredentialsCachedWhenTheProbeFails(t *testing.T) {
 	defer SetSudoProbeForTest(func(context.Context) error { return errors.New("a password is required") })()
@@ -141,16 +157,21 @@ func TestSudoProbeIsThrottledWhileCold(t *testing.T) {
 	}
 }
 
-// Throttling a cold probe must only spare the probe process. It must not route
-// later commands back through captured execution, where a password prompt made
-// by the command would disappear behind the dashboard.
-func TestThrottledColdProbeStillHandsEveryCommandTheTerminal(t *testing.T) {
+// A cold probe authenticates once through the controlled password path. The
+// actual commands remain captured, so raw package and user-management output
+// cannot collide with the dashboard.
+func TestColdProbeAuthenticatesOnceAndKeepsCommandsCaptured(t *testing.T) {
 	if runtime.GOOS == types.OSWindows {
 		t.Skip("no sudo on windows")
 	}
 
 	defer SetSudoProbeForTest(func(context.Context) error {
 		return errors.New("a password is required")
+	})()
+	var authentications int
+	defer SetSudoAuthenticateForTest(func(context.Context) error {
+		authentications++
+		return nil
 	})()
 	resetSudoThrottleForTest()
 	defer resetSudoThrottleForTest()
@@ -169,8 +190,42 @@ func TestThrottledColdProbeStillHandsEveryCommandTheTerminal(t *testing.T) {
 			handovers++
 		}
 	}
-	if handovers != 2 {
-		t.Errorf("terminal handovers = %d, want one for each cold command", handovers)
+	if authentications != 1 {
+		t.Errorf("authentications = %d, want one", authentications)
+	}
+	if handovers != 0 {
+		t.Errorf("command terminal handovers = %d, want none", handovers)
+	}
+}
+
+func TestSudoAuthenticationFailureStopsTheCommand(t *testing.T) {
+	if runtime.GOOS == types.OSWindows {
+		t.Skip("no sudo on windows")
+	}
+
+	defer SetSudoProbeForTest(func(context.Context) error { return errors.New("cold") })()
+	defer SetSudoAuthenticateForTest(func(context.Context) error { return errors.New("denied") })()
+	resetSudoThrottleForTest()
+	defer resetSudoThrottleForTest()
+
+	err := RunCommand(types.Command{Exec: "true", Elevated: true}, false)
+	if !errors.Is(err, ErrSudoAuthentication) {
+		t.Fatalf("RunCommand error = %v, want ErrSudoAuthentication", err)
+	}
+}
+
+func TestNoTerminalLeavesCommandScopedNopasswdPathAvailable(t *testing.T) {
+	if runtime.GOOS == types.OSWindows {
+		t.Skip("no sudo on windows")
+	}
+
+	defer SetSudoProbeForTest(func(context.Context) error { return errors.New("cold") })()
+	defer SetSudoAuthenticateForTest(func(context.Context) error { return errNoSudoTerminal })()
+	resetSudoThrottleForTest()
+	defer resetSudoThrottleForTest()
+
+	if err := runCommand(types.Command{Exec: "true", Escalates: true}, false); err != nil {
+		t.Fatalf("headless command was rejected before its own policy could run: %v", err)
 	}
 }
 

--- a/internal/tui/activate.go
+++ b/internal/tui/activate.go
@@ -58,3 +58,7 @@ func NewReporter(program *tea.Program) *Reporter { return &Reporter{program: pro
 
 // Emit implements reporting.Reporter.
 func (r *Reporter) Emit(e reporting.Event) { r.program.Send(event{e: e}) }
+
+// SupportsInlinePrompts lets processors ask through the running model instead
+// of suspending Bubble Tea and competing for stdin.
+func (r *Reporter) SupportsInlinePrompts() bool { return true }

--- a/internal/tui/checklist_test.go
+++ b/internal/tui/checklist_test.go
@@ -60,7 +60,7 @@ func TestPrompting_HaltDecisions(t *testing.T) {
 		m.width, m.height = 100, 30
 
 		decision := make(chan reporting.HaltDecision, 1)
-		m.apply(reporting.HaltReq{Processor: "packages", Err: errors.New("boom"), Decision: decision})
+		m.apply(reporting.HaltReq{Processor: "packages", Err: errors.New("boom"), Retryable: true, Decision: decision})
 		if m.state != Prompting {
 			t.Fatalf("state = %v after HaltReq, want Prompting", m.state)
 		}
@@ -88,7 +88,7 @@ func TestPrompting_AllowsMouseRelease(t *testing.T) {
 	plan := &types.Plan{Order: []string{"users"}}
 	m := New(mustTheme("rwr"), plan, reporting.NewStore(10), false, "")
 	m.width, m.height = 100, 30
-	m.apply(reporting.HaltReq{Processor: "users", Err: errors.New("boom"), Decision: make(chan reporting.HaltDecision, 1)})
+	m.apply(reporting.HaltReq{Processor: "users", Err: errors.New("boom"), Retryable: true, Decision: make(chan reporting.HaltDecision, 1)})
 	m.resumedAt = time.Now().Add(-time.Second)
 
 	m.key(tea.KeyPressMsg{Code: 'm', Text: "m"})
@@ -97,6 +97,33 @@ func TestPrompting_AllowsMouseRelease(t *testing.T) {
 	}
 	if m.state != Prompting || m.halt == nil {
 		t.Fatal("mouse toggle answered or dismissed the halt prompt")
+	}
+}
+
+func TestPrompting_FinalFailuresRequireAcknowledgement(t *testing.T) {
+	plan := &types.Plan{Order: []string{"run"}}
+	m := New(mustTheme("rwr"), plan, reporting.NewStore(10), false, "")
+	m.width, m.height = 100, 30
+	decision := make(chan reporting.HaltDecision, 1)
+	m.apply(reporting.HaltReq{Processor: "run", Err: errors.New("operation failed"), Decision: decision})
+	m.resumedAt = time.Now().Add(-time.Second)
+
+	if view := m.View().Content; strings.Contains(view, "retry") {
+		t.Fatalf("final failure prompt offered unsafe retry:\n%s", view)
+	}
+	m.key(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	select {
+	case got := <-decision:
+		t.Fatalf("retry key answered non-retryable final prompt with %v", got)
+	default:
+	}
+	if m.state != Prompting {
+		t.Fatalf("retry key dismissed final prompt; state = %v", m.state)
+	}
+
+	m.key(tea.KeyPressMsg{Code: 's', Text: "s"})
+	if got := <-decision; got != reporting.HaltSkip {
+		t.Fatalf("acknowledge sent %v, want %v", got, reporting.HaltSkip)
 	}
 }
 

--- a/internal/tui/checklist_test.go
+++ b/internal/tui/checklist_test.go
@@ -84,6 +84,22 @@ func TestPrompting_HaltDecisions(t *testing.T) {
 	}
 }
 
+func TestPrompting_AllowsMouseRelease(t *testing.T) {
+	plan := &types.Plan{Order: []string{"users"}}
+	m := New(mustTheme("rwr"), plan, reporting.NewStore(10), false, "")
+	m.width, m.height = 100, 30
+	m.apply(reporting.HaltReq{Processor: "users", Err: errors.New("boom"), Decision: make(chan reporting.HaltDecision, 1)})
+	m.resumedAt = time.Now().Add(-time.Second)
+
+	m.key(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if m.mouseCapture {
+		t.Fatal("m did not release mouse capture while the halt prompt was active")
+	}
+	if m.state != Prompting || m.halt == nil {
+		t.Fatal("mouse toggle answered or dismissed the halt prompt")
+	}
+}
+
 // Fresh-machine ghost lane: stage 2 planned unpinned entries into an "items"
 // lane because no provider existed yet; the first runtime LaneUpdate for the
 // resolved provider re-keys that lane instead of leaving it pending forever

--- a/internal/tui/checklist_test.go
+++ b/internal/tui/checklist_test.go
@@ -100,6 +100,57 @@ func TestPrompting_AllowsMouseRelease(t *testing.T) {
 	}
 }
 
+func TestPrompting_SecretStaysInsideTUIAndIsMasked(t *testing.T) {
+	plan := &types.Plan{Order: []string{"users"}}
+	m := New(mustTheme("rwr"), plan, reporting.NewStore(10), false, "")
+	m.width, m.height = 100, 30
+	result := make(chan reporting.SecretResult, 1)
+	m.apply(reporting.SecretReq{Prompt: "sudo password", Result: result})
+
+	for _, r := range "s3cret" {
+		m.key(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+	view := m.View().Content
+	if strings.Contains(view, "s3cret") {
+		t.Fatal("secret was rendered in the TUI")
+	}
+	if !strings.Contains(view, "••••••") {
+		t.Fatalf("masked input not rendered:\n%s", view)
+	}
+
+	m.key(tea.KeyPressMsg{Code: tea.KeyEnter})
+	answer := <-result
+	if answer.Err != nil || string(answer.Value) != "s3cret" {
+		t.Fatalf("secret result = (%q, %v)", answer.Value, answer.Err)
+	}
+	for i := range answer.Value {
+		answer.Value[i] = 0
+	}
+	if m.state != Running || m.secret != nil {
+		t.Fatal("secret prompt did not return the model to running")
+	}
+}
+
+func TestPrompting_ConfirmationStaysInsideTUI(t *testing.T) {
+	plan := &types.Plan{Order: []string{"files"}}
+	m := New(mustTheme("rwr"), plan, reporting.NewStore(10), false, "")
+	m.width, m.height = 100, 30
+	result := make(chan reporting.ConfirmResult, 1)
+	m.apply(reporting.ConfirmReq{Prompt: "Overwrite existing file? /tmp/config", Result: result})
+
+	if view := m.View().Content; !strings.Contains(view, "Overwrite existing file?") {
+		t.Fatalf("confirmation not rendered:\n%s", view)
+	}
+	m.key(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	answer := <-result
+	if answer.Err != nil || !answer.Yes {
+		t.Fatalf("confirmation result = (%v, %v)", answer.Yes, answer.Err)
+	}
+	if m.state != Running || m.confirm != nil {
+		t.Fatal("confirmation did not return the model to running")
+	}
+}
+
 // Fresh-machine ghost lane: stage 2 planned unpinned entries into an "items"
 // lane because no provider existed yet; the first runtime LaneUpdate for the
 // resolved provider re-keys that lane instead of leaving it pending forever

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -660,6 +660,9 @@ func (m *Model) key(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case "r", "R":
+			if !m.halt.Retryable {
+				return m, nil
+			}
 			answer(reporting.HaltRetry)
 			m.levelFilter = ""
 			return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -578,6 +578,19 @@ func (m *Model) key(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.state = Running
 		}
 		switch msg.String() {
+		case "m":
+			m.mouseCapture = !m.mouseCapture
+			if !m.mouseCapture {
+				m.hovered = -1
+			}
+			return m, nil
+		case "y":
+			return m, tea.SetClipboard(strings.Join(m.plainLines(m.panelLogLines()), "\n"))
+		case "Y":
+			if m.runLogPath != "" {
+				return m, tea.SetClipboard(m.runLogPath)
+			}
+			return m, nil
 		case "r", "R":
 			answer(reporting.HaltRetry)
 			m.levelFilter = ""

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/log/v2"
@@ -152,7 +153,10 @@ type Model struct {
 	lastLogLines int  // log capacity of the last rendered panel
 
 	// halt is the pending interactive-halt request while state == Prompting.
-	halt *reporting.HaltReq
+	halt        *reporting.HaltReq
+	secret      *reporting.SecretReq
+	secretValue []rune
+	confirm     *reporting.ConfirmReq
 	// resumedAt is when the terminal last came back from a child process or
 	// a prompt entered Prompting; plain keys within the grace window after
 	// it are typeahead, not commands.
@@ -386,6 +390,17 @@ func (m *Model) apply(e reporting.Event) tea.Cmd {
 			done <- err
 			return execDone{}
 		})
+	case reporting.SecretReq:
+		m.state = Prompting
+		m.secret = &ev
+		m.secretValue = nil
+		m.resumedAt = time.Time{}
+		return nil
+	case reporting.ConfirmReq:
+		m.state = Prompting
+		m.confirm = &ev
+		m.resumedAt = time.Time{}
+		return nil
 	case reporting.RunFinished:
 		// Append, not replace: All() emits its collected step errors when it
 		// reaches the end, and the runner emits a second RunFinished carrying
@@ -543,6 +558,59 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) key(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if m.state == Prompting && m.secret != nil {
+		finish := func(value []byte, err error) {
+			if reporting.TryClaim(m.secret.Claim) {
+				m.secret.Result <- reporting.SecretResult{Value: value, Err: err}
+			}
+			for i := range m.secretValue {
+				m.secretValue[i] = 0
+			}
+			m.secretValue = nil
+			m.secret = nil
+			m.state = Running
+		}
+		switch msg.String() {
+		case "enter":
+			value := make([]byte, 0, len(m.secretValue))
+			for _, r := range m.secretValue {
+				value = utf8.AppendRune(value, r)
+			}
+			finish(value, nil)
+		case "backspace":
+			if len(m.secretValue) > 0 {
+				m.secretValue[len(m.secretValue)-1] = 0
+				m.secretValue = m.secretValue[:len(m.secretValue)-1]
+			}
+		case "esc", "ctrl+c":
+			finish(nil, reporting.ErrPromptCancelled)
+		default:
+			if msg.Text != "" {
+				m.secretValue = append(m.secretValue, []rune(msg.Text)...)
+			}
+		}
+		return m, nil
+	}
+
+	if m.state == Prompting && m.confirm != nil {
+		finish := func(yes bool, err error) {
+			if reporting.TryClaim(m.confirm.Claim) {
+				m.confirm.Result <- reporting.ConfirmResult{Yes: yes, Err: err}
+			}
+			m.confirm = nil
+			m.state = Running
+		}
+		switch msg.String() {
+		case "y", "Y", "enter":
+			finish(true, nil)
+		case "n", "N":
+			finish(false, nil)
+		case "esc", "ctrl+c":
+			finish(false, reporting.ErrPromptCancelled)
+		}
+		return m, nil
+	}
+
 	// Typeahead grace: within 750ms of resuming from a terminal handover (or
 	// entering a halt prompt), plain keys are leftover input from the child -
 	// password characters, stray Enters - not commands. ctrl+c always works.

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -593,7 +593,7 @@ func (m *Model) viewRunning() string {
 			reason = display.Truncate(strings.ReplaceAll(m.halt.Err.Error(), "\n", " · "), m.width-40)
 		}
 		b.WriteString(style(m.theme.Danger).Render(" "+m.theme.Glyphs.Failed+" "+m.halt.Processor+" failed: "+reason) + "\n")
-		b.WriteString(style(m.theme.Warning).Render(" r retry · R redo processor · s skip · q abort"))
+		b.WriteString(style(m.theme.Warning).Render(" r retry · R redo processor · s skip · m mouse · y copy · q abort"))
 		return b.String()
 	}
 	b.WriteString(m.viewHelp(m.height < 20))

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -596,6 +596,16 @@ func (m *Model) viewRunning() string {
 		b.WriteString(style(m.theme.Warning).Render(" r retry · R redo processor · s skip · m mouse · y copy · q abort"))
 		return b.String()
 	}
+	if m.state == Prompting && m.secret != nil {
+		b.WriteString(style(m.theme.Warning).Render(" "+m.secret.Prompt+": "+strings.Repeat("•", len(m.secretValue))) + "\n")
+		b.WriteString(style(m.theme.Muted).Render(" enter submit · esc cancel"))
+		return b.String()
+	}
+	if m.state == Prompting && m.confirm != nil {
+		b.WriteString(style(m.theme.Warning).Render(" "+display.Truncate(m.confirm.Prompt, m.width)) + "\n")
+		b.WriteString(style(m.theme.Muted).Render(" y yes · n no · esc cancel"))
+		return b.String()
+	}
 	b.WriteString(m.viewHelp(m.height < 20))
 	return b.String()
 }

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -593,7 +593,11 @@ func (m *Model) viewRunning() string {
 			reason = display.Truncate(strings.ReplaceAll(m.halt.Err.Error(), "\n", " · "), m.width-40)
 		}
 		b.WriteString(style(m.theme.Danger).Render(" "+m.theme.Glyphs.Failed+" "+m.halt.Processor+" failed: "+reason) + "\n")
-		b.WriteString(style(m.theme.Warning).Render(" r retry · R redo processor · s skip · m mouse · y copy · q abort"))
+		help := " s acknowledge · m mouse · y copy · q abort"
+		if m.halt.Retryable {
+			help = " r retry · R redo processor · s skip · m mouse · y copy · q abort"
+		}
+		b.WriteString(style(m.theme.Warning).Render(help))
 		return b.String()
 	}
 	if m.state == Prompting && m.secret != nil {

--- a/openspec/specs/command-execution/spec.md
+++ b/openspec/specs/command-execution/spec.md
@@ -110,13 +110,21 @@ timeout once per package.
 
 A cached cold result SHALL NOT be treated as warm. Every command that may invoke
 sudo while the result is cold SHALL receive the real terminal, so any password
-prompt made by the command itself remains visible and answerable.
+prompt made by the command itself remains visible and answerable. A provider-wide
+escalation declaration SHALL be narrowed when the operation can be classified:
+Homebrew formulae remain captured, while casks retain the terminal handoff.
 
 #### Scenario: Sudo credentials are not cached
 
 - **WHEN** `sudo -n -v` reports that credentials are not cached
 - **THEN** RWR does not ask for a password itself
 - **AND** each potentially escalating command receives the real terminal
+
+#### Scenario: A Homebrew formula with a cold sudo cache
+
+- **WHEN** Homebrew metadata classifies a package operation as a formula
+- **THEN** the command remains captured by the TUI
+- **AND** the dashboard is not suspended for that package
 
 #### Scenario: The sudo policy backend stalls
 

--- a/openspec/specs/command-execution/spec.md
+++ b/openspec/specs/command-execution/spec.md
@@ -95,7 +95,8 @@ leaves the run blocked with no indication of what it waits for.
 #### Scenario: A command that prompts for a password
 
 - **WHEN** an interactive elevated command runs and `sudo` requires a password
-- **THEN** the prompt appears on the terminal and the operator can answer it
+- **THEN** RWR completes masked sudo validation before launching that command
+- **AND** the command receives the terminal only for its own interaction
 
 ### Requirement: Sudo readiness checks never prompt or delay cancellation
 
@@ -108,17 +109,22 @@ run SHALL cancel an in-flight check immediately. RWR SHALL cache both a warm and
 a cold result for one minute so a stalled policy backend cannot impose its full
 timeout once per package.
 
-A cached cold result SHALL NOT be treated as warm. Every command that may invoke
-sudo while the result is cold SHALL receive the real terminal, so any password
-prompt made by the command itself remains visible and answerable. A provider-wide
-escalation declaration SHALL be narrowed when the operation can be classified:
-Homebrew formulae remain captured, while casks retain the terminal handoff.
+A cached cold result SHALL NOT be treated as warm. Before a command that may
+invoke sudo, RWR SHALL collect a password through a masked terminal prompt and
+validate it with `sudo -S -v`. The password SHALL NOT appear in argv, logs, or
+terminal output and SHALL be cleared from its temporary byte buffers after use.
+The actual command SHALL remain captured by the TUI after validation.
+
+A provider-wide escalation declaration SHALL be narrowed when the operation can
+be classified: Homebrew formulae remain captured without sudo validation, while
+casks retain the secure validation step.
 
 #### Scenario: Sudo credentials are not cached
 
 - **WHEN** `sudo -n -v` reports that credentials are not cached
-- **THEN** RWR does not ask for a password itself
-- **AND** each potentially escalating command receives the real terminal
+- **THEN** RWR asks once through a masked terminal prompt
+- **AND** validates the supplied password without placing it in argv
+- **AND** runs the actual command captured by the TUI
 
 #### Scenario: A Homebrew formula with a cold sudo cache
 
@@ -131,7 +137,14 @@ Homebrew formulae remain captured, while casks retain the terminal handoff.
 - **WHEN** the non-interactive sudo check reaches its timeout
 - **THEN** the result is cached briefly as cold
 - **AND** adjacent package commands do not each repeat the stalled check
-- **AND** those commands still receive the real terminal
+- **AND** the secure validation prompt is used before the next command that may
+  invoke sudo
+
+#### Scenario: No terminal is available
+
+- **WHEN** sudo credentials are cold and stdin is not a terminal
+- **THEN** RWR does not attempt to read a password
+- **AND** the command proceeds so command-scoped `NOPASSWD` policies still work
 
 #### Scenario: The operator cancels during the sudo check
 

--- a/openspec/specs/command-execution/spec.md
+++ b/openspec/specs/command-execution/spec.md
@@ -110,10 +110,12 @@ a cold result for one minute so a stalled policy backend cannot impose its full
 timeout once per package.
 
 A cached cold result SHALL NOT be treated as warm. Before a command that may
-invoke sudo, RWR SHALL collect a password through a masked terminal prompt and
-validate it with `sudo -S -v`. The password SHALL NOT appear in argv, logs, or
-terminal output and SHALL be cleared from its temporary byte buffers after use.
-The actual command SHALL remain captured by the TUI after validation.
+invoke sudo, RWR SHALL collect a password through a masked prompt inside an
+active TUI. When no TUI is active, RWR SHALL use the masked terminal fallback.
+It SHALL validate the password with `sudo -S -v`. The password SHALL NOT appear
+in argv, logs, or terminal output and SHALL be cleared from its temporary byte
+buffers after use. The actual command SHALL remain captured by the TUI after
+validation; collecting the password SHALL NOT suspend or replace the dashboard.
 
 A provider-wide escalation declaration SHALL be narrowed when the operation can
 be classified: Homebrew formulae remain captured without sudo validation, while
@@ -122,7 +124,7 @@ casks retain the secure validation step.
 #### Scenario: Sudo credentials are not cached
 
 - **WHEN** `sudo -n -v` reports that credentials are not cached
-- **THEN** RWR asks once through a masked terminal prompt
+- **THEN** RWR asks once through the TUI's masked prompt, or the masked terminal fallback when headless
 - **AND** validates the supplied password without placing it in argv
 - **AND** runs the actual command captured by the TUI
 


### PR DESCRIPTION
## What changed

- classify Homebrew formula versus cask operations before setting per-command escalation metadata
- keep formula output captured inside the TUI
- retain terminal handoff for explicit or metadata-resolved casks when sudo is cold
- fail safe to terminal handoff when Homebrew metadata cannot classify a package
- make the Git checkout scan fixture independent of an enclosing worktree

## Root cause

Homebrew's provider-wide `escalates` flag was copied to every package command. With a cold sudo cache, every formula install suspended the dashboard and wrote directly to the terminal even though formulae never invoke sudo.

## Validation

- `go test -race ./...`
- `golangci-lint run`
- `gosec -quiet -fmt=text -exclude-dir=openspec -exclude-dir=docs -exclude-dir=examples ./...`
- `govulncheck ./...`
- `openspec validate command-execution --type spec --strict`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added masked sudo authentication for elevated commands, keeping passwords out of command arguments, logs, and terminal output.
  - Commands remain visible in the dashboard after authentication, with terminal access provided only when direct interaction is required.
  - Homebrew formula and cask operations now receive appropriate escalation handling automatically.
  - Noninteractive macOS user-management commands no longer unexpectedly open a terminal.

- **Documentation**
  - Clarified interactive command behavior, sudo prompts, and Homebrew escalation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->